### PR TITLE
Fix binary.wast and global.wast conformance

### DIFF
--- a/src/Validator.zig
+++ b/src/Validator.zig
@@ -812,6 +812,7 @@ fn checkOneBody(m: *const Mod.Module, func: *const Mod.Func, declared_funcs: *co
                         try checkUnary(&val_stack, &ctrl_stack, input, output, gpa(m));
                     },
                     0x08 => { // memory.init
+                        if (!m.has_data_count) return error.InvalidDataIndex;
                         const data_idx = readU32(bytes, &pos);
                         _ = readU32(bytes, &pos); // mem idx
                         if (data_idx >= m.data_segments.items.len) return error.InvalidDataIndex;
@@ -821,6 +822,7 @@ fn checkOneBody(m: *const Mod.Module, func: *const Mod.Func, declared_funcs: *co
                         try popExpect(&val_stack, &ctrl_stack, .i32);
                     },
                     0x09 => { // data.drop
+                        if (!m.has_data_count) return error.InvalidDataIndex;
                         const idx = readU32(bytes, &pos);
                         if (idx >= m.data_segments.items.len) return error.InvalidDataIndex;
                     },
@@ -910,6 +912,9 @@ fn checkOneBody(m: *const Mod.Module, func: *const Mod.Func, declared_funcs: *co
             const actual = popVal(&val_stack, &ctrl_stack) catch return error.TypeMismatch;
             if (!actual.matches(ValTypeOrUnknown.fromValType(expected))) return error.TypeMismatch;
         }
+    } else {
+        // Function body ended with unclosed blocks — unexpected end
+        return error.TypeMismatch;
     }
 }
 

--- a/src/binary/reader.zig
+++ b/src/binary/reader.zig
@@ -289,7 +289,9 @@ const Reader = struct {
         const count = try self.readU32();
         for (0..count) |_| {
             const module_name = try self.readName();
+            if (!std.unicode.utf8ValidateSlice(module_name)) return error.InvalidSection;
             const field_name = try self.readName();
+            if (!std.unicode.utf8ValidateSlice(field_name)) return error.InvalidSection;
             const kind_byte = try self.readByte();
             const kind: types.ExternalKind = enumFromIntChecked(types.ExternalKind, kind_byte) orelse
                 return error.InvalidSection;
@@ -332,6 +334,7 @@ const Reader = struct {
                 .global => {
                     const val_type = try self.readValType();
                     const mut_byte = try self.readByte();
+                    if (mut_byte > 1) return error.InvalidType;
                     const mutability: types.Mutability = if (mut_byte != 0) .mutable else .immutable;
                     import.global = .{ .val_type = val_type, .mutability = mutability };
                     try self.module.globals.append(self.allocator, .{
@@ -388,6 +391,7 @@ const Reader = struct {
         for (0..count) |_| {
             const val_type = try self.readValType();
             const mut_byte = try self.readByte();
+            if (mut_byte > 1) return error.InvalidType;
             const mutability: types.Mutability = if (mut_byte != 0) .mutable else .immutable;
             try self.skipInitExpr();
             try self.module.globals.append(self.allocator, .{
@@ -400,6 +404,7 @@ const Reader = struct {
         const count = try self.readU32();
         for (0..count) |_| {
             const exp_name = try self.readName();
+            if (!std.unicode.utf8ValidateSlice(exp_name)) return error.InvalidSection;
             const kind_byte = try self.readByte();
             const index = try self.readU32();
             try self.module.exports.append(self.allocator, .{

--- a/src/wast_runner.zig
+++ b/src/wast_runner.zig
@@ -1736,6 +1736,28 @@ fn decodeWastHexStrings(allocator: std.mem.Allocator, text: []const u8) ![]u8 {
     errdefer res.deinit(allocator);
     var i: usize = 0;
     while (i < text.len) {
+        // Skip line comments: ;; ... \n
+        if (text[i] == ';' and i + 1 < text.len and text[i + 1] == ';') {
+            while (i < text.len and text[i] != '\n') : (i += 1) {}
+            continue;
+        }
+        // Skip block comments: (; ... ;)
+        if (text[i] == '(' and i + 1 < text.len and text[i + 1] == ';') {
+            i += 2;
+            var depth: usize = 1;
+            while (i + 1 < text.len and depth > 0) {
+                if (text[i] == '(' and text[i + 1] == ';') {
+                    depth += 1;
+                    i += 2;
+                } else if (text[i] == ';' and text[i + 1] == ')') {
+                    depth -= 1;
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            continue;
+        }
         if (text[i] == '"') {
             i += 1;
             while (i < text.len and text[i] != '"') {


### PR DESCRIPTION
Fix 4 binary.wast failures:
- Validate data count section required before memory.init/data.drop
- Fix hex string decoder to skip comments in binary modules
- Validate control stack empty at end of function body
- Validate global mutability byte (must be 0 or 1)

binary.wast: 135p 0f, global.wast: 110p 0f