### PR TITLE
fix: revert overly permissive +1 type index bound

### DIFF
--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -566,7 +566,7 @@ const Parser = struct {
                         } else if (self.in_type_parse) {
                             if (self.module) |mod| {
                                 // Allow self-reference: idx == items.len refers to the type currently being parsed
-                                const max = if (mod.num_declared_types > 0) mod.num_declared_types else @as(u32, @intCast(mod.module_types.items.len)) + 1;
+                                const max = if (mod.num_declared_types > 0) mod.num_declared_types else @as(u32, @intCast(mod.module_types.items.len));
                                 if (idx >= max) self.malformed = true;
                             }
                         } else {


### PR DESCRIPTION
Revert the +1 from PR #84 that caused ref.wast regressions.