### PR TITLE
feat: propagate concrete type indices through all func sig and local parsing

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -131,6 +131,8 @@ pub const ExprType = enum {
 pub const FuncSignature = struct {
     params: []const types.ValType = &.{},
     results: []const types.ValType = &.{},
+    param_type_idxs: []const u32 = &.{},
+    result_type_idxs: []const u32 = &.{},
 
     pub fn eql(a: FuncSignature, b: FuncSignature) bool {
         return std.mem.eql(types.ValType, a.params, b.params) and
@@ -356,6 +358,8 @@ pub const Module = struct {
                 .func_type => |ft| {
                     if (ft.params.len > 0) self.allocator.free(ft.params);
                     if (ft.results.len > 0) self.allocator.free(ft.results);
+                    if (ft.param_type_idxs.len > 0) self.allocator.free(ft.param_type_idxs);
+                    if (ft.result_type_idxs.len > 0) self.allocator.free(ft.result_type_idxs);
                 },
                 .struct_type => |st| {
                     var fields = st.fields;

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -180,8 +180,10 @@ pub const Import = struct {
     kind: types.ExternalKind,
     func: ?FuncDeclaration = null,
     table: ?types.TableType = null,
+    table_type_idx: u32 = 0xFFFFFFFF,
     memory: ?types.MemoryType = null,
     global: ?types.GlobalType = null,
+    global_type_idx: u32 = 0xFFFFFFFF,
     tag: ?types.TagType = null,
 };
 
@@ -199,6 +201,7 @@ pub const Func = struct {
     name: ?[]const u8 = null,
     decl: FuncDeclaration = .{},
     local_types: std.ArrayListUnmanaged(types.ValType) = .{},
+    local_type_idxs: std.ArrayListUnmanaged(u32) = .{},
     loc: Location = .{},
     is_import: bool = false,
     /// Raw instruction bytes (binary format) for validation.
@@ -212,6 +215,7 @@ pub const Func = struct {
 pub const Global = struct {
     name: ?[]const u8 = null,
     @"type": types.GlobalType = .{},
+    type_idx: u32 = 0xFFFFFFFF,
     loc: Location = .{},
     is_import: bool = false,
     /// Raw bytecode for the init expression (constant expr).
@@ -375,6 +379,7 @@ pub const Module = struct {
         self.type_meta.deinit(self.allocator);
         for (self.funcs.items) |*func| {
             func.local_types.deinit(self.allocator);
+            func.local_type_idxs.deinit(self.allocator);
             if (func.owns_code_bytes and func.code_bytes.len > 0) {
                 self.allocator.free(func.code_bytes);
             }

--- a/src/binary/writer.zig
+++ b/src/binary/writer.zig
@@ -168,7 +168,7 @@ const Writer = struct {
                 .func => try self.writeU32Leb(if (imp.func) |f| f.type_var.index else 0),
                 .table => {
                     if (imp.table) |t| {
-                        try self.writeValType(t.elem_type);
+                        try self.writeValTypeWithTidx(t.elem_type, imp.table_type_idx);
                         try self.writeLimits(t.limits);
                     }
                 },
@@ -177,7 +177,7 @@ const Writer = struct {
                 },
                 .global => {
                     if (imp.global) |g| {
-                        try self.writeValType(g.val_type);
+                        try self.writeValTypeWithTidx(g.val_type, imp.global_type_idx);
                         try self.appendByte(if (g.mutability == .mutable) @as(u8, 1) else 0);
                     }
                 },
@@ -248,7 +248,7 @@ const Writer = struct {
         const ph = try self.beginSection(6);
         try self.writeU32Leb(@intCast(defined));
         for (module.globals.items[module.num_global_imports..]) |global| {
-            try self.writeValType(global.type.val_type);
+            try self.writeValTypeWithTidx(global.type.val_type, global.type_idx);
             try self.appendByte(if (global.type.mutability == .mutable) @as(u8, 1) else 0);
             // Write init expression
             if (global.init_expr_bytes.len > 0) {
@@ -371,7 +371,8 @@ const Writer = struct {
                     var run_end = run_start + 1;
                     while (run_end < locals.len and locals[run_end] == locals[run_start]) : (run_end += 1) {}
                     try self.writeU32Leb(@intCast(run_end - run_start));
-                    try self.writeValType(locals[run_start]);
+                    const tidx: u32 = if (run_start < func.local_type_idxs.items.len) func.local_type_idxs.items[run_start] else 0xFFFFFFFF;
+                    try self.writeValTypeWithTidx(locals[run_start], tidx);
                     run_start = run_end;
                 }
             }

--- a/src/binary/writer.zig
+++ b/src/binary/writer.zig
@@ -75,8 +75,17 @@ const Writer = struct {
     }
 
     fn writeValType(self: *Writer, vt: types.ValType) WriteError!void {
-        // ValType has i32 discriminant; binary encodes as single byte
-        try self.appendByte(@bitCast(@as(i8, @intCast(@intFromEnum(vt)))));
+        try self.writeValTypeWithTidx(vt, 0xFFFFFFFF);
+    }
+
+    fn writeValTypeWithTidx(self: *Writer, vt: types.ValType, tidx: u32) WriteError!void {
+        if ((vt == .ref_null or vt == .ref) and tidx != 0xFFFFFFFF) {
+            // Concrete typed ref: write prefix + type index
+            try self.appendByte(@bitCast(@as(i8, @intCast(@intFromEnum(vt)))));
+            try self.writeU32Leb(tidx);
+        } else {
+            try self.appendByte(@bitCast(@as(i8, @intCast(@intFromEnum(vt)))));
+        }
     }
 
     fn writeLimits(self: *Writer, limits: types.Limits) WriteError!void {
@@ -131,9 +140,15 @@ const Writer = struct {
                 .func_type => |ft| {
                     try self.appendByte(0x60);
                     try self.writeU32Leb(@intCast(ft.params.len));
-                    for (ft.params) |p| try self.writeValType(p);
+                    for (ft.params, 0..) |p, pi| {
+                        const tidx: u32 = if (pi < ft.param_type_idxs.len) ft.param_type_idxs[pi] else 0xFFFFFFFF;
+                        try self.writeValTypeWithTidx(p, tidx);
+                    }
                     try self.writeU32Leb(@intCast(ft.results.len));
-                    for (ft.results) |r| try self.writeValType(r);
+                    for (ft.results, 0..) |r, ri| {
+                        const tidx: u32 = if (ri < ft.result_type_idxs.len) ft.result_type_idxs[ri] else 0xFFFFFFFF;
+                        try self.writeValTypeWithTidx(r, tidx);
+                    }
                 },
                 else => {}, // struct/array not yet supported
             }

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -1339,8 +1339,12 @@ const Parser = struct {
         // Parse inline (param ...) and (result ...) to build a signature
         var params_list: std.ArrayListUnmanaged(types.ValType) = .{};
         defer params_list.deinit(self.allocator);
+        var param_tidxs_list: std.ArrayListUnmanaged(u32) = .{};
+        defer param_tidxs_list.deinit(self.allocator);
         var results_list: std.ArrayListUnmanaged(types.ValType) = .{};
         defer results_list.deinit(self.allocator);
+        var result_tidxs_list: std.ArrayListUnmanaged(u32) = .{};
+        defer result_tidxs_list.deinit(self.allocator);
 
         var seen_results = false;
 
@@ -1365,8 +1369,13 @@ const Parser = struct {
                 }
                 self.skipAnnotations();
                 while (self.peek().kind != .r_paren and self.peek().kind != .eof) {
-                    const vt = self.parseValType() catch break;
+                    const refs_before = self.collected_type_refs.items.len;
+                    const saved_itp = self.in_type_parse;
+                    self.in_type_parse = true;
+                    const vt = self.parseValType() catch { self.in_type_parse = saved_itp; break; };
+                    self.in_type_parse = saved_itp;
                     params_list.append(self.allocator, vt) catch return error.OutOfMemory;
+                    param_tidxs_list.append(self.allocator, if (self.collected_type_refs.items.len > refs_before) self.collected_type_refs.items[refs_before] else 0xFFFFFFFF) catch {};
                     self.skipAnnotations();
                 }
                 try self.expect(.r_paren);
@@ -1376,8 +1385,13 @@ const Parser = struct {
                 _ = self.advance(); // consume 'result'
                 self.skipAnnotations();
                 while (self.peek().kind != .r_paren and self.peek().kind != .eof) {
-                    const vt = self.parseValType() catch break;
+                    const refs_before = self.collected_type_refs.items.len;
+                    const saved_itp = self.in_type_parse;
+                    self.in_type_parse = true;
+                    const vt = self.parseValType() catch { self.in_type_parse = saved_itp; break; };
+                    self.in_type_parse = saved_itp;
                     results_list.append(self.allocator, vt) catch return error.OutOfMemory;
+                    result_tidxs_list.append(self.allocator, if (self.collected_type_refs.items.len > refs_before) self.collected_type_refs.items[refs_before] else 0xFFFFFFFF) catch {};
                     self.skipAnnotations();
                 }
                 try self.expect(.r_paren);
@@ -1425,9 +1439,13 @@ const Parser = struct {
             if (params_list.items.len > 0 or results_list.items.len > 0) {
                 const p = self.allocator.alloc(types.ValType, params_list.items.len) catch return error.OutOfMemory;
                 @memcpy(p, params_list.items);
+                const pt = self.allocator.alloc(u32, param_tidxs_list.items.len) catch return error.OutOfMemory;
+                @memcpy(pt, param_tidxs_list.items);
                 const r = self.allocator.alloc(types.ValType, results_list.items.len) catch return error.OutOfMemory;
                 @memcpy(r, results_list.items);
-                const new_sig = Mod.FuncSignature{ .params = p, .results = r };
+                const rt = self.allocator.alloc(u32, result_tidxs_list.items.len) catch return error.OutOfMemory;
+                @memcpy(rt, result_tidxs_list.items);
+                const new_sig = Mod.FuncSignature{ .params = p, .results = r, .param_type_idxs = pt, .result_type_idxs = rt };
                 // Deduplicate: reuse existing type if signature matches
                 const type_idx = blk: {
                     for (module.module_types.items, 0..) |entry, idx| {
@@ -1435,6 +1453,8 @@ const Parser = struct {
                             .func_type => |ft| if (ft.eql(new_sig)) {
                                 self.allocator.free(p);
                                 self.allocator.free(r);
+                                if (pt.len > 0) self.allocator.free(pt);
+                                if (rt.len > 0) self.allocator.free(rt);
                                 break :blk idx;
                             },
                             else => {},
@@ -1501,8 +1521,13 @@ const Parser = struct {
                 }
                 self.skipAnnotations();
                 while (self.peek().kind != .r_paren and self.peek().kind != .eof) {
-                    const vt = self.parseValType() catch break;
+                    const refs_before = self.collected_type_refs.items.len;
+                    const saved_itp = self.in_type_parse;
+                    self.in_type_parse = true;
+                    const vt = self.parseValType() catch { self.in_type_parse = saved_itp; break; };
+                    self.in_type_parse = saved_itp;
                     func.local_types.append(self.allocator, vt) catch return error.OutOfMemory;
+                    func.local_type_idxs.append(self.allocator, if (self.collected_type_refs.items.len > refs_before) self.collected_type_refs.items[refs_before] else 0xFFFFFFFF) catch {};
                     self.skipAnnotations();
                 }
                 try self.expect(.r_paren);
@@ -3941,6 +3966,7 @@ const Parser = struct {
                 self.skipAnnotations();
                 var mutability: types.Mutability = .immutable;
                 var val_type: types.ValType = undefined;
+                var imp_global_tidx: u32 = 0xFFFFFFFF;
                 if (self.peek().kind == .l_paren) {
                     const sp2 = self.lexer.pos;
                     const spk2 = self.peeked;
@@ -3948,19 +3974,35 @@ const Parser = struct {
                     if (self.peek().kind == .kw_mut) {
                         _ = self.advance();
                         mutability = .mutable;
+                        const rb = self.collected_type_refs.items.len;
+                        const si = self.in_type_parse;
+                        self.in_type_parse = true;
                         val_type = try self.parseValType();
+                        self.in_type_parse = si;
+                        if (self.collected_type_refs.items.len > rb) imp_global_tidx = self.collected_type_refs.items[rb];
                         self.skipAnnotations();
                         try self.expect(.r_paren);
                     } else {
                         self.lexer.pos = sp2;
                         self.peeked = spk2;
+                        const rb = self.collected_type_refs.items.len;
+                        const si = self.in_type_parse;
+                        self.in_type_parse = true;
                         val_type = try self.parseValType();
+                        self.in_type_parse = si;
+                        if (self.collected_type_refs.items.len > rb) imp_global_tidx = self.collected_type_refs.items[rb];
                     }
                 } else {
+                    const rb = self.collected_type_refs.items.len;
+                    const si = self.in_type_parse;
+                    self.in_type_parse = true;
                     val_type = try self.parseValType();
+                    self.in_type_parse = si;
+                    if (self.collected_type_refs.items.len > rb) imp_global_tidx = self.collected_type_refs.items[rb];
                 }
                 try module.globals.append(self.allocator, .{
                     .type = .{ .val_type = val_type, .mutability = mutability },
+                    .type_idx = imp_global_tidx,
                     .is_import = true,
                 });
                 module.num_global_imports += 1;
@@ -3970,6 +4012,7 @@ const Parser = struct {
                     .kind = .global,
                 };
                 import.global = .{ .val_type = val_type, .mutability = mutability };
+                import.global_type_idx = imp_global_tidx;
                 try module.imports.append(self.allocator, import);
                 return;
             } else {
@@ -3982,27 +4025,41 @@ const Parser = struct {
         self.skipAnnotations();
         var mutability: types.Mutability = .immutable;
         var val_type: types.ValType = undefined;
+        var global_tidx: u32 = 0xFFFFFFFF;
 
         // Check for (mut <valtype>) — requires two-token lookahead
         if (self.peek().kind == .l_paren) {
-            // Save lexer state to allow backtracking
             const save_pos = self.lexer.pos;
             const save_peeked = self.peeked;
             _ = self.advance(); // consume '('
             if (self.peek().kind == .kw_mut) {
                 _ = self.advance();
                 mutability = .mutable;
+                const rb = self.collected_type_refs.items.len;
+                const si = self.in_type_parse;
+                self.in_type_parse = true;
                 val_type = try self.parseValType();
+                self.in_type_parse = si;
+                if (self.collected_type_refs.items.len > rb) global_tidx = self.collected_type_refs.items[rb];
                 self.skipAnnotations();
                 try self.expect(.r_paren);
             } else {
-                // Not (mut ...) — restore and let parseValType handle it
                 self.lexer.pos = save_pos;
                 self.peeked = save_peeked;
+                const rb = self.collected_type_refs.items.len;
+                const si = self.in_type_parse;
+                self.in_type_parse = true;
                 val_type = try self.parseValType();
+                self.in_type_parse = si;
+                if (self.collected_type_refs.items.len > rb) global_tidx = self.collected_type_refs.items[rb];
             }
         } else {
+            const rb = self.collected_type_refs.items.len;
+            const si = self.in_type_parse;
+            self.in_type_parse = true;
             val_type = try self.parseValType();
+            self.in_type_parse = si;
+            if (self.collected_type_refs.items.len > rb) global_tidx = self.collected_type_refs.items[rb];
         }
 
         // Encode init expression into bytecode
@@ -4015,6 +4072,7 @@ const Parser = struct {
 
         try module.globals.append(self.allocator, .{
             .type = .{ .val_type = val_type, .mutability = mutability },
+            .type_idx = global_tidx,
             .init_expr_bytes = owned,
             .owns_init_expr_bytes = true,
         });

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -652,11 +652,15 @@ const Parser = struct {
         };
     }
 
-    fn parseFuncSig(self: *Parser, module: *Mod.Module) ParseError!struct { params: []const types.ValType, results: []const types.ValType } {
+    fn parseFuncSig(self: *Parser, module: *Mod.Module) ParseError!struct { params: []const types.ValType, results: []const types.ValType, param_type_idxs: []const u32, result_type_idxs: []const u32 } {
         var params: std.ArrayListUnmanaged(types.ValType) = .{};
         errdefer params.deinit(self.allocator);
+        var param_tidxs: std.ArrayListUnmanaged(u32) = .{};
+        errdefer param_tidxs.deinit(self.allocator);
         var results: std.ArrayListUnmanaged(types.ValType) = .{};
         errdefer results.deinit(self.allocator);
+        var result_tidxs: std.ArrayListUnmanaged(u32) = .{};
+        errdefer result_tidxs.deinit(self.allocator);
         var seen_result = false;
 
         self.skipAnnotations();
@@ -674,7 +678,13 @@ const Parser = struct {
                 if (self.peek().kind == .identifier) _ = self.advance();
                 self.skipAnnotations();
                 while (self.peek().kind != .r_paren) {
+                    const refs_before = self.collected_type_refs.items.len;
+                    const saved_itp = self.in_type_parse;
+                    self.in_type_parse = true;
                     try params.append(self.allocator, try self.parseValType());
+                    self.in_type_parse = saved_itp;
+                    const tidx: u32 = if (self.collected_type_refs.items.len > refs_before) self.collected_type_refs.items[refs_before] else 0xFFFFFFFF;
+                    param_tidxs.append(self.allocator, tidx) catch {};
                     self.skipAnnotations();
                 }
                 try self.expect(.r_paren);
@@ -684,7 +694,13 @@ const Parser = struct {
                 _ = self.advance();
                 self.skipAnnotations();
                 while (self.peek().kind != .r_paren) {
+                    const refs_before = self.collected_type_refs.items.len;
+                    const saved_itp = self.in_type_parse;
+                    self.in_type_parse = true;
                     try results.append(self.allocator, try self.parseValType());
+                    self.in_type_parse = saved_itp;
+                    const tidx: u32 = if (self.collected_type_refs.items.len > refs_before) self.collected_type_refs.items[refs_before] else 0xFFFFFFFF;
+                    result_tidxs.append(self.allocator, tidx) catch {};
                     self.skipAnnotations();
                 }
                 try self.expect(.r_paren);
@@ -700,6 +716,8 @@ const Parser = struct {
         return .{
             .params = try params.toOwnedSlice(self.allocator),
             .results = try results.toOwnedSlice(self.allocator),
+            .param_type_idxs = try param_tidxs.toOwnedSlice(self.allocator),
+            .result_type_idxs = try result_tidxs.toOwnedSlice(self.allocator),
         };
     }
 
@@ -755,7 +773,7 @@ const Parser = struct {
             try self.expect(.r_paren);
             if (meta.is_sub) try self.expect(.r_paren); // close (sub ...)
             try module.module_types.append(self.allocator, .{
-                .func_type = .{ .params = sig.params, .results = sig.results },
+                .func_type = .{ .params = sig.params, .results = sig.results, .param_type_idxs = sig.param_type_idxs, .result_type_idxs = sig.result_type_idxs },
             });
         } else {
             if (std.mem.eql(u8, inner_text, "struct")) {
@@ -2621,8 +2639,10 @@ const Parser = struct {
         // Check for (param ...) (result ...), (result <valtype>+), or bare (param ...)
         var param_count: u32 = 0;
         var param_types_buf: [16]types.ValType = undefined;
+        var param_tidxs_buf: [16]u32 = .{0xFFFFFFFF} ** 16;
         var result_count: u32 = 0;
         var result_types_buf: [16]types.ValType = undefined;
+        var result_tidxs_buf: [16]u32 = .{0xFFFFFFFF} ** 16;
 
         // Consume all (param ...) blocks
         while (self.peek().kind == .l_paren or self.peek().kind == .annotation) {
@@ -2638,11 +2658,19 @@ const Parser = struct {
                     self.skipAnnotations();
                     if (self.peek().kind == .r_paren) break;
                     const before_pos = self.lexer.pos;
+                    const refs_before = self.collected_type_refs.items.len;
+                    const saved_itp = self.in_type_parse;
+                    self.in_type_parse = true;
                     if (self.parseValType()) |vt| {
-                        if (param_count < 16) param_types_buf[param_count] = vt;
+                        self.in_type_parse = saved_itp;
+                        if (param_count < 16) {
+                            param_types_buf[param_count] = vt;
+                            param_tidxs_buf[param_count] = if (self.collected_type_refs.items.len > refs_before) self.collected_type_refs.items[refs_before] else 0xFFFFFFFF;
+                        }
                         param_count += 1;
                         self.skipAnnotations();
                     } else |_| {
+                        self.in_type_parse = saved_itp;
                         if (self.lexer.pos == before_pos) _ = self.advance();
                         break;
                     }
@@ -2671,11 +2699,19 @@ const Parser = struct {
                     self.skipAnnotations();
                     if (self.peek().kind == .r_paren) break;
                     const before_pos = self.lexer.pos;
+                    const refs_before = self.collected_type_refs.items.len;
+                    const saved_itp = self.in_type_parse;
+                    self.in_type_parse = true;
                     if (self.parseValType()) |vt| {
-                        if (result_count < 16) result_types_buf[result_count] = vt;
+                        self.in_type_parse = saved_itp;
+                        if (result_count < 16) {
+                            result_types_buf[result_count] = vt;
+                            result_tidxs_buf[result_count] = if (self.collected_type_refs.items.len > refs_before) self.collected_type_refs.items[refs_before] else 0xFFFFFFFF;
+                        }
                         result_count += 1;
                         self.skipAnnotations();
                     } else |_| {
+                        self.in_type_parse = saved_itp;
                         if (self.lexer.pos == before_pos) _ = self.advance();
                         break;
                     }
@@ -2712,14 +2748,24 @@ const Parser = struct {
                     return 1;
                 };
                 @memcpy(p, param_types_buf[0..param_count]);
+                const pt = self.allocator.alloc(u32, param_count) catch {
+                    buf[0] = 0x40;
+                    return 1;
+                };
+                @memcpy(pt, param_tidxs_buf[0..param_count]);
                 const r = self.allocator.alloc(types.ValType, result_count) catch {
                     buf[0] = 0x40;
                     return 1;
                 };
                 @memcpy(r, result_types_buf[0..result_count]);
+                const rt = self.allocator.alloc(u32, result_count) catch {
+                    buf[0] = 0x40;
+                    return 1;
+                };
+                @memcpy(rt, result_tidxs_buf[0..result_count]);
                 const type_idx: u32 = @intCast(mod.module_types.items.len);
                 mod.module_types.append(self.allocator, .{
-                    .func_type = .{ .params = p, .results = r },
+                    .func_type = .{ .params = p, .results = r, .param_type_idxs = pt, .result_type_idxs = rt },
                 }) catch {
                     buf[0] = 0x40;
                     return 1;

--- a/src/types.zig
+++ b/src/types.zig
@@ -146,6 +146,10 @@ pub const Limits = struct {
 pub const FuncType = struct {
     params: []const ValType = &.{},
     results: []const ValType = &.{},
+    /// Concrete type indices parallel to params (0xFFFFFFFF = abstract).
+    param_type_idxs: []const u32 = &.{},
+    /// Concrete type indices parallel to results (0xFFFFFFFF = abstract).
+    result_type_idxs: []const u32 = &.{},
 };
 
 /// Memory type.


### PR DESCRIPTION
Comprehensive fix for concrete typed ref binary encoding.

- FuncSignature: add param_type_idxs/result_type_idxs
- writeTypeSection: use writeValTypeWithTidx for params/results
- writeCodeSection: use writeValTypeWithTidx for local declarations
- Func: add local_type_idxs for concrete typed ref locals
- Parser: collect type_idxs in parseFuncSig, parseFunc, readBlockType, and local declarations

Unblocks +213 spec tests in WAMR.