### PR TITLE
Cross-module linking: shared tables, memory grow, elem segments

### DIFF
--- a/linking_stderr.txt
+++ b/linking_stderr.txt
@@ -1,1 +1,0 @@
-third_party\testsuite\linking.wast: 132 passed, 0 failed, 0 skipped (132 total)

--- a/linking_stderr.txt
+++ b/linking_stderr.txt
@@ -1,0 +1,1 @@
+third_party\testsuite\linking.wast: 132 passed, 0 failed, 0 skipped (132 total)

--- a/src/interp/Interpreter.zig
+++ b/src/interp/Interpreter.zig
@@ -81,6 +81,10 @@ pub const Instance = struct {
     /// Back-reference to the owning interpreter (set after creation).
     interp_ref: ?*Interpreter = null,
 
+    /// Interpreter refs for imported funcref globals.
+    /// Maps global index to the interpreter that owns the referenced function.
+    global_func_interps: std.ArrayListUnmanaged(?*Interpreter) = .{},
+
     /// Get the active memory (shared or local).
     pub fn getMemory(self: *Instance) *std.ArrayListUnmanaged(u8) {
         return self.shared_memory orelse &self.memory;
@@ -173,6 +177,7 @@ pub const Instance = struct {
         for (self.tables.items) |*t| t.deinit(self.allocator);
         self.tables.deinit(self.allocator);
         self.table_func_refs.deinit(self.allocator);
+        self.global_func_interps.deinit(self.allocator);
         self.dropped_data.deinit(self.allocator);
         self.dropped_elems.deinit(self.allocator);
     }
@@ -230,17 +235,34 @@ pub const Instance = struct {
                 }
             }
 
+            // Bounds check for empty elem segments (offset must be ≤ table.size)
+            const elem_count = @max(seg.elem_var_indices.items.len, @as(usize, seg.elem_expr_count));
+            if (offset + elem_count > tbl.items.len) {
+                return error.OutOfBoundsTableAccess;
+            }
+            if (offset > tbl.items.len) {
+                return error.OutOfBoundsTableAccess;
+            }
+
             // Try elem expressions first (funcref expressions like ref.func, global.get)
             if (seg.elem_expr_count > 0 and seg.elem_expr_bytes.len > 0) {
-                if (offset + seg.elem_expr_count > tbl.items.len) {
-                    return error.OutOfBoundsTableAccess;
-                }
                 var expr_pc: usize = 0;
                 var expr_i: u32 = 0;
                 while (expr_i < seg.elem_expr_count) : (expr_i += 1) {
                     const entry_idx: u32 = @intCast(offset + expr_i);
-                    // Evaluate one const expression (terminated by 0x0b)
                     const expr_start = expr_pc;
+                    // Detect if expression is global.get (0x23) for funcref source tracking
+                    var source_interp: ?*Interpreter = self.interp_ref;
+                    if (expr_pc < seg.elem_expr_bytes.len and seg.elem_expr_bytes[expr_pc] == 0x23) {
+                        // global.get — check if it references an imported funcref global
+                        var tmp = expr_pc + 1;
+                        const gidx = readCodeU32(seg.elem_expr_bytes, &tmp);
+                        if (gidx < self.global_func_interps.items.len) {
+                            if (self.global_func_interps.items[gidx]) |gi| {
+                                source_interp = gi;
+                            }
+                        }
+                    }
                     // Find the end of this expression
                     while (expr_pc < seg.elem_expr_bytes.len and seg.elem_expr_bytes[expr_pc] != 0x0b) {
                         expr_pc += 1;
@@ -250,7 +272,7 @@ pub const Instance = struct {
                     if (val) |v| switch (v) {
                         .ref_func => |func_idx| {
                             tbl.items[entry_idx] = func_idx;
-                            if (self.interp_ref) |interp| {
+                            if (source_interp) |interp| {
                                 const refs = self.getTableFuncRefs();
                                 refs.put(self.allocator, makeTableKey(tbl_idx, entry_idx), interp) catch {};
                             }
@@ -262,9 +284,6 @@ pub const Instance = struct {
                     };
                 }
             } else if (seg.elem_var_indices.items.len > 0) {
-                if (offset + seg.elem_var_indices.items.len > tbl.items.len) {
-                    return error.OutOfBoundsTableAccess;
-                }
                 for (seg.elem_var_indices.items, 0..) |var_, j| {
                     const table_entry = offset + j;
                     switch (var_) {
@@ -277,6 +296,15 @@ pub const Instance = struct {
                         },
                         .name => {},
                     }
+                }
+            }
+        }
+
+        // Implicitly drop active and declarative elem segments (per spec)
+        for (self.module.elem_segments.items, 0..) |seg, seg_i| {
+            if (seg.kind == .active or seg.kind == .declared) {
+                if (seg_i < self.dropped_elems.capacity()) {
+                    self.dropped_elems.set(seg_i);
                 }
             }
         }
@@ -1698,13 +1726,50 @@ pub const Interpreter = struct {
         const dropped = elem_idx < self.instance.dropped_elems.capacity() and
             self.instance.dropped_elems.isSet(elem_idx);
         const seg = &self.instance.module.elem_segments.items[elem_idx];
-        const seg_len: u32 = if (dropped) 0 else @intCast(seg.elem_var_indices.items.len);
+        // Use the larger of var_indices count and expr count for segment length
+        const var_len: u32 = @intCast(seg.elem_var_indices.items.len);
+        const expr_len: u32 = seg.elem_expr_count;
+        const seg_len: u32 = if (dropped) 0 else @max(var_len, expr_len);
         const tbl = self.instance.getTable(tbl_idx);
         if (@as(u64, src) + n > seg_len or
             @as(u64, dst) + n > tbl.items.len)
             return error.OutOfBoundsTableAccess;
         if (n == 0) return;
         const refs = self.instance.getTableFuncRefs();
+
+        // If elem segment uses expressions (funcref/externref), evaluate them
+        if (var_len == 0 and expr_len > 0 and seg.elem_expr_bytes.len > 0) {
+            // Navigate to the src-th expression
+            var expr_pc: usize = 0;
+            var skip: u32 = 0;
+            while (skip < src and expr_pc < seg.elem_expr_bytes.len) : (skip += 1) {
+                while (expr_pc < seg.elem_expr_bytes.len and seg.elem_expr_bytes[expr_pc] != 0x0b) {
+                    expr_pc += 1;
+                }
+                if (expr_pc < seg.elem_expr_bytes.len) expr_pc += 1;
+            }
+            var i: u32 = 0;
+            while (i < n) : (i += 1) {
+                const expr_start = expr_pc;
+                while (expr_pc < seg.elem_expr_bytes.len and seg.elem_expr_bytes[expr_pc] != 0x0b) {
+                    expr_pc += 1;
+                }
+                if (expr_pc < seg.elem_expr_bytes.len) expr_pc += 1;
+                const val = evalConstExpr(self.instance, seg.elem_expr_bytes[expr_start..expr_pc]);
+                if (val) |v| switch (v) {
+                    .ref_func => |func_idx| {
+                        tbl.items[dst + i] = func_idx;
+                        refs.put(self.allocator, Instance.makeTableKey(tbl_idx, dst + i), self) catch {};
+                    },
+                    .ref_null => {
+                        tbl.items[dst + i] = null;
+                    },
+                    else => {},
+                };
+            }
+            return;
+        }
+
         var i: u32 = 0;
         while (i < n) : (i += 1) {
             const var_entry = seg.elem_var_indices.items[src + i];

--- a/src/interp/Interpreter.zig
+++ b/src/interp/Interpreter.zig
@@ -69,6 +69,18 @@ pub const Instance = struct {
     /// Shared table pointers — when set, table operations use this instead of local tables.
     shared_tables: ?*std.ArrayListUnmanaged(std.ArrayListUnmanaged(?u32)) = null,
 
+    /// Max pages for shared (imported) memory — from the exporter's definition.
+    shared_memory_max_pages: ?u64 = null,
+
+    /// Per-table-entry interpreter refs for cross-module function references.
+    /// Key = (tbl_idx << 32) | entry_idx. Only used when tables are shared.
+    table_func_refs: std.AutoHashMapUnmanaged(u64, *Interpreter) = .{},
+    /// Points to the table owner's table_func_refs when tables are shared.
+    shared_table_func_refs: ?*std.AutoHashMapUnmanaged(u64, *Interpreter) = null,
+
+    /// Back-reference to the owning interpreter (set after creation).
+    interp_ref: ?*Interpreter = null,
+
     /// Get the active memory (shared or local).
     pub fn getMemory(self: *Instance) *std.ArrayListUnmanaged(u8) {
         return self.shared_memory orelse &self.memory;
@@ -85,6 +97,15 @@ pub const Instance = struct {
         const tbls = self.shared_tables orelse &self.tables;
         if (idx < tbls.items.len) return &tbls.items[idx];
         return &tbls.items[0];
+    }
+
+    /// Get the table func refs map (shared or local).
+    pub fn getTableFuncRefs(self: *Instance) *std.AutoHashMapUnmanaged(u64, *Interpreter) {
+        return self.shared_table_func_refs orelse &self.table_func_refs;
+    }
+
+    fn makeTableKey(tbl_idx: u32, entry_idx: u32) u64 {
+        return (@as(u64, tbl_idx) << 32) | entry_idx;
     }
 
     pub fn init(allocator: std.mem.Allocator, module: *const Mod.Module) TrapError!Instance {
@@ -151,6 +172,7 @@ pub const Instance = struct {
         self.globals.deinit(self.allocator);
         for (self.tables.items) |*t| t.deinit(self.allocator);
         self.tables.deinit(self.allocator);
+        self.table_func_refs.deinit(self.allocator);
         self.dropped_data.deinit(self.allocator);
         self.dropped_elems.deinit(self.allocator);
     }
@@ -207,14 +229,54 @@ pub const Instance = struct {
                     };
                 }
             }
-            if (offset + seg.elem_var_indices.items.len > tbl.items.len) {
-                return error.OutOfBoundsTableAccess;
-            }
-            for (seg.elem_var_indices.items, 0..) |var_, j| {
-                const table_entry = offset + j;
-                switch (var_) {
-                    .index => |idx| tbl.items[table_entry] = idx,
-                    .name => {},
+
+            // Try elem expressions first (funcref expressions like ref.func, global.get)
+            if (seg.elem_expr_count > 0 and seg.elem_expr_bytes.len > 0) {
+                if (offset + seg.elem_expr_count > tbl.items.len) {
+                    return error.OutOfBoundsTableAccess;
+                }
+                var expr_pc: usize = 0;
+                var expr_i: u32 = 0;
+                while (expr_i < seg.elem_expr_count) : (expr_i += 1) {
+                    const entry_idx: u32 = @intCast(offset + expr_i);
+                    // Evaluate one const expression (terminated by 0x0b)
+                    const expr_start = expr_pc;
+                    // Find the end of this expression
+                    while (expr_pc < seg.elem_expr_bytes.len and seg.elem_expr_bytes[expr_pc] != 0x0b) {
+                        expr_pc += 1;
+                    }
+                    if (expr_pc < seg.elem_expr_bytes.len) expr_pc += 1; // skip 0x0b
+                    const val = evalConstExpr(self, seg.elem_expr_bytes[expr_start..expr_pc]);
+                    if (val) |v| switch (v) {
+                        .ref_func => |func_idx| {
+                            tbl.items[entry_idx] = func_idx;
+                            if (self.interp_ref) |interp| {
+                                const refs = self.getTableFuncRefs();
+                                refs.put(self.allocator, makeTableKey(tbl_idx, entry_idx), interp) catch {};
+                            }
+                        },
+                        .ref_null => {
+                            tbl.items[entry_idx] = null;
+                        },
+                        else => {},
+                    };
+                }
+            } else if (seg.elem_var_indices.items.len > 0) {
+                if (offset + seg.elem_var_indices.items.len > tbl.items.len) {
+                    return error.OutOfBoundsTableAccess;
+                }
+                for (seg.elem_var_indices.items, 0..) |var_, j| {
+                    const table_entry = offset + j;
+                    switch (var_) {
+                        .index => |idx| {
+                            tbl.items[table_entry] = idx;
+                            if (self.interp_ref) |interp| {
+                                const refs = self.getTableFuncRefs();
+                                refs.put(self.allocator, makeTableKey(tbl_idx, @intCast(table_entry)), interp) catch {};
+                            }
+                        },
+                        .name => {},
+                    }
                 }
             }
         }
@@ -1221,8 +1283,15 @@ pub const Interpreter = struct {
             return;
         }
 
-        // Apply max limit from the module definition if present.
-        if (self.instance.module.memories.items.len > 0) {
+        // For imported (shared) memory, respect the exporter's actual max.
+        if (self.instance.shared_memory != null) {
+            if (self.instance.shared_memory_max_pages) |max| {
+                if (new_pages > max) {
+                    try self.pushValue(.{ .i32 = -1 });
+                    return;
+                }
+            }
+        } else if (self.instance.module.memories.items.len > 0) {
             const mem = self.instance.module.memories.items[0];
             if (mem.@"type".limits.has_max) {
                 if (new_pages > mem.@"type".limits.max) {
@@ -1635,6 +1704,7 @@ pub const Interpreter = struct {
             @as(u64, dst) + n > tbl.items.len)
             return error.OutOfBoundsTableAccess;
         if (n == 0) return;
+        const refs = self.instance.getTableFuncRefs();
         var i: u32 = 0;
         while (i < n) : (i += 1) {
             const var_entry = seg.elem_var_indices.items[src + i];
@@ -1646,6 +1716,7 @@ pub const Interpreter = struct {
                 tbl.items[dst + i] = null;
             } else {
                 tbl.items[dst + i] = func_idx;
+                refs.put(self.allocator, Instance.makeTableKey(tbl_idx, dst + i), self) catch {};
             }
         }
     }
@@ -2051,9 +2122,15 @@ pub const Interpreter = struct {
                     const ci_tbl = self.instance.getTable(ci_tbl_idx);
                     if (uidx >= ci_tbl.items.len) return error.OutOfBoundsTableAccess;
                     const func_idx = ci_tbl.items[uidx] orelse return error.UninitializedElement;
-                    if (func_idx >= self.instance.module.funcs.items.len) return error.UndefinedElement;
-                    const target = self.instance.module.funcs.items[func_idx];
-                    const func_sig = self.resolveSig(target.decl);
+
+                    // Check for cross-module function reference
+                    const key = Instance.makeTableKey(ci_tbl_idx, uidx);
+                    const refs = self.instance.getTableFuncRefs();
+                    const target_interp = refs.get(key) orelse self;
+
+                    if (func_idx >= target_interp.instance.module.funcs.items.len) return error.UndefinedElement;
+                    const target = target_interp.instance.module.funcs.items[func_idx];
+                    const func_sig = target_interp.resolveSig(target.decl);
                     // Verify type matches the expected signature (structural)
                     if (type_idx < self.instance.module.module_types.items.len) {
                         switch (self.instance.module.module_types.items[type_idx]) {
@@ -2074,7 +2151,16 @@ pub const Interpreter = struct {
                         i -= 1;
                         call_args[i] = try self.popValue();
                     }
-                    try self.callFunc(func_idx, call_args);
+                    if (target_interp != self) {
+                        // Cross-module call: call through target interpreter and copy results
+                        const link_base = target_interp.stack.items.len;
+                        try target_interp.callFunc(func_idx, call_args);
+                        const link_results = target_interp.stack.items[link_base..];
+                        for (link_results) |v| try self.pushValue(v);
+                        target_interp.stack.shrinkRetainingCapacity(link_base);
+                    } else {
+                        try self.callFunc(func_idx, call_args);
+                    }
                 },
                 0x1a => _ = try self.popValue(), // drop
                 0x1b => try self.selectOp(), // select

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -2148,16 +2148,46 @@ const Parser = struct {
                     } else |_| {}
                 }
                 var type_index: types.Index = 0;
-                if (self.peek().kind == .l_paren) {
+                var params_list: std.ArrayListUnmanaged(types.ValType) = .{};
+                defer params_list.deinit(self.allocator);
+                var results_list: std.ArrayListUnmanaged(types.ValType) = .{};
+                defer results_list.deinit(self.allocator);
+                while (self.peek().kind == .l_paren) {
+                    const sp2 = self.lexer.pos;
+                    const spk2 = self.peeked;
                     _ = self.advance();
                     if (self.peek().kind == .kw_type) {
                         _ = self.advance();
                         type_index = try self.parseTypeIdx();
                         try self.expect(.r_paren);
-                    } else {
-                        try self.skipSExpr();
+                    } else if (self.peek().kind == .kw_param) {
+                        _ = self.advance();
+                        if (self.peek().kind == .identifier) _ = self.advance();
+                        while (self.peek().kind != .r_paren and self.peek().kind != .eof) {
+                            const vt = self.parseValType() catch break;
+                            params_list.append(self.allocator, vt) catch {};
+                        }
                         try self.expect(.r_paren);
+                    } else if (self.peek().kind == .kw_result) {
+                        _ = self.advance();
+                        while (self.peek().kind != .r_paren and self.peek().kind != .eof) {
+                            const vt = self.parseValType() catch break;
+                            results_list.append(self.allocator, vt) catch {};
+                        }
+                        try self.expect(.r_paren);
+                    } else {
+                        self.lexer.pos = sp2;
+                        self.peeked = spk2;
+                        break;
                     }
+                }
+                if (params_list.items.len > 0 or results_list.items.len > 0) {
+                    const params = params_list.toOwnedSlice(self.allocator) catch &.{};
+                    const results = results_list.toOwnedSlice(self.allocator) catch &.{};
+                    type_index = @intCast(module.module_types.items.len);
+                    module.module_types.append(self.allocator, .{
+                        .func_type = .{ .params = params, .results = results },
+                    }) catch {};
                 }
                 import.func = .{ .type_var = .{ .index = type_index } };
                 try module.funcs.append(self.allocator, .{

--- a/src/wast_runner.zig
+++ b/src/wast_runner.zig
@@ -287,6 +287,9 @@ const RunState = struct {
         if (mod.num_global_imports > 0) {
             interp.global_links.resize(self.allocator, mod.globals.items.len) catch return;
             @memset(interp.global_links.items, null);
+            // Allocate global_func_interps for funcref global tracking
+            interp.instance.global_func_interps.resize(self.allocator, mod.globals.items.len) catch {};
+            @memset(interp.instance.global_func_interps.items, null);
         }
 
         var func_import_idx: u32 = 0;
@@ -328,6 +331,13 @@ const RunState = struct {
                             .instance = triple.instance,
                             .global_idx = src_idx,
                         };
+                    }
+                    // Track funcref source interpreter for cross-module elem init
+                    const val = triple.instance.globals.items[src_idx];
+                    if (val == .ref_func) {
+                        if (global_import_idx < interp.instance.global_func_interps.items.len) {
+                            interp.instance.global_func_interps.items[global_import_idx] = triple.interpreter;
+                        }
                     }
                 }
             } else if (imp.kind == .memory) {
@@ -1169,8 +1179,6 @@ fn processAssertUnlinkable(allocator: std.mem.Allocator, sexpr: []const u8, stat
         };
         // Everything succeeded — unexpected for assert_unlinkable.
         result.failed += 1;
-        const mod_text = findEmbeddedModule(sexpr) orelse sexpr;
-        std.debug.print("  FAIL assert_unlinkable: module linked OK: {s}\n", .{mod_text[0..@min(200, mod_text.len)]});
     } else {
         // Imports couldn't be resolved — this is the expected unlinkable behavior
         result.passed += 1;

--- a/src/wast_runner.zig
+++ b/src/wast_runner.zig
@@ -142,6 +142,7 @@ const RunState = struct {
             return false;
         };
         interp.* = Interp.Interpreter.init(self.allocator, inst);
+        inst.interp_ref = interp;
         self.resolveImports(mod, interp);
         inst.instantiate() catch {
             interp.deinit();
@@ -196,6 +197,7 @@ const RunState = struct {
             return false;
         };
         interp.* = Interp.Interpreter.init(self.allocator, inst);
+        inst.interp_ref = interp;
 
         // Resolve function and global imports BEFORE instantiation so init
         // expressions like (global.get 0) can see imported global values.
@@ -326,6 +328,13 @@ const RunState = struct {
                 if (exp.kind != .memory) continue;
                 // Point to the exporter's memory for true sharing
                 interp.instance.shared_memory = triple.instance.getMemory();
+                // Store the exporter's actual max for grow limit checks
+                if (triple.module.memories.items.len > 0) {
+                    const exp_mem = triple.module.memories.items[0];
+                    if (exp_mem.@"type".limits.has_max) {
+                        interp.instance.shared_memory_max_pages = exp_mem.@"type".limits.max;
+                    }
+                }
             } else if (imp.kind == .table) {
                 // Share tables from exporting module via pointer
                 const triple = self.registered_modules.get(imp.module_name) orelse continue;
@@ -334,6 +343,8 @@ const RunState = struct {
                 // Point to the exporter's tables for true sharing
                 const src_tables = triple.instance.shared_tables orelse &triple.instance.tables;
                 interp.instance.shared_tables = src_tables;
+                // Share the table func refs map for cross-module call_indirect
+                interp.instance.shared_table_func_refs = triple.instance.getTableFuncRefs();
             }
         }
     }
@@ -383,7 +394,23 @@ const RunState = struct {
                     }
                 },
                 .memory => {
-                    // Memory import: check limits
+                    // Memory import: check limits compatibility
+                    if (imp.memory) |imp_m| {
+                        const exp_idx: u32 = switch (exp.var_) { .index => |i| i, .name => continue };
+                        if (exp_idx >= triple.module.memories.items.len) return false;
+                        const exp_mem = triple.module.memories.items[exp_idx];
+                        // Actual size must be what's required
+                        const actual = if (triple.instance.shared_memory) |_|
+                            @as(u64, @intCast(triple.instance.getMemory().items.len / 65536))
+                        else
+                            @as(u64, @intCast(triple.instance.getMemory().items.len / 65536));
+                        if (actual < imp_m.limits.initial) return false;
+                        // If import has max, export must also have max and export.max ≤ import.max
+                        if (imp_m.limits.has_max) {
+                            if (!exp_mem.@"type".limits.has_max) return false;
+                            if (exp_mem.@"type".limits.max > imp_m.limits.max) return false;
+                        }
+                    }
                 },
                 .table => {
                     // Table import: check elem type and limits
@@ -391,7 +418,15 @@ const RunState = struct {
                         const exp_idx: u32 = switch (exp.var_) { .index => |i| i, .name => continue };
                         if (exp_idx >= triple.module.tables.items.len) return false;
                         const exp_tbl = triple.module.tables.items[exp_idx];
-                        if (imp_t.elem_type != exp_tbl.type.elem_type) return false;
+                        if (imp_t.elem_type != exp_tbl.@"type".elem_type) return false;
+                        // Actual table size must be at least what's required
+                        const actual_size: u64 = @intCast(triple.instance.getTable(exp_idx).items.len);
+                        if (actual_size < imp_t.limits.initial) return false;
+                        // If import has max, export must also have max and export.max ≤ import.max
+                        if (imp_t.limits.has_max) {
+                            if (!exp_tbl.@"type".limits.has_max) return false;
+                            if (exp_tbl.@"type".limits.max > imp_t.limits.max) return false;
+                        }
                     }
                 },
                 else => {},
@@ -510,6 +545,7 @@ const RunState = struct {
             return;
         };
         interp.* = Interp.Interpreter.init(self.allocator, inst);
+        inst.interp_ref = interp;
 
         self.putRegistered("spectest", .{ .module = mod, .instance = inst, .interpreter = interp });
     }
@@ -1074,6 +1110,7 @@ fn processAssertUnlinkable(allocator: std.mem.Allocator, sexpr: []const u8, stat
 
     var interp = Interp.Interpreter.init(allocator, &instance);
     defer interp.deinit();
+    instance.interp_ref = &interp;
 
     // Check that all imports can be resolved
     if (state.checkImportsResolvable(&module)) {
@@ -1085,6 +1122,8 @@ fn processAssertUnlinkable(allocator: std.mem.Allocator, sexpr: []const u8, stat
         };
         // Everything succeeded — unexpected for assert_unlinkable.
         result.failed += 1;
+        const mod_text = findEmbeddedModule(sexpr) orelse sexpr;
+        std.debug.print("  FAIL assert_unlinkable: module linked OK: {s}\n", .{mod_text[0..@min(200, mod_text.len)]});
     } else {
         // Imports couldn't be resolved — this is the expected unlinkable behavior
         result.passed += 1;

--- a/src/wast_runner.zig
+++ b/src/wast_runner.zig
@@ -61,6 +61,8 @@ const RunState = struct {
     owned_keys: std.ArrayListUnmanaged([]const u8) = .{},
     /// Source texts from decoded quote modules (kept alive for name slices).
     owned_sources: std.ArrayListUnmanaged([]const u8) = .{},
+    /// Triples kept alive because they wrote to shared tables (prevent dangling refs).
+    zombie_triples: std.ArrayListUnmanaged(ModuleTriple) = .{},
 
     fn deinit(self: *RunState) void {
         self.destroyCurrent();
@@ -80,6 +82,13 @@ const RunState = struct {
                 destroyed.put(self.allocator, triple.module, {}) catch {};
             }
         }
+        for (self.zombie_triples.items) |triple| {
+            if (!destroyed.contains(triple.module)) {
+                triple.destroy(self.allocator);
+                destroyed.put(self.allocator, triple.module, {}) catch {};
+            }
+        }
+        self.zombie_triples.deinit(self.allocator);
         self.named_modules.deinit(self.allocator);
         self.registered_modules.deinit(self.allocator);
         for (self.owned_keys.items) |key| self.allocator.free(key);
@@ -975,38 +984,76 @@ fn processAssertTrap(allocator: std.mem.Allocator, sexpr: []const u8, state: *Ru
             return;
         }
 
-        // Text module
-        var module = Parser.parseModule(allocator, inner) catch {
-            result.passed += 1;
-            return;
-        };
-        defer module.deinit();
-
-        Validator.validate(&module, .{}) catch {
+        // Text module — heap-allocate so resources survive if the module
+        // writes to shared tables/memory before trapping.
+        const mod = allocator.create(Mod.Module) catch { result.skipped += 1; return; };
+        mod.* = Parser.parseModule(allocator, inner) catch {
+            allocator.destroy(mod);
             result.passed += 1;
             return;
         };
 
-        var instance = Interp.Instance.init(allocator, &module) catch {
+        Validator.validate(mod, .{}) catch {
+            mod.deinit();
+            allocator.destroy(mod);
             result.passed += 1;
             return;
         };
-        defer instance.deinit();
-        instance.instantiate() catch {
-            result.passed += 1;
-            return;
-        };
-        var interp2 = Interp.Interpreter.init(allocator, &instance);
-        defer interp2.deinit();
 
-        if (module.start_var) |sv| {
+        const inst = allocator.create(Interp.Instance) catch {
+            mod.deinit();
+            allocator.destroy(mod);
+            result.skipped += 1;
+            return;
+        };
+        inst.* = Interp.Instance.init(allocator, mod) catch {
+            allocator.destroy(inst);
+            mod.deinit();
+            allocator.destroy(mod);
+            result.passed += 1;
+            return;
+        };
+
+        const interp2 = allocator.create(Interp.Interpreter) catch {
+            inst.deinit();
+            allocator.destroy(inst);
+            mod.deinit();
+            allocator.destroy(mod);
+            result.skipped += 1;
+            return;
+        };
+        interp2.* = Interp.Interpreter.init(allocator, inst);
+        inst.interp_ref = interp2;
+        state.resolveImports(mod, interp2);
+
+        const has_shared = inst.shared_memory != null or inst.shared_tables != null;
+        const triple = ModuleTriple{ .module = mod, .instance = inst, .interpreter = interp2 };
+
+        inst.instantiate() catch {
+            if (has_shared) {
+                state.zombie_triples.append(allocator, triple) catch {};
+            } else {
+                triple.destroy(allocator);
+            }
+            result.passed += 1;
+            return;
+        };
+
+        if (mod.start_var) |sv| {
             interp2.callFunc(sv.index, &.{}) catch {
+                if (has_shared) {
+                    state.zombie_triples.append(allocator, triple) catch {};
+                } else {
+                    triple.destroy(allocator);
+                }
                 result.passed += 1;
                 return;
             };
+            triple.destroy(allocator);
             result.failed += 1;
             return;
         }
+        triple.destroy(allocator);
         result.failed += 1;
         return;
     };


### PR DESCRIPTION
linking.wast: 0f, elem.wast: 0f, table_init.wast: 0f