### PR TITLE
Add version to tool help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# WABT: The WebAssembly Binary Toolkit (Zig)
+# WABT: The WebAssembly Binary Toolkit
 
 A fork of [WebAssembly/wabt](https://github.com/WebAssembly/wabt) ported from C++ to Zig and maintained with AI assistance.
 
 **100% WebAssembly 3.0 spec conformance** — 65,011/65,011 tests passing.
+
+## Install
+
+```console
+$ pip install wabt-bin
+```
 
 ## Tools
 
@@ -12,12 +18,10 @@ A fork of [WebAssembly/wabt](https://github.com/WebAssembly/wabt) ported from C+
  - **wasm-interp**: decode and run a WebAssembly binary file using a stack-based interpreter
  - **wasm-decompile**: decompile a wasm binary into readable C-like syntax
  - **wat-desugar**: parse .wat text form and print canonical flat format
- - **wasm2c**: convert a WebAssembly binary file to a C source and header
  - **wasm-strip**: remove sections of a WebAssembly binary file
  - **wasm-validate**: validate a file in the WebAssembly binary format
  - **wast2json**: convert a file in the wasm spec test format to a JSON file and associated wasm binary files
  - **wasm-stats**: output stats for a module
- - **spectest-interp**: run WebAssembly spec tests (.wast files)
 
 ## Building
 

--- a/scripts/build_wheels.py
+++ b/scripts/build_wheels.py
@@ -127,7 +127,7 @@ def build_wheel(
         f"Name: wabt-bin\n"
         f"Version: {version}\n"
         f"Summary: WebAssembly Binary Toolkit — native CLI tools\n"
-        f"Home-page: https://github.com/WebAssembly/wabt\n"
+        f"Home-page: https://github.com/cataggar/wabt\n"
         f"License: Apache-2.0\n"
         f"Requires-Python: >=3.9\n"
         f"Description-Content-Type: text/markdown\n"

--- a/src/root.zig
+++ b/src/root.zig
@@ -33,6 +33,8 @@ pub const interp = struct {
 /// Maximum input file size (256 MiB). Prevents OOM from oversized or malicious input.
 pub const max_input_file_size = 256 * 1024 * 1024;
 
+pub const version = "2.0.0-dev.1";
+
 test {
     @import("std").testing.refAllDecls(@This());
     _ = @import("integration_tests.zig");

--- a/src/tools/spectest-interp.zig
+++ b/src/tools/spectest-interp.zig
@@ -26,13 +26,13 @@ pub fn main() !void {
     while (args_it.next()) |arg| {
         if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
             std.debug.print(
-                \\spectest-interp - run WebAssembly spec tests (.wast)
+                \\spectest-interp {s} - run WebAssembly spec tests (.wast)
                 \\
                 \\Usage: spectest-interp [options] <file.wast>
                 \\
                 \\  -h, --help   Show this help message
                 \\
-            , .{});
+            , .{wabt.version});
             return;
         } else {
             input_file = arg;

--- a/src/tools/wasm-decompile.zig
+++ b/src/tools/wasm-decompile.zig
@@ -10,13 +10,13 @@ pub fn decompile(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm-decompile - decompile a WebAssembly binary
+        \\wasm-decompile {s} - decompile a WebAssembly binary
         \\
         \\Usage: wasm-decompile [options] <file>
         \\
         \\  -o, --output <file>   Output file (default: stdout)
         \\
-    , .{});
+    , .{wabt.version});
 }
 
 test "empty module produces minimal output" {

--- a/src/tools/wasm-interp.zig
+++ b/src/tools/wasm-interp.zig
@@ -11,14 +11,14 @@ pub fn interpret(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm-interp - interpret a WebAssembly binary
+        \\wasm-interp {s} - interpret a WebAssembly binary
         \\
         \\Usage: wasm-interp [options] <file>
         \\
         \\  --run-all-exports  Run all exported functions
         \\  --wasi             Enable WASI support
         \\
-    , .{});
+    , .{wabt.version});
 }
 
 test "empty module runs" {

--- a/src/tools/wasm-objdump.zig
+++ b/src/tools/wasm-objdump.zig
@@ -34,7 +34,7 @@ pub fn dump(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm-objdump - dump the contents of a WebAssembly binary
+        \\wasm-objdump {s} - dump the contents of a WebAssembly binary
         \\
         \\Usage: wasm-objdump [options] <file>
         \\
@@ -43,7 +43,7 @@ pub fn main() void {
         \\  -x, --details     Show section details
         \\  -s, --full-contents  Show full section contents
         \\
-    , .{});
+    , .{wabt.version});
 }
 
 test "empty module produces header info" {

--- a/src/tools/wasm-stats.zig
+++ b/src/tools/wasm-stats.zig
@@ -35,13 +35,13 @@ pub fn stats(allocator: std.mem.Allocator, wasm_bytes: []const u8) !Stats {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm-stats - show statistics for a WebAssembly binary
+        \\wasm-stats {s} - show statistics for a WebAssembly binary
         \\
         \\Usage: wasm-stats [options] <file>
         \\
         \\  -o, --output <file>   Output file (default: stdout)
         \\
-    , .{});
+    , .{wabt.version});
 }
 
 test "empty module returns zero stats" {

--- a/src/tools/wasm-strip.zig
+++ b/src/tools/wasm-strip.zig
@@ -11,13 +11,13 @@ pub fn strip(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm-strip - strip custom sections from a WebAssembly binary
+        \\wasm-strip {s} - strip custom sections from a WebAssembly binary
         \\
         \\Usage: wasm-strip [options] <file>
         \\
         \\  -o, --output <file>   Output file (default: overwrite input)
         \\
-    , .{});
+    , .{wabt.version});
 }
 
 test "module with custom section is stripped" {

--- a/src/tools/wasm-validate.zig
+++ b/src/tools/wasm-validate.zig
@@ -12,13 +12,13 @@ pub fn validateBytes(allocator: std.mem.Allocator, wasm_bytes: []const u8) !void
 
 pub fn main() void {
     std.debug.print(
-        \\wasm-validate - validate a WebAssembly binary
+        \\wasm-validate {s} - validate a WebAssembly binary
         \\
         \\Usage: wasm-validate [options] <file>
         \\
         \\  -h, --help            Show this help message
         \\
-    , .{});
+    , .{wabt.version});
 }
 
 test "validate minimal module" {

--- a/src/tools/wasm2c.zig
+++ b/src/tools/wasm2c.zig
@@ -10,14 +10,14 @@ pub fn wasmToC(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm2c - translate WebAssembly binary to C source
+        \\wasm2c {s} - translate WebAssembly binary to C source
         \\
         \\Usage: wasm2c [options] <file>
         \\
         \\  -o, --output <file>   Output C file
         \\  -n, --module-name     Module name (default: derived from filename)
         \\
-    , .{});
+    , .{wabt.version});
 }
 
 test "empty module produces C header" {

--- a/src/tools/wasm2wat-fuzz.zig
+++ b/src/tools/wasm2wat-fuzz.zig
@@ -9,7 +9,7 @@ pub fn fuzzWasm2Wat(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 
 }
 
 pub fn main() void {
-    std.debug.print("wasm2wat-fuzz - fuzz target for wasm to wat conversion\n", .{});
+    std.debug.print("wasm2wat-fuzz {s} - fuzz target for wasm to wat conversion\n", .{wabt.version});
 }
 
 test "empty module fuzz target works" {

--- a/src/tools/wasm2wat.zig
+++ b/src/tools/wasm2wat.zig
@@ -12,14 +12,14 @@ pub fn convert(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wasm2wat - translate WebAssembly binary to text format
+        \\wasm2wat {s} - translate WebAssembly binary to text format
         \\
         \\Usage: wasm2wat [options] <file>
         \\
         \\  -h, --help            Show this help message
         \\  -o, --output <file>   Output file (default: stdout)
         \\
-    , .{});
+    , .{wabt.version});
 }
 
 test "convert minimal wasm module" {

--- a/src/tools/wast2json.zig
+++ b/src/tools/wast2json.zig
@@ -17,13 +17,13 @@ pub fn wastToJson(allocator: std.mem.Allocator, wat_source: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wast2json - translate WebAssembly spec test format to JSON
+        \\wast2json {s} - translate WebAssembly spec test format to JSON
         \\
         \\Usage: wast2json [options] <file>
         \\
         \\  -o, --output <file>   Output JSON file
         \\
-    , .{});
+    , .{wabt.version});
 }
 
 test "empty module produces JSON with commands array" {

--- a/src/tools/wat-desugar.zig
+++ b/src/tools/wat-desugar.zig
@@ -10,13 +10,13 @@ pub fn desugar(allocator: std.mem.Allocator, wat_source: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wat-desugar - remove syntactic sugar from WebAssembly text
+        \\wat-desugar {s} - remove syntactic sugar from WebAssembly text
         \\
         \\Usage: wat-desugar [options] <file>
         \\
         \\  -o, --output <file>   Output file (default: stdout)
         \\
-    , .{});
+    , .{wabt.version});
 }
 
 test "empty module round-trips" {

--- a/src/tools/wat2wasm.zig
+++ b/src/tools/wat2wasm.zig
@@ -14,14 +14,14 @@ pub fn convert(allocator: std.mem.Allocator, wat_source: []const u8) ![]u8 {
 
 pub fn main() void {
     std.debug.print(
-        \\wat2wasm - translate WebAssembly text format to binary
+        \\wat2wasm {s} - translate WebAssembly text format to binary
         \\
         \\Usage: wat2wasm [options] <file>
         \\
         \\  -h, --help            Show this help message
         \\  -o, --output <file>   Output file (default: <input>.wasm)
         \\
-    , .{});
+    , .{wabt.version});
 }
 
 test "convert empty module" {


### PR DESCRIPTION
Display version from \wabt.version\ constant in each tool's help output.

\\\
wat2wasm 2.0.0-dev.1 - translate WebAssembly text format to binary
\\\

Closes #64