### PR TITLE
Fix call_indirect.wast and token.wast conformance

### DIFF
--- a/src/Validator.zig
+++ b/src/Validator.zig
@@ -188,7 +188,7 @@ fn checkElemSegments(m: *const Mod.Module) Error!void {
         }
         // Validate that func refs in funcref segments actually exist
         for (seg.elem_var_indices.items) |v| {
-            if (v.index != 0 and v.index >= m.funcs.items.len)
+            if (v.index >= m.funcs.items.len)
                 return error.InvalidFuncIndex;
         }
     }

--- a/src/text/Lexer.zig
+++ b/src/text/Lexer.zig
@@ -326,7 +326,10 @@ pub fn classifyWord(text: []const u8) TokenKind {
     if (text.len == 0) return .invalid;
 
     // Check for numeric literal: starts with digit, or +/- followed by digit
-    if (isNumStart(text)) return classifyNumber(text);
+    if (isNumStart(text)) {
+        if (!hasValidNumberChars(text)) return .invalid;
+        return classifyNumber(text);
+    }
 
     // Bare "inf", "nan", "nan:0x..." are float literals
     if (eql(text, "inf") or eql(text, "nan")) return .float;
@@ -380,6 +383,33 @@ fn classifyNumber(text: []const u8) TokenKind {
         }
     }
     return .integer;
+}
+
+/// Check that a number-starting word only contains valid number characters.
+/// Rejects glued tokens like `0drop`, `0$l` where a number runs into a keyword/identifier.
+fn hasValidNumberChars(text: []const u8) bool {
+    var i: usize = 0;
+    // Skip optional sign
+    if (i < text.len and (text[i] == '+' or text[i] == '-')) i += 1;
+    // Handle special values: inf, nan, nan:0x...
+    if (i < text.len) {
+        const rest = text[i..];
+        if (std.mem.startsWith(u8, rest, "inf") and rest.len == 3) return true;
+        if (std.mem.startsWith(u8, rest, "nan")) return true;
+    }
+    // Check hex prefix
+    const is_hex = (i + 2 <= text.len and text[i] == '0' and
+        (text[i + 1] == 'x' or text[i + 1] == 'X'));
+    if (is_hex) i += 2;
+    while (i < text.len) : (i += 1) {
+        const c = text[i];
+        if (c >= '0' and c <= '9') continue;
+        if (c == '_' or c == '.' or c == '+' or c == '-') continue;
+        if (c == 'e' or c == 'E' or c == 'p' or c == 'P') continue;
+        if (is_hex and ((c >= 'a' and c <= 'f') or (c >= 'A' and c <= 'F'))) continue;
+        return false;
+    }
+    return true;
 }
 
 fn matchKeyword(text: []const u8) TokenKind {

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -115,6 +115,10 @@ pub fn parseModule(allocator: std.mem.Allocator, source: []const u8) ParseError!
             .kw_elem => try p.parseElem(&module),
             .kw_data => try p.parseData(&module),
             .kw_definition => try p.skipSExpr(),
+            .invalid => {
+                p.malformed = true;
+                try p.skipSExpr();
+            },
             else => try p.skipSExpr(),
         }
         try p.expect(.r_paren);
@@ -936,6 +940,7 @@ const Parser = struct {
                         has_operands = true;
                     } else {
                         // Could be additional immediates — skip them
+                        if (self.peek().kind == .invalid) self.malformed = true;
                         _ = self.advance();
                     }
                 }
@@ -1045,7 +1050,10 @@ const Parser = struct {
                         targets.append(self.allocator, idx) catch return;
                     } else {
                         const label_tok = self.advance();
-                        const depth = self.resolveLabelDepth(label_tok.text) orelse 0;
+                        const depth = self.resolveLabelDepth(label_tok.text) orelse blk: {
+                            self.malformed = true;
+                            break :blk 0;
+                        };
                         targets.append(self.allocator, depth) catch return;
                     }
                 }
@@ -1097,6 +1105,35 @@ const Parser = struct {
                         // No '(' follows, restore and treat as type index
                         self.lexer.pos = sp_ci;
                         self.peeked = spk_ci;
+                    }
+                }
+                // Pre-scan: check type/param/result ordering
+                // Valid order is: (type ...)? (param ...)* (result ...)*
+                {
+                    var scan = Lexer.init(self.lexer.source);
+                    scan.pos = if (self.peeked) |pk| pk.offset else self.lexer.pos;
+                    var saw_type = false;
+                    var saw_param = false;
+                    var saw_result = false;
+                    while (true) {
+                        const stok = scan.next();
+                        if (stok.kind != .l_paren) break;
+                        const inner = scan.next();
+                        if (inner.kind == .kw_type) {
+                            if (saw_param or saw_result) self.malformed = true;
+                            saw_type = true;
+                        } else if (inner.kind == .kw_param) {
+                            if (saw_result) self.malformed = true;
+                            saw_param = true;
+                        } else if (inner.kind == .kw_result) {
+                            saw_result = true;
+                        } else break;
+                        // Skip to matching ')'
+                        var sdepth: u32 = 1;
+                        while (sdepth > 0) {
+                            const s2 = scan.next();
+                            if (s2.kind == .l_paren) sdepth += 1 else if (s2.kind == .r_paren) sdepth -= 1 else if (s2.kind == .eof) break;
+                        }
                     }
                 }
                 // Parse type use: (type $idx) or inline


### PR DESCRIPTION
Fix 11 failures: call_indirect.wast 6f→0f, token.wast 5f→0f

- Detect type annotation conflicts in call_indirect
- Detect wrong param/result/type ordering
- Detect glued number+keyword and keyword+string tokens