### PR TITLE
feat(writer): encode concrete typed refs in func type params/results

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -131,6 +131,8 @@ pub const ExprType = enum {
 pub const FuncSignature = struct {
     params: []const types.ValType = &.{},
     results: []const types.ValType = &.{},
+    param_type_idxs: []const u32 = &.{},
+    result_type_idxs: []const u32 = &.{},
 
     pub fn eql(a: FuncSignature, b: FuncSignature) bool {
         return std.mem.eql(types.ValType, a.params, b.params) and
@@ -356,6 +358,8 @@ pub const Module = struct {
                 .func_type => |ft| {
                     if (ft.params.len > 0) self.allocator.free(ft.params);
                     if (ft.results.len > 0) self.allocator.free(ft.results);
+                    if (ft.param_type_idxs.len > 0) self.allocator.free(ft.param_type_idxs);
+                    if (ft.result_type_idxs.len > 0) self.allocator.free(ft.result_type_idxs);
                 },
                 .struct_type => |st| {
                     var fields = st.fields;

--- a/src/binary/writer.zig
+++ b/src/binary/writer.zig
@@ -75,8 +75,17 @@ const Writer = struct {
     }
 
     fn writeValType(self: *Writer, vt: types.ValType) WriteError!void {
-        // ValType has i32 discriminant; binary encodes as single byte
-        try self.appendByte(@bitCast(@as(i8, @intCast(@intFromEnum(vt)))));
+        try self.writeValTypeWithTidx(vt, 0xFFFFFFFF);
+    }
+
+    fn writeValTypeWithTidx(self: *Writer, vt: types.ValType, tidx: u32) WriteError!void {
+        if ((vt == .ref_null or vt == .ref) and tidx != 0xFFFFFFFF) {
+            // Concrete typed ref: write prefix + type index
+            try self.appendByte(@bitCast(@as(i8, @intCast(@intFromEnum(vt)))));
+            try self.writeU32Leb(tidx);
+        } else {
+            try self.appendByte(@bitCast(@as(i8, @intCast(@intFromEnum(vt)))));
+        }
     }
 
     fn writeLimits(self: *Writer, limits: types.Limits) WriteError!void {
@@ -131,9 +140,15 @@ const Writer = struct {
                 .func_type => |ft| {
                     try self.appendByte(0x60);
                     try self.writeU32Leb(@intCast(ft.params.len));
-                    for (ft.params) |p| try self.writeValType(p);
+                    for (ft.params, 0..) |p, pi| {
+                        const tidx: u32 = if (pi < ft.param_type_idxs.len) ft.param_type_idxs[pi] else 0xFFFFFFFF;
+                        try self.writeValTypeWithTidx(p, tidx);
+                    }
                     try self.writeU32Leb(@intCast(ft.results.len));
-                    for (ft.results) |r| try self.writeValType(r);
+                    for (ft.results, 0..) |r, ri| {
+                        const tidx: u32 = if (ri < ft.result_type_idxs.len) ft.result_type_idxs[ri] else 0xFFFFFFFF;
+                        try self.writeValTypeWithTidx(r, tidx);
+                    }
                 },
                 else => {}, // struct/array not yet supported
             }

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -652,11 +652,15 @@ const Parser = struct {
         };
     }
 
-    fn parseFuncSig(self: *Parser, module: *Mod.Module) ParseError!struct { params: []const types.ValType, results: []const types.ValType } {
+    fn parseFuncSig(self: *Parser, module: *Mod.Module) ParseError!struct { params: []const types.ValType, results: []const types.ValType, param_type_idxs: []const u32, result_type_idxs: []const u32 } {
         var params: std.ArrayListUnmanaged(types.ValType) = .{};
         errdefer params.deinit(self.allocator);
+        var param_tidxs: std.ArrayListUnmanaged(u32) = .{};
+        errdefer param_tidxs.deinit(self.allocator);
         var results: std.ArrayListUnmanaged(types.ValType) = .{};
         errdefer results.deinit(self.allocator);
+        var result_tidxs: std.ArrayListUnmanaged(u32) = .{};
+        errdefer result_tidxs.deinit(self.allocator);
         var seen_result = false;
 
         self.skipAnnotations();
@@ -674,7 +678,13 @@ const Parser = struct {
                 if (self.peek().kind == .identifier) _ = self.advance();
                 self.skipAnnotations();
                 while (self.peek().kind != .r_paren) {
+                    const refs_before = self.collected_type_refs.items.len;
+                    const saved_itp = self.in_type_parse;
+                    self.in_type_parse = true;
                     try params.append(self.allocator, try self.parseValType());
+                    self.in_type_parse = saved_itp;
+                    const tidx: u32 = if (self.collected_type_refs.items.len > refs_before) self.collected_type_refs.items[refs_before] else 0xFFFFFFFF;
+                    param_tidxs.append(self.allocator, tidx) catch {};
                     self.skipAnnotations();
                 }
                 try self.expect(.r_paren);
@@ -684,7 +694,13 @@ const Parser = struct {
                 _ = self.advance();
                 self.skipAnnotations();
                 while (self.peek().kind != .r_paren) {
+                    const refs_before = self.collected_type_refs.items.len;
+                    const saved_itp = self.in_type_parse;
+                    self.in_type_parse = true;
                     try results.append(self.allocator, try self.parseValType());
+                    self.in_type_parse = saved_itp;
+                    const tidx: u32 = if (self.collected_type_refs.items.len > refs_before) self.collected_type_refs.items[refs_before] else 0xFFFFFFFF;
+                    result_tidxs.append(self.allocator, tidx) catch {};
                     self.skipAnnotations();
                 }
                 try self.expect(.r_paren);
@@ -700,6 +716,8 @@ const Parser = struct {
         return .{
             .params = try params.toOwnedSlice(self.allocator),
             .results = try results.toOwnedSlice(self.allocator),
+            .param_type_idxs = try param_tidxs.toOwnedSlice(self.allocator),
+            .result_type_idxs = try result_tidxs.toOwnedSlice(self.allocator),
         };
     }
 
@@ -755,7 +773,7 @@ const Parser = struct {
             try self.expect(.r_paren);
             if (meta.is_sub) try self.expect(.r_paren); // close (sub ...)
             try module.module_types.append(self.allocator, .{
-                .func_type = .{ .params = sig.params, .results = sig.results },
+                .func_type = .{ .params = sig.params, .results = sig.results, .param_type_idxs = sig.param_type_idxs, .result_type_idxs = sig.result_type_idxs },
             });
         } else {
             if (std.mem.eql(u8, inner_text, "struct")) {
@@ -2621,8 +2639,10 @@ const Parser = struct {
         // Check for (param ...) (result ...), (result <valtype>+), or bare (param ...)
         var param_count: u32 = 0;
         var param_types_buf: [16]types.ValType = undefined;
+        var param_tidxs_buf: [16]u32 = .{0xFFFFFFFF} ** 16;
         var result_count: u32 = 0;
         var result_types_buf: [16]types.ValType = undefined;
+        var result_tidxs_buf: [16]u32 = .{0xFFFFFFFF} ** 16;
 
         // Consume all (param ...) blocks
         while (self.peek().kind == .l_paren or self.peek().kind == .annotation) {
@@ -2638,11 +2658,19 @@ const Parser = struct {
                     self.skipAnnotations();
                     if (self.peek().kind == .r_paren) break;
                     const before_pos = self.lexer.pos;
+                    const refs_before = self.collected_type_refs.items.len;
+                    const saved_itp = self.in_type_parse;
+                    self.in_type_parse = true;
                     if (self.parseValType()) |vt| {
-                        if (param_count < 16) param_types_buf[param_count] = vt;
+                        self.in_type_parse = saved_itp;
+                        if (param_count < 16) {
+                            param_types_buf[param_count] = vt;
+                            param_tidxs_buf[param_count] = if (self.collected_type_refs.items.len > refs_before) self.collected_type_refs.items[refs_before] else 0xFFFFFFFF;
+                        }
                         param_count += 1;
                         self.skipAnnotations();
                     } else |_| {
+                        self.in_type_parse = saved_itp;
                         if (self.lexer.pos == before_pos) _ = self.advance();
                         break;
                     }
@@ -2671,11 +2699,19 @@ const Parser = struct {
                     self.skipAnnotations();
                     if (self.peek().kind == .r_paren) break;
                     const before_pos = self.lexer.pos;
+                    const refs_before = self.collected_type_refs.items.len;
+                    const saved_itp = self.in_type_parse;
+                    self.in_type_parse = true;
                     if (self.parseValType()) |vt| {
-                        if (result_count < 16) result_types_buf[result_count] = vt;
+                        self.in_type_parse = saved_itp;
+                        if (result_count < 16) {
+                            result_types_buf[result_count] = vt;
+                            result_tidxs_buf[result_count] = if (self.collected_type_refs.items.len > refs_before) self.collected_type_refs.items[refs_before] else 0xFFFFFFFF;
+                        }
                         result_count += 1;
                         self.skipAnnotations();
                     } else |_| {
+                        self.in_type_parse = saved_itp;
                         if (self.lexer.pos == before_pos) _ = self.advance();
                         break;
                     }
@@ -2712,14 +2748,24 @@ const Parser = struct {
                     return 1;
                 };
                 @memcpy(p, param_types_buf[0..param_count]);
+                const pt = self.allocator.alloc(u32, param_count) catch {
+                    buf[0] = 0x40;
+                    return 1;
+                };
+                @memcpy(pt, param_tidxs_buf[0..param_count]);
                 const r = self.allocator.alloc(types.ValType, result_count) catch {
                     buf[0] = 0x40;
                     return 1;
                 };
                 @memcpy(r, result_types_buf[0..result_count]);
+                const rt = self.allocator.alloc(u32, result_count) catch {
+                    buf[0] = 0x40;
+                    return 1;
+                };
+                @memcpy(rt, result_tidxs_buf[0..result_count]);
                 const type_idx: u32 = @intCast(mod.module_types.items.len);
                 mod.module_types.append(self.allocator, .{
-                    .func_type = .{ .params = p, .results = r },
+                    .func_type = .{ .params = p, .results = r, .param_type_idxs = pt, .result_type_idxs = rt },
                 }) catch {
                     buf[0] = 0x40;
                     return 1;

--- a/src/types.zig
+++ b/src/types.zig
@@ -146,6 +146,10 @@ pub const Limits = struct {
 pub const FuncType = struct {
     params: []const ValType = &.{},
     results: []const ValType = &.{},
+    /// Concrete type indices parallel to params (0xFFFFFFFF = abstract).
+    param_type_idxs: []const u32 = &.{},
+    /// Concrete type indices parallel to results (0xFFFFFFFF = abstract).
+    result_type_idxs: []const u32 = &.{},
 };
 
 /// Memory type.


### PR DESCRIPTION
Add param_type_idxs/result_type_idxs to FuncSignature. writeTypeSection now emits \ef_null\/\ef\ + heap_type for concrete typed references.

Unblocks 160 spec tests in WAMR (PR cataggar/wamr#29).