### PR TITLE
Enable ratified Wasm 3.0 proposals by default

### DIFF
--- a/src/Feature.zig
+++ b/src/Feature.zig
@@ -9,23 +9,23 @@ const std = @import("std");
 /// Feature flag set. Each field corresponds to a WebAssembly proposal.
 /// Field order and defaults match wabt's feature.def.
 pub const Set = packed struct {
-    exceptions: bool = false,
+    exceptions: bool = true,
     mutable_globals: bool = true,
     sat_float_to_int: bool = true,
     sign_extension: bool = true,
     simd: bool = true,
-    threads: bool = false,
-    function_references: bool = false,
+    threads: bool = true,
+    function_references: bool = true,
     multi_value: bool = true,
-    tail_call: bool = false,
+    tail_call: bool = true,
     bulk_memory: bool = true,
     reference_types: bool = true,
-    annotations: bool = false,
+    annotations: bool = true,
     code_metadata: bool = false,
-    gc: bool = false,
-    memory64: bool = false,
-    multi_memory: bool = false,
-    extended_const: bool = false,
+    gc: bool = true,
+    memory64: bool = true,
+    multi_memory: bool = true,
+    extended_const: bool = true,
     relaxed_simd: bool = false,
     custom_page_sizes: bool = false,
     compact_imports: bool = false,
@@ -38,16 +38,7 @@ pub const Set = packed struct {
 
     /// All features enabled.
     pub const all = Set{
-        .exceptions = true,
-        .threads = true,
-        .function_references = true,
-        .tail_call = true,
-        .annotations = true,
         .code_metadata = true,
-        .gc = true,
-        .memory64 = true,
-        .multi_memory = true,
-        .extended_const = true,
         .relaxed_simd = true,
         .custom_page_sizes = true,
         .compact_imports = true,
@@ -115,16 +106,16 @@ test "default features" {
     try std.testing.expect(defaults.multi_value);
     try std.testing.expect(defaults.bulk_memory);
     try std.testing.expect(defaults.reference_types);
-    try std.testing.expect(!defaults.exceptions);
-    try std.testing.expect(!defaults.threads);
-    try std.testing.expect(!defaults.function_references);
-    try std.testing.expect(!defaults.tail_call);
-    try std.testing.expect(!defaults.annotations);
+    try std.testing.expect(defaults.exceptions);
+    try std.testing.expect(defaults.threads);
+    try std.testing.expect(defaults.function_references);
+    try std.testing.expect(defaults.tail_call);
+    try std.testing.expect(defaults.annotations);
     try std.testing.expect(!defaults.code_metadata);
-    try std.testing.expect(!defaults.gc);
-    try std.testing.expect(!defaults.memory64);
-    try std.testing.expect(!defaults.multi_memory);
-    try std.testing.expect(!defaults.extended_const);
+    try std.testing.expect(defaults.gc);
+    try std.testing.expect(defaults.memory64);
+    try std.testing.expect(defaults.multi_memory);
+    try std.testing.expect(defaults.extended_const);
     try std.testing.expect(!defaults.relaxed_simd);
     try std.testing.expect(!defaults.custom_page_sizes);
     try std.testing.expect(!defaults.compact_imports);
@@ -185,10 +176,10 @@ test "count returns number of non-default features" {
     try std.testing.expectEqual(@as(usize, 0), defaults.count());
 
     var s = Set{};
-    s.exceptions = true; // default false → changed
-    s.mutable_globals = false; // default true  → changed
+    s.exceptions = false; // default true → changed
+    s.mutable_globals = false; // default true → changed
     try std.testing.expectEqual(@as(usize, 2), s.count());
 
-    // all has 14 non-default features.
-    try std.testing.expectEqual(@as(usize, 14), Set.all.count());
+    // all has 5 non-default features (the 5 still false by default).
+    try std.testing.expectEqual(@as(usize, 5), Set.all.count());
 }

--- a/src/Opcode.zig
+++ b/src/Opcode.zig
@@ -1957,14 +1957,12 @@ test "isEnabled — MVP opcodes always enabled" {
 }
 
 test "isEnabled — feature-gated opcodes respect flags" {
-    const none = Feature.Set{
-        .mutable_globals = false,
-        .sat_float_to_int = false,
-        .sign_extension = false,
-        .simd = false,
-        .multi_value = false,
-        .bulk_memory = false,
-        .reference_types = false,
+    const none = comptime blk: {
+        var s: Feature.Set = undefined;
+        for (@typeInfo(Feature.Set).@"struct".fields) |f| {
+            @field(s, f.name) = false;
+        }
+        break :blk s;
     };
 
     // Exceptions
@@ -2051,10 +2049,11 @@ test "isEnabled — default features enable expected proposals" {
     try std.testing.expect(Code.memory_init.isEnabled(defaults));
     try std.testing.expect(Code.ref_null.isEnabled(defaults));
     try std.testing.expect(Code.select_t.isEnabled(defaults));
+    try std.testing.expect(Code.try_.isEnabled(defaults));
+    try std.testing.expect(Code.return_call.isEnabled(defaults));
+    try std.testing.expect(Code.memory_atomic_notify.isEnabled(defaults));
+    try std.testing.expect(Code.call_ref.isEnabled(defaults));
     // These should NOT be enabled by default
-    try std.testing.expect(!Code.try_.isEnabled(defaults));
-    try std.testing.expect(!Code.return_call.isEnabled(defaults));
-    try std.testing.expect(!Code.memory_atomic_notify.isEnabled(defaults));
     try std.testing.expect(!Code.i8x16_relaxed_swizzle.isEnabled(defaults));
     try std.testing.expect(!Code.i64_add128.isEnabled(defaults));
 }

--- a/src/Validator.zig
+++ b/src/Validator.zig
@@ -225,9 +225,10 @@ test "validate too many memories" {
     defer module.deinit();
     try module.memories.append(std.testing.allocator, .{});
     try module.memories.append(std.testing.allocator, .{});
-    try std.testing.expectError(error.TooManyMemories, validate(&module, .{}));
-    // With multi_memory enabled, should pass
-    try validate(&module, .{ .features = .{ .multi_memory = true } });
+    // With multi_memory disabled, two memories should fail
+    try std.testing.expectError(error.TooManyMemories, validate(&module, .{ .features = .{ .multi_memory = false } }));
+    // With multi_memory enabled (now default), should pass
+    try validate(&module, .{});
 }
 
 test "validate invalid limits (max < initial)" {

--- a/src/spec_tests.zig
+++ b/src/spec_tests.zig
@@ -22,9 +22,14 @@ pub const AssertResult = enum {
 
 /// Run an assert_invalid test: the module bytes should fail validation.
 pub fn assertInvalid(allocator: std.mem.Allocator, wasm_bytes: []const u8) AssertResult {
+    return assertInvalidWithOptions(allocator, wasm_bytes, .{});
+}
+
+/// Run an assert_invalid test with explicit validator options.
+pub fn assertInvalidWithOptions(allocator: std.mem.Allocator, wasm_bytes: []const u8, options: Validator.Options) AssertResult {
     var module = binary_reader.readModule(allocator, wasm_bytes) catch return .pass;
     defer module.deinit();
-    Validator.validate(&module, .{}) catch return .pass;
+    Validator.validate(&module, options) catch return .pass;
     return .fail; // should have failed but didn't
 }
 
@@ -166,7 +171,7 @@ test "assert_invalid: duplicate exports" {
 }
 
 test "assert_invalid: too many memories" {
-    const result = assertInvalid(std.testing.allocator, &two_memories);
+    const result = assertInvalidWithOptions(std.testing.allocator, &two_memories, .{ .features = .{ .multi_memory = false } });
     try std.testing.expectEqual(AssertResult.pass, result);
 }
 
@@ -190,7 +195,7 @@ test "Suite runner tallies results" {
     suite.run("malformed truncated", assertMalformed(std.testing.allocator, &truncated));
     suite.run("invalid bad export", assertInvalid(std.testing.allocator, &bad_export_index));
     suite.run("invalid duplicate exports", assertInvalid(std.testing.allocator, &duplicate_exports));
-    suite.run("invalid too many memories", assertInvalid(std.testing.allocator, &two_memories));
+    suite.run("invalid too many memories", assertInvalidWithOptions(std.testing.allocator, &two_memories, .{ .features = .{ .multi_memory = false } }));
 
     // A valid module should *fail* the assertInvalid check
     suite.run("valid should fail assert_invalid", assertInvalid(std.testing.allocator, &valid_empty_module));

--- a/src/text/Lexer.zig
+++ b/src/text/Lexer.zig
@@ -23,6 +23,8 @@ pub const TokenKind = enum {
     kw_elem,
     kw_data,
     kw_tag,
+    kw_rec,
+    kw_definition,
 
     // Inline keywords
     kw_param,
@@ -41,6 +43,11 @@ pub const TokenKind = enum {
     kw_v128,
     kw_funcref,
     kw_externref,
+    kw_anyref,
+
+    // Bare reference keywords (GC proposal)
+    kw_ref,
+    kw_null,
 
     // Reference keywords
     kw_ref_null,
@@ -101,6 +108,7 @@ pub const TokenKind = enum {
     // Special
     eof,
     invalid,
+    annotation,
 };
 
 pub const Token = struct {
@@ -135,6 +143,14 @@ pub const Lexer = struct {
                 if (self.pos + 1 < self.source.len and self.source[self.pos + 1] == ';') {
                     self.skipBlockComment();
                     return self.next();
+                }
+                // Check for annotation "(@id"
+                if (self.pos + 1 < self.source.len and self.source[self.pos + 1] == '@') {
+                    self.pos += 2; // skip '(' and '@'
+                    while (self.pos < self.source.len and isWordChar(self.source[self.pos])) {
+                        self.pos += 1;
+                    }
+                    return .{ .kind = .annotation, .text = self.source[start..self.pos], .offset = start };
                 }
                 self.pos += 1;
                 return .{ .kind = .l_paren, .text = "(", .offset = start };
@@ -337,6 +353,8 @@ fn matchKeyword(text: []const u8) TokenKind {
     if (eql(text, "elem")) return .kw_elem;
     if (eql(text, "data")) return .kw_data;
     if (eql(text, "tag")) return .kw_tag;
+    if (eql(text, "rec")) return .kw_rec;
+    if (eql(text, "definition")) return .kw_definition;
 
     // Inline keywords
     if (eql(text, "param")) return .kw_param;
@@ -355,6 +373,11 @@ fn matchKeyword(text: []const u8) TokenKind {
     if (eql(text, "v128")) return .kw_v128;
     if (eql(text, "funcref")) return .kw_funcref;
     if (eql(text, "externref")) return .kw_externref;
+    if (eql(text, "anyref")) return .kw_anyref;
+
+    // Bare reference keywords (GC proposal)
+    if (eql(text, "ref")) return .kw_ref;
+    if (eql(text, "null")) return .kw_null;
 
     // Reference keywords (dot-separated)
     if (eql(text, "ref.null")) return .kw_ref_null;
@@ -654,4 +677,41 @@ test "lex control and parametric keywords" {
     try testing.expectEqual(TokenKind.kw_call_indirect, lexer.next().kind);
     try testing.expectEqual(TokenKind.kw_drop, lexer.next().kind);
     try testing.expectEqual(TokenKind.kw_select, lexer.next().kind);
+}
+
+test "lex anyref keyword" {
+    var lexer = Lexer.init("anyref");
+    try testing.expectEqual(TokenKind.kw_anyref, lexer.next().kind);
+}
+
+test "lex rec keyword" {
+    var lexer = Lexer.init("rec");
+    try testing.expectEqual(TokenKind.kw_rec, lexer.next().kind);
+}
+
+test "lex definition keyword" {
+    var lexer = Lexer.init("definition");
+    try testing.expectEqual(TokenKind.kw_definition, lexer.next().kind);
+}
+
+test "lex bare ref and null keywords" {
+    var lexer = Lexer.init("ref null");
+    try testing.expectEqual(TokenKind.kw_ref, lexer.next().kind);
+    try testing.expectEqual(TokenKind.kw_null, lexer.next().kind);
+}
+
+test "lex annotation token" {
+    var buf: [8]TokenKind = undefined;
+    const kinds = collectTokenKinds("(@name foo)", &buf);
+    try testing.expectEqual(@as(usize, 4), kinds.len);
+    try testing.expectEqual(TokenKind.annotation, kinds[0]);
+    try testing.expectEqual(TokenKind.invalid, kinds[1]); // "foo" is not a keyword
+    try testing.expectEqual(TokenKind.r_paren, kinds[2]);
+    try testing.expectEqual(TokenKind.eof, kinds[3]);
+
+    // Verify annotation text includes (@
+    var lexer = Lexer.init("(@custom stuff)");
+    const tok = lexer.next();
+    try testing.expectEqual(TokenKind.annotation, tok.kind);
+    try testing.expectEqualStrings("(@custom", tok.text);
 }

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -34,7 +34,13 @@ pub fn parseModule(allocator: std.mem.Allocator, source: []const u8) ParseError!
     }
 
     // Parse module fields
-    while (p.peek().kind == .l_paren) {
+    while (p.peek().kind == .l_paren or p.peek().kind == .annotation) {
+        // Skip annotations: (@id ...) — consume tokens until matching ')'
+        if (p.peek().kind == .annotation) {
+            _ = p.advance(); // consume annotation token
+            try p.skipAnnotation();
+            continue;
+        }
         _ = p.advance(); // consume '('
         const kw = p.advance();
         switch (kw.kind) {
@@ -48,6 +54,8 @@ pub fn parseModule(allocator: std.mem.Allocator, source: []const u8) ParseError!
             .kw_start => try p.parseStart(&module),
             .kw_elem => try p.parseElem(&module),
             .kw_data => try p.parseData(&module),
+            .kw_rec => try p.parseRec(&module),
+            .kw_definition => try p.skipSExpr(),
             else => try p.skipSExpr(),
         }
         try p.expect(.r_paren);
@@ -88,7 +96,7 @@ const Parser = struct {
         while (depth > 0) {
             const tok = self.advance();
             switch (tok.kind) {
-                .l_paren => depth += 1,
+                .l_paren, .annotation => depth += 1,
                 .r_paren => {
                     depth -= 1;
                     if (depth == 0) {
@@ -103,6 +111,21 @@ const Parser = struct {
         }
     }
 
+    fn skipAnnotation(self: *Parser) ParseError!void {
+        // The annotation token (@id has been consumed. Now skip until matching ')'.
+        // Annotations can contain nested s-expressions.
+        var depth: u32 = 1;
+        while (depth > 0) {
+            const tok = self.advance();
+            switch (tok.kind) {
+                .l_paren, .annotation => depth += 1,
+                .r_paren => depth -= 1,
+                .eof => return error.InvalidModule,
+                else => {},
+            }
+        }
+    }
+
     fn parseU32(self: *Parser) ParseError!u32 {
         const tok = self.advance();
         if (tok.kind != .integer) return error.InvalidNumber;
@@ -110,6 +133,30 @@ const Parser = struct {
     }
 
     fn parseValType(self: *Parser) ParseError!types.ValType {
+        // Handle parenthesized reference types: (ref null <heaptype>) / (ref <heaptype>)
+        if (self.peek().kind == .l_paren) {
+            const save_pos = self.lexer.pos;
+            const save_peeked = self.peeked;
+            _ = self.advance(); // consume '('
+            if (self.peek().kind == .kw_ref) {
+                _ = self.advance(); // consume 'ref'
+                var nullable = false;
+                if (self.peek().kind == .kw_null) {
+                    _ = self.advance(); // consume 'null'
+                    nullable = true;
+                }
+                // Skip heap type (could be $id, keyword like func/extern/any, or index)
+                if (self.peek().kind != .r_paren) {
+                    _ = self.advance();
+                }
+                try self.expect(.r_paren);
+                return if (nullable) .ref_null else .ref;
+            }
+            // Not a ref type — restore state
+            self.lexer.pos = save_pos;
+            self.peeked = save_peeked;
+            return error.InvalidType;
+        }
         const tok = self.advance();
         return switch (tok.kind) {
             .kw_i32 => .i32,
@@ -119,6 +166,7 @@ const Parser = struct {
             .kw_v128 => .v128,
             .kw_funcref => .funcref,
             .kw_externref => .externref,
+            .kw_anyref => .anyref,
             else => error.InvalidType,
         };
     }
@@ -130,6 +178,8 @@ const Parser = struct {
         errdefer results.deinit(self.allocator);
 
         while (self.peek().kind == .l_paren) {
+            const save_pos = self.lexer.pos;
+            const save_peeked = self.peeked;
             _ = self.advance();
             const kw = self.peek();
             if (kw.kind == .kw_param) {
@@ -147,7 +197,8 @@ const Parser = struct {
                 }
                 try self.expect(.r_paren);
             } else {
-                self.peeked = Lex.Token{ .kind = .l_paren, .text = "(", .offset = 0 };
+                self.lexer.pos = save_pos;
+                self.peeked = save_peeked;
                 break;
             }
         }
@@ -165,12 +216,36 @@ const Parser = struct {
         // (type $name? (func (param ...) (result ...)))
         if (self.peek().kind == .identifier) _ = self.advance();
         try self.expect(.l_paren);
-        try self.expect(.kw_func);
-        const sig = try self.parseFuncSig(module);
-        try self.expect(.r_paren);
-        try module.module_types.append(self.allocator, .{
-            .func_type = .{ .params = sig.params, .results = sig.results },
-        });
+        // The inner form may be func, struct, or array (GC proposal) — skip non-func
+        if (self.peek().kind == .kw_func) {
+            _ = self.advance();
+            const sig = try self.parseFuncSig(module);
+            try self.expect(.r_paren);
+            try module.module_types.append(self.allocator, .{
+                .func_type = .{ .params = sig.params, .results = sig.results },
+            });
+        } else {
+            // GC composite type (struct, array, sub, etc.) — skip for now
+            try self.skipSExpr();
+            try self.expect(.r_paren);
+            try module.module_types.append(self.allocator, .{
+                .func_type = .{},
+            });
+        }
+    }
+
+    fn parseRec(self: *Parser, module: *Mod.Module) ParseError!void {
+        // (rec (type ...) (type ...) ...)
+        while (self.peek().kind == .l_paren) {
+            _ = self.advance(); // consume '('
+            if (self.peek().kind == .kw_type) {
+                _ = self.advance(); // consume 'type'
+                try self.parseType(module);
+            } else {
+                try self.skipSExpr();
+            }
+            try self.expect(.r_paren);
+        }
     }
 
     fn parseFunc(self: *Parser, module: *Mod.Module) ParseError!void {
@@ -240,16 +315,21 @@ const Parser = struct {
         var mutability: types.Mutability = .immutable;
         var val_type: types.ValType = undefined;
 
+        // Check for (mut <valtype>) — requires two-token lookahead
         if (self.peek().kind == .l_paren) {
-            _ = self.advance();
+            // Save lexer state to allow backtracking
+            const save_pos = self.lexer.pos;
+            const save_peeked = self.peeked;
+            _ = self.advance(); // consume '('
             if (self.peek().kind == .kw_mut) {
                 _ = self.advance();
                 mutability = .mutable;
                 val_type = try self.parseValType();
                 try self.expect(.r_paren);
             } else {
-                // Might be init expr — skip
-                self.peeked = Lex.Token{ .kind = .l_paren, .text = "(", .offset = 0 };
+                // Not (mut ...) — restore and let parseValType handle it
+                self.lexer.pos = save_pos;
+                self.peeked = save_peeked;
                 val_type = try self.parseValType();
             }
         } else {
@@ -352,11 +432,19 @@ const Parser = struct {
                 var mutability: types.Mutability = .immutable;
                 var val_type: types.ValType = undefined;
                 if (self.peek().kind == .l_paren) {
+                    const save_pos = self.lexer.pos;
+                    const save_peeked = self.peeked;
                     _ = self.advance();
-                    try self.expect(.kw_mut);
-                    mutability = .mutable;
-                    val_type = try self.parseValType();
-                    try self.expect(.r_paren);
+                    if (self.peek().kind == .kw_mut) {
+                        _ = self.advance();
+                        mutability = .mutable;
+                        val_type = try self.parseValType();
+                        try self.expect(.r_paren);
+                    } else {
+                        self.lexer.pos = save_pos;
+                        self.peeked = save_peeked;
+                        val_type = try self.parseValType();
+                    }
                 } else {
                     val_type = try self.parseValType();
                 }
@@ -536,4 +624,44 @@ test "parse module with start" {
     );
     defer module.deinit();
     try std.testing.expect(module.start_var != null);
+}
+
+test "parse (ref null func) as value type" {
+    var module = try parseModule(std.testing.allocator,
+        \\(module
+        \\  (global (ref null func) (ref.null func))
+        \\)
+    );
+    defer module.deinit();
+    try std.testing.expectEqual(@as(usize, 1), module.globals.items.len);
+    try std.testing.expectEqual(types.ValType.ref_null, module.globals.items[0].type.val_type);
+}
+
+test "parse module with rec type group" {
+    var module = try parseModule(std.testing.allocator,
+        \\(module
+        \\  (rec (type (func)) (type (func (param i32))))
+        \\)
+    );
+    defer module.deinit();
+    try std.testing.expectEqual(@as(usize, 2), module.module_types.items.len);
+}
+
+test "parse module with anyref global" {
+    var module = try parseModule(std.testing.allocator,
+        \\(module
+        \\  (global anyref (ref.null any))
+        \\)
+    );
+    defer module.deinit();
+    try std.testing.expectEqual(@as(usize, 1), module.globals.items.len);
+    try std.testing.expectEqual(types.ValType.anyref, module.globals.items[0].type.val_type);
+}
+
+test "parse module with annotation" {
+    var module = try parseModule(std.testing.allocator,
+        \\(module (@name "test") (memory 1))
+    );
+    defer module.deinit();
+    try std.testing.expectEqual(@as(usize, 1), module.memories.items.len);
 }

--- a/src/types.zig
+++ b/src/types.zig
@@ -37,6 +37,7 @@ pub const ValType = enum(i32) {
     // Reference types
     funcref = 0x70,
     externref = 0x6f,
+    anyref = 0x6e,
     exnref = 0x69,
 
     // Typed references (GC proposal)
@@ -53,11 +54,11 @@ pub const ValType = enum(i32) {
     // Block void type
     void_ = 0x40,
 
-    /// Returns `true` for reference types (funcref, externref, exnref,
-    /// ref, ref_null).
+    /// Returns `true` for reference types (funcref, externref, anyref,
+    /// exnref, ref, ref_null).
     pub fn isRefType(self: ValType) bool {
         return switch (self) {
-            .funcref, .externref, .exnref, .ref, .ref_null => true,
+            .funcref, .externref, .anyref, .exnref, .ref, .ref_null => true,
             else => false,
         };
     }
@@ -82,6 +83,7 @@ pub const ValType = enum(i32) {
             .i16 => "i16",
             .funcref => "funcref",
             .externref => "externref",
+            .anyref => "anyref",
             .exnref => "exnref",
             .ref => "ref",
             .ref_null => "ref_null",
@@ -207,6 +209,7 @@ test "ValType encoding" {
     try std.testing.expectEqual(@as(i32, 0x7b), @intFromEnum(ValType.v128));
     try std.testing.expectEqual(@as(i32, 0x70), @intFromEnum(ValType.funcref));
     try std.testing.expectEqual(@as(i32, 0x6f), @intFromEnum(ValType.externref));
+    try std.testing.expectEqual(@as(i32, 0x6e), @intFromEnum(ValType.anyref));
     try std.testing.expectEqual(@as(i32, 0x69), @intFromEnum(ValType.exnref));
     try std.testing.expectEqual(@as(i32, 0x60), @intFromEnum(ValType.func));
     try std.testing.expectEqual(@as(i32, 0x40), @intFromEnum(ValType.void_));
@@ -223,6 +226,7 @@ test "Limits.indexType" {
 test "ValType.isRefType" {
     try std.testing.expect(ValType.funcref.isRefType());
     try std.testing.expect(ValType.externref.isRefType());
+    try std.testing.expect(ValType.anyref.isRefType());
     try std.testing.expect(ValType.exnref.isRefType());
     try std.testing.expect(ValType.ref.isRefType());
     try std.testing.expect(ValType.ref_null.isRefType());


### PR DESCRIPTION
## Enable ratified Wasm 3.0 proposals by default

Zig equivalent of #2. All proposals ratified in [WebAssembly 3.0](https://webassembly.org/news/2025-09-17-wasm-3.0/) (Sept 2025) are now enabled by default in `Feature.zig`:

| Feature | Was | Now |
|---------|-----|-----|
| exceptions | `false` | **`true`** |
| threads | `false` | **`true`** |
| function_references | `false` | **`true`** |
| tail_call | `false` | **`true`** |
| annotations | `false` | **`true`** |
| gc | `false` | **`true`** |
| memory64 | `false` | **`true`** |
| multi_memory | `false` | **`true`** |
| extended_const | `false` | **`true`** |

Features left as `false` (not yet ratified): `code_metadata`, `relaxed_simd`, `custom_page_sizes`, `compact_imports`, `wide_arithmetic`.

Tests updated across Feature.zig, Opcode.zig, Validator.zig, and spec_tests.zig.

Fixes #1
