### PR TITLE
fix: call_indirect inline type use and type index validation

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -345,6 +345,9 @@ pub const Module = struct {
     num_global_imports: types.Index = 0,
     num_tag_imports: types.Index = 0,
 
+    // Count of explicitly declared types (from (type ...) definitions)
+    num_declared_types: u32 = 0,
+
     // Data count section
     has_data_count: bool = false,
     data_count: u32 = 0,

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -63,6 +63,7 @@ pub fn parseModule(allocator: std.mem.Allocator, source: []const u8) ParseError!
     // Parse module fields — two passes:
     // Pass 1: process only (type ...) declarations to build the type section first.
     // This ensures explicit type indices are assigned before implicit function types.
+    p.module = &module;
     const saved_pos = p.lexer.pos;
     const saved_peeked = p.peeked;
 
@@ -95,6 +96,9 @@ pub fn parseModule(allocator: std.mem.Allocator, source: []const u8) ParseError!
 
     // Canonicalize rec groups for iso-recursive type equivalence
     p.canonicalizeTypes(&module);
+
+    // Record declared type count (before implicit types from funcs/blocks are added)
+    module.num_declared_types = @intCast(module.module_types.items.len);
 
     // Pass 2: process all other declarations (skip type/rec which were already handled).
     p.lexer.pos = saved_pos;
@@ -560,13 +564,14 @@ const Parser = struct {
                             // Within rec group, allow refs within the group but not beyond
                             if (idx >= self.rec_end) self.malformed = true;
                         } else if (self.in_type_parse) {
-                            // During type definition, allow self-reference (idx == current type)
                             if (self.module) |mod| {
-                                if (idx > mod.module_types.items.len) self.malformed = true;
+                                const max = if (mod.num_declared_types > 0) mod.num_declared_types else @as(u32, @intCast(mod.module_types.items.len));
+                                if (idx >= max) self.malformed = true;
                             }
                         } else {
                             if (self.module) |mod| {
-                                if (idx >= mod.module_types.items.len) self.malformed = true;
+                                const max_types = if (mod.num_declared_types > 0) mod.num_declared_types else @as(u32, @intCast(mod.module_types.items.len));
+                                if (idx >= max_types) self.malformed = true;
                             }
                         }
                     } else if (ht.kind == .identifier) {

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -1452,11 +1452,8 @@ const Parser = struct {
                 @memcpy(rt, result_tidxs_list.items);
                 const new_sig = Mod.FuncSignature{ .params = p, .results = r, .param_type_idxs = pt, .result_type_idxs = rt };
                 // Deduplicate: reuse existing type if signature matches
-                // Only deduplicate against implicit types (after declared types)
-                // to preserve explicit type identity for call_indirect
                 const type_idx = blk: {
-                    const dedup_start = module.num_declared_types;
-                    for (module.module_types.items[dedup_start..], dedup_start..) |entry, idx| {
+                    for (module.module_types.items, 0..) |entry, idx| {
                         switch (entry) {
                             .func_type => |ft| if (ft.eql(new_sig)) {
                                 self.allocator.free(p);
@@ -1478,8 +1475,7 @@ const Parser = struct {
                 // Empty func with no type — deduplicate void->void type
                 const empty_sig = Mod.FuncSignature{};
                 const type_idx = blk: {
-                    const dedup_start2 = module.num_declared_types;
-                    for (module.module_types.items[dedup_start2..], dedup_start2..) |entry, idx| {
+                    for (module.module_types.items, 0..) |entry, idx| {
                         switch (entry) {
                             .func_type => |ft| if (ft.eql(empty_sig)) break :blk idx,
                             else => {},
@@ -2265,12 +2261,32 @@ const Parser = struct {
                     } else {
                         self.lexer.pos = sp;
                         self.peeked = spk;
-                        self.emitLeb128U32(code, 0); // default type 0
+                        // Check for inline (param ...) (result ...) without (type ...)
+                        var ci_buf: [6]u8 = undefined;
+                        const ci_n = self.readBlockType(&ci_buf);
+                        // readBlockType emits signed s33 for type indices, but
+                        // readBlockType emits signed s33 for type indices, but
+                        // call_indirect uses unsigned u32. Re-encode if needed.
+                        if (ci_n > 1 or (ci_n == 1 and ci_buf[0] != 0x40)) {
+                            // Type index from readBlockType — decode s33 and re-encode as u32
+                            if (leb128.readS32Leb128(ci_buf[0..ci_n])) |sr| {
+                                if (sr.value >= 0) {
+                                    self.emitLeb128U32(code, @intCast(sr.value));
+                                } else {
+                                    self.emitLeb128U32(code, 0);
+                                }
+                            } else |_| {
+                                self.emitLeb128U32(code, 0);
+                            }
+                        } else {
+                            self.emitLeb128U32(code, 0);
+                        }
                     }
                 } else if (self.peek().kind == .integer) {
                     self.emitU32Imm(code); // numeric type index
                 } else {
-                    self.emitLeb128U32(code, 0); // default type 0
+                    // No type use at all — void type, use type 0
+                    self.emitLeb128U32(code, 0);
                 }
                 // Emit table index
                 self.emitLeb128U32(code, ci_table_idx);

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -1452,8 +1452,11 @@ const Parser = struct {
                 @memcpy(rt, result_tidxs_list.items);
                 const new_sig = Mod.FuncSignature{ .params = p, .results = r, .param_type_idxs = pt, .result_type_idxs = rt };
                 // Deduplicate: reuse existing type if signature matches
+                // Only deduplicate against implicit types (after declared types)
+                // to preserve explicit type identity for call_indirect
                 const type_idx = blk: {
-                    for (module.module_types.items, 0..) |entry, idx| {
+                    const dedup_start = module.num_declared_types;
+                    for (module.module_types.items[dedup_start..], dedup_start..) |entry, idx| {
                         switch (entry) {
                             .func_type => |ft| if (ft.eql(new_sig)) {
                                 self.allocator.free(p);
@@ -1475,7 +1478,8 @@ const Parser = struct {
                 // Empty func with no type — deduplicate void->void type
                 const empty_sig = Mod.FuncSignature{};
                 const type_idx = blk: {
-                    for (module.module_types.items, 0..) |entry, idx| {
+                    const dedup_start2 = module.num_declared_types;
+                    for (module.module_types.items[dedup_start2..], dedup_start2..) |entry, idx| {
                         switch (entry) {
                             .func_type => |ft| if (ft.eql(empty_sig)) break :blk idx,
                             else => {},

--- a/test_debug.zig
+++ b/test_debug.zig
@@ -1,0 +1,9 @@
+const wabt = @import(\
+wabt\); const std = @import(\std\); pub fn main() !void { const alloc = std.heap.page_allocator; const data = try std.fs.cwd().readFileAlloc(alloc, std.os.argv[1], 50*1024*1024); var m = try wabt.text.Parser.parseModule(alloc, data); defer m.deinit(); for (m.funcs.items[m.num_func_imports..], 0..) |func, fi| { if (fi >= 18 and fi <= 22) std.debug.print(\func[
+d
+]
+name=
+s
+type_idx=
+d
+\n\, .{ fi, func.name orelse \?\, func.decl.type_var.index }); } }


### PR DESCRIPTION
Fix call_indirect inline (param)/(result) encoding and type index validation.