### PR TITLE
Replace em dash with ASCII dash in tool help text

### DIFF
--- a/src/tools/spectest-interp.zig
+++ b/src/tools/spectest-interp.zig
@@ -26,7 +26,7 @@ pub fn main() !void {
     while (args_it.next()) |arg| {
         if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
             std.debug.print(
-                \\spectest-interp — run WebAssembly spec tests (.wast)
+                \\spectest-interp - run WebAssembly spec tests (.wast)
                 \\
                 \\Usage: spectest-interp [options] <file.wast>
                 \\

--- a/src/tools/wasm-decompile.zig
+++ b/src/tools/wasm-decompile.zig
@@ -10,7 +10,7 @@ pub fn decompile(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm-decompile — decompile a WebAssembly binary
+        \\wasm-decompile - decompile a WebAssembly binary
         \\
         \\Usage: wasm-decompile [options] <file>
         \\

--- a/src/tools/wasm-interp.zig
+++ b/src/tools/wasm-interp.zig
@@ -11,7 +11,7 @@ pub fn interpret(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm-interp — interpret a WebAssembly binary
+        \\wasm-interp - interpret a WebAssembly binary
         \\
         \\Usage: wasm-interp [options] <file>
         \\

--- a/src/tools/wasm-objdump.zig
+++ b/src/tools/wasm-objdump.zig
@@ -34,7 +34,7 @@ pub fn dump(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm-objdump — dump the contents of a WebAssembly binary
+        \\wasm-objdump - dump the contents of a WebAssembly binary
         \\
         \\Usage: wasm-objdump [options] <file>
         \\

--- a/src/tools/wasm-stats.zig
+++ b/src/tools/wasm-stats.zig
@@ -35,7 +35,7 @@ pub fn stats(allocator: std.mem.Allocator, wasm_bytes: []const u8) !Stats {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm-stats — show statistics for a WebAssembly binary
+        \\wasm-stats - show statistics for a WebAssembly binary
         \\
         \\Usage: wasm-stats [options] <file>
         \\

--- a/src/tools/wasm-strip.zig
+++ b/src/tools/wasm-strip.zig
@@ -11,7 +11,7 @@ pub fn strip(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm-strip — strip custom sections from a WebAssembly binary
+        \\wasm-strip - strip custom sections from a WebAssembly binary
         \\
         \\Usage: wasm-strip [options] <file>
         \\

--- a/src/tools/wasm-validate.zig
+++ b/src/tools/wasm-validate.zig
@@ -12,7 +12,7 @@ pub fn validateBytes(allocator: std.mem.Allocator, wasm_bytes: []const u8) !void
 
 pub fn main() void {
     std.debug.print(
-        \\wasm-validate — validate a WebAssembly binary
+        \\wasm-validate - validate a WebAssembly binary
         \\
         \\Usage: wasm-validate [options] <file>
         \\

--- a/src/tools/wasm2c.zig
+++ b/src/tools/wasm2c.zig
@@ -10,7 +10,7 @@ pub fn wasmToC(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm2c — translate WebAssembly binary to C source
+        \\wasm2c - translate WebAssembly binary to C source
         \\
         \\Usage: wasm2c [options] <file>
         \\

--- a/src/tools/wasm2wat-fuzz.zig
+++ b/src/tools/wasm2wat-fuzz.zig
@@ -9,7 +9,7 @@ pub fn fuzzWasm2Wat(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 
 }
 
 pub fn main() void {
-    std.debug.print("wasm2wat-fuzz — fuzz target for wasm to wat conversion\n", .{});
+    std.debug.print("wasm2wat-fuzz - fuzz target for wasm to wat conversion\n", .{});
 }
 
 test "empty module fuzz target works" {

--- a/src/tools/wasm2wat.zig
+++ b/src/tools/wasm2wat.zig
@@ -12,7 +12,7 @@ pub fn convert(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm2wat — translate WebAssembly binary to text format
+        \\wasm2wat - translate WebAssembly binary to text format
         \\
         \\Usage: wasm2wat [options] <file>
         \\

--- a/src/tools/wast2json.zig
+++ b/src/tools/wast2json.zig
@@ -17,7 +17,7 @@ pub fn wastToJson(allocator: std.mem.Allocator, wat_source: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wast2json — translate WebAssembly spec test format to JSON
+        \\wast2json - translate WebAssembly spec test format to JSON
         \\
         \\Usage: wast2json [options] <file>
         \\

--- a/src/tools/wat-desugar.zig
+++ b/src/tools/wat-desugar.zig
@@ -10,7 +10,7 @@ pub fn desugar(allocator: std.mem.Allocator, wat_source: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wat-desugar — remove syntactic sugar from WebAssembly text
+        \\wat-desugar - remove syntactic sugar from WebAssembly text
         \\
         \\Usage: wat-desugar [options] <file>
         \\

--- a/src/tools/wat2wasm.zig
+++ b/src/tools/wat2wasm.zig
@@ -14,7 +14,7 @@ pub fn convert(allocator: std.mem.Allocator, wat_source: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wat2wasm — translate WebAssembly text format to binary
+        \\wat2wasm - translate WebAssembly text format to binary
         \\
         \\Usage: wat2wasm [options] <file>
         \\


### PR DESCRIPTION
The em dash (U+2014, \—\) in help strings displays as garbled text (\ΓÇö\) on Windows consoles that don't use UTF-8 codepages.

Replaces \ — \ with \ - \ in all 13 tool help descriptions.

Fixes #66