### PR TITLE
fix: struct/array field type indices in binary writer

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -155,6 +155,7 @@ pub const TypeEntry = union(enum) {
             name: ?[]const u8 = null,
             @"type": types.ValType,
             mutable: bool = false,
+            type_idx: u32 = 0xFFFFFFFF,
         };
     };
 

--- a/src/binary/writer.zig
+++ b/src/binary/writer.zig
@@ -218,13 +218,13 @@ const Writer = struct {
                     try self.appendByte(0x5F);
                     try self.writeU32Leb(@intCast(st.fields.items.len));
                     for (st.fields.items) |f| {
-                        try self.writeValTypeWithTidx(f.@"type", 0xFFFFFFFF);
+                        try self.writeValTypeWithTidx(f.@"type", f.type_idx);
                         try self.appendByte(if (f.mutable) 1 else 0);
                     }
                 },
                 .array_type => |at| {
                     try self.appendByte(0x5E);
-                    try self.writeValTypeWithTidx(at.field.@"type", 0xFFFFFFFF);
+                    try self.writeValTypeWithTidx(at.field.@"type", at.field.type_idx);
                     try self.appendByte(if (at.field.mutable) 1 else 0);
                 },
             }

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -816,23 +816,39 @@ const Parser = struct {
                                 if (self.peek().kind == .kw_mut) {
                                     _ = self.advance();
                                     fmut = true;
+                                    const rb1 = self.collected_type_refs.items.len;
+                                    const si1 = self.in_type_parse; self.in_type_parse = true;
                                     const ftype = self.parseValType() catch .ref_null;
+                                    self.in_type_parse = si1;
+                                    const ft1: u32 = if (self.collected_type_refs.items.len > rb1) self.collected_type_refs.items[rb1] else 0xFFFFFFFF;
                                     if (self.peek().kind == .r_paren) _ = self.advance();
-                                    fields.append(self.allocator, .{ .name = fname, .@"type" = ftype, .mutable = fmut }) catch {};
+                                    fields.append(self.allocator, .{ .name = fname, .@"type" = ftype, .mutable = fmut, .type_idx = ft1 }) catch {};
                                 } else {
                                     self.lexer.pos = sp2;
                                     self.peeked = spk2;
+                                    const rb2 = self.collected_type_refs.items.len;
+                                    const si2 = self.in_type_parse; self.in_type_parse = true;
                                     const ftype = self.parseValType() catch .ref_null;
-                                    fields.append(self.allocator, .{ .name = fname, .@"type" = ftype, .mutable = false }) catch {};
+                                    self.in_type_parse = si2;
+                                    const ft2: u32 = if (self.collected_type_refs.items.len > rb2) self.collected_type_refs.items[rb2] else 0xFFFFFFFF;
+                                    fields.append(self.allocator, .{ .name = fname, .@"type" = ftype, .mutable = false, .type_idx = ft2 }) catch {};
                                 }
                             } else {
+                                const rb3 = self.collected_type_refs.items.len;
+                                const si3 = self.in_type_parse; self.in_type_parse = true;
                                 const ftype = self.parseValType() catch .ref_null;
-                                fields.append(self.allocator, .{ .name = fname, .@"type" = ftype, .mutable = false }) catch {};
+                                self.in_type_parse = si3;
+                                const ft3: u32 = if (self.collected_type_refs.items.len > rb3) self.collected_type_refs.items[rb3] else 0xFFFFFFFF;
+                                fields.append(self.allocator, .{ .name = fname, .@"type" = ftype, .mutable = false, .type_idx = ft3 }) catch {};
                             }
                             // Handle multiple anonymous fields: (field type type type ...)
                             while (self.peek().kind != .r_paren and self.peek().kind != .eof) {
+                                const rb4 = self.collected_type_refs.items.len;
+                                const si4 = self.in_type_parse; self.in_type_parse = true;
                                 const extra_type = self.parseValType() catch break;
-                                fields.append(self.allocator, .{ .@"type" = extra_type }) catch {};
+                                self.in_type_parse = si4;
+                                const ft4: u32 = if (self.collected_type_refs.items.len > rb4) self.collected_type_refs.items[rb4] else 0xFFFFFFFF;
+                                fields.append(self.allocator, .{ .@"type" = extra_type, .type_idx = ft4 }) catch {};
                             }
                             if (self.peek().kind == .r_paren) _ = self.advance();
                         }


### PR DESCRIPTION
Store and emit concrete type indices for struct fields and array element types. Previously typed references like \(ref \)\ in struct fields were encoded without their type index, causing WAMR to reject the binary with InvalidFuncType/InvalidValType.

Combined with the WAMR-side fix to parse standalone struct/array composite types, this fixes 9 more spec tests in type-rec.wast (4 are now expected failures pending iso-recursive type equivalence implementation).