### PR TITLE
fix(writer): preserve empty init expressions and emit table init expressions

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -222,6 +222,7 @@ pub const Table = struct {
     name: ?[]const u8 = null,
     @"type": types.TableType = .{},
     init_expr_bytes: []const u8 = &.{},
+    type_idx: u32 = 0xFFFFFFFF,
     loc: Location = .{},
     is_import: bool = false,
     is_table64: bool = false,

--- a/src/binary/writer.zig
+++ b/src/binary/writer.zig
@@ -192,8 +192,26 @@ const Writer = struct {
         const ph = try self.beginSection(4);
         try self.writeU32Leb(@intCast(defined));
         for (module.tables.items[module.num_table_imports..]) |table| {
-            try self.writeValType(table.type.elem_type);
-            try self.writeLimits(table.type.limits);
+            const et = table.type.elem_type;
+            if (table.init_expr_bytes.len > 0 and et != .ref_null and et != .ref) {
+                // Table with init expression: 0x40 0x00 reftype limits expr
+                try self.appendByte(0x40);
+                try self.appendByte(0x00);
+                try self.writeValType(et);
+                try self.writeLimits(table.type.limits);
+                try self.appendSlice(table.init_expr_bytes);
+                if (table.init_expr_bytes[table.init_expr_bytes.len - 1] != 0x0b) {
+                    try self.appendByte(0x0b);
+                }
+            } else if ((et == .ref_null or et == .ref) and table.type_idx != 0xFFFFFFFF) {
+                // Typed reference: write prefix + concrete type index
+                try self.appendByte(@bitCast(@as(i8, @intCast(@intFromEnum(et)))));
+                try self.writeU32Leb(table.type_idx);
+                try self.writeLimits(table.type.limits);
+            } else {
+                try self.writeValType(et);
+                try self.writeLimits(table.type.limits);
+            }
         }
         self.endSection(ph);
     }
@@ -224,34 +242,8 @@ const Writer = struct {
                     try self.appendByte(0x0b);
                 }
             } else {
-                // Default init expr: type.const 0, end
-                switch (global.type.val_type) {
-                    .i32 => {
-                        try self.appendByte(0x41);
-                        try self.writeS32Leb(0);
-                    },
-                    .i64 => {
-                        try self.appendByte(0x42);
-                        try self.writeS32Leb(0);
-                    },
-                    .f32 => {
-                        try self.appendByte(0x43);
-                        try self.writeU32LE(0);
-                    },
-                    .f64 => {
-                        try self.appendByte(0x44);
-                        try self.appendSlice(&[8]u8{ 0, 0, 0, 0, 0, 0, 0, 0 });
-                    },
-                    .funcref, .externref => {
-                        try self.appendByte(0xd0); // ref.null
-                        try self.writeValType(global.type.val_type);
-                    },
-                    else => {
-                        try self.appendByte(0x41);
-                        try self.writeS32Leb(0);
-                    },
-                }
-                try self.appendByte(0x0b); // end
+                // Empty init expression: emit just end opcode (invalid per spec)
+                try self.appendByte(0x0b);
             }
         }
         self.endSection(ph);
@@ -310,8 +302,7 @@ const Writer = struct {
                         try self.appendByte(0x0b);
                     }
                 } else {
-                    try self.appendByte(0x41);
-                    try self.writeS32Leb(0);
+                    // Empty offset expression: emit just end opcode (invalid per spec)
                     try self.appendByte(0x0b);
                 }
             }
@@ -407,9 +398,7 @@ const Writer = struct {
                         try self.appendByte(0x0b);
                     }
                 } else {
-                    // Default: i32.const 0, end
-                    try self.appendByte(0x41);
-                    try self.writeS32Leb(0);
+                    // Empty offset expression: emit just end opcode (invalid per spec)
                     try self.appendByte(0x0b);
                 }
             }

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -2694,12 +2694,18 @@ const Parser = struct {
         if (param_count == 0 and result_count == 0) {
             // Fall through to check for (type N) below
         } else if (param_count == 0 and result_count == 1 and @intFromEnum(result_types_buf[0]) > 0) {
-            // Simple single-result block type: emit valtype byte (only for standard types)
-            const raw: u32 = @bitCast(@intFromEnum(result_types_buf[0]));
-            buf[0] = @truncate(raw);
-            return 1;
-        } else {
-            // Multi-value: create a func type entry and emit type index
+            // Simple single-result block type: emit valtype byte
+            // BUT ref/ref_null need the multi-value path (type index) because
+            // they require a heap type that can't be encoded in a single byte
+            const rt = result_types_buf[0];
+            if (rt != .ref_null and rt != .ref) {
+                const raw: u32 = @bitCast(@intFromEnum(rt));
+                buf[0] = @truncate(raw);
+                return 1;
+            }
+        }
+        // Multi-value or ref/ref_null: create a func type entry and emit type index
+        if (param_count > 0 or result_count > 0) {
             if (self.module) |mod| {
                 const p = self.allocator.alloc(types.ValType, param_count) catch {
                     buf[0] = 0x40;
@@ -3535,7 +3541,15 @@ const Parser = struct {
         self.skipAnnotations();
         if (self.peek().kind != .integer) {
             // elemtype first — inline elem syntax
+            const saved_refs_len2 = self.collected_type_refs.items.len;
+            const saved_in_type2 = self.in_type_parse;
+            self.in_type_parse = true;
             const elem_type = self.parseValType() catch .funcref;
+            self.in_type_parse = saved_in_type2;
+            const inline_type_idx: u32 = if (self.collected_type_refs.items.len > saved_refs_len2)
+                self.collected_type_refs.items[saved_refs_len2]
+            else
+                0xFFFFFFFF;
             // Parse (elem func_refs...)
             var elem_indices: std.ArrayListUnmanaged(Mod.Var) = .{};
             if (self.peek().kind == .l_paren) {
@@ -3589,6 +3603,7 @@ const Parser = struct {
             const initial: u64 = @intCast(elem_indices.items.len);
             try module.tables.append(self.allocator, .{
                 .@"type" = .{ .elem_type = elem_type, .limits = .{ .initial = initial } },
+                .type_idx = inline_type_idx,
                 .is_table64 = is_table64,
             });
             // Create active element segment for the inline elements
@@ -3626,7 +3641,16 @@ const Parser = struct {
             limits.has_max = true;
         }
         self.skipAnnotations();
+        // Capture concrete type index if elem type is (ref null $t) / (ref $t)
+        const saved_refs_len = self.collected_type_refs.items.len;
+        const saved_in_type = self.in_type_parse;
+        self.in_type_parse = true;
         const elem_type = try self.parseValType();
+        self.in_type_parse = saved_in_type;
+        const table_type_idx: u32 = if (self.collected_type_refs.items.len > saved_refs_len)
+            self.collected_type_refs.items[saved_refs_len]
+        else
+            0xFFFFFFFF;
         // Parse optional table initializer expression: (ref.null func) etc.
         var table_init_bytes: []const u8 = &.{};
         if (self.peek().kind == .l_paren) {
@@ -3675,6 +3699,7 @@ const Parser = struct {
         try module.tables.append(self.allocator, .{
             .@"type" = .{ .elem_type = elem_type, .limits = limits },
             .init_expr_bytes = table_init_bytes,
+            .type_idx = table_type_idx,
             .is_table64 = is_table64,
         });
     }


### PR DESCRIPTION
Stop normalizing invalid empty init expressions into valid defaults in the binary writer.

## Problem
The binary writer was silently replacing empty \init_expr_bytes\ (from invalid WAT like \(global i32)\ without an initializer) with type-specific defaults (\i32.const 0\, \ef.null\, etc.). This masked validation errors in downstream consumers like WAMR.

## Changes
- Global/data/elem sections: emit just \