### PR TITLE
Fix binary module use-after-free, float_literals.wast 100%

### DIFF
--- a/src/wast_runner.zig
+++ b/src/wast_runner.zig
@@ -607,10 +607,11 @@ pub fn run(allocator: std.mem.Allocator, source: []const u8) Result {
                             result.skipped += 1;
                             continue;
                         };
-                        defer allocator.free(wasm_bytes);
                         if (state.setModuleBinary(wasm_bytes)) {
+                            // Module now owns the bytes (slices into them for names/code)
                             result.passed += 1;
                         } else {
+                            allocator.free(wasm_bytes);
                             result.skipped += 1;
                         }
                     } else {


### PR DESCRIPTION
float_literals.wast: 179p 0f (100%)