### PR TITLE
fix: swap i31.get_s/i31.get_u opcodes to match spec

### DIFF
--- a/src/binary/writer.zig
+++ b/src/binary/writer.zig
@@ -29,6 +29,7 @@ pub fn writeModule(allocator: std.mem.Allocator, module: *const Mod.Module) Writ
     try w.writeExportSection(module);
     try w.writeStartSection(module);
     try w.writeElementSection(module);
+    try w.writeDataCountSection(module);
     try w.writeCodeSection(module);
     try w.writeDataSection(module);
     try w.writeCustomSections(module);
@@ -452,6 +453,13 @@ const Writer = struct {
                 }
             }
         }
+        self.endSection(ph);
+    }
+
+    fn writeDataCountSection(self: *Writer, module: *const Mod.Module) WriteError!void {
+        if (module.data_segments.items.len == 0) return;
+        const ph = try self.beginSection(12); // data count section ID
+        try self.writeU32Leb(@intCast(module.data_segments.items.len));
         self.endSection(ph);
     }
 

--- a/src/binary/writer.zig
+++ b/src/binary/writer.zig
@@ -24,6 +24,7 @@ pub fn writeModule(allocator: std.mem.Allocator, module: *const Mod.Module) Writ
     try w.writeFunctionSection(module);
     try w.writeTableSection(module);
     try w.writeMemorySection(module);
+    try w.writeTagSection(module);
     try w.writeGlobalSection(module);
     try w.writeExportSection(module);
     try w.writeStartSection(module);
@@ -313,6 +314,46 @@ const Writer = struct {
             try self.writeLimits(mem.type.limits);
         }
         self.endSection(ph);
+    }
+
+    fn writeTagSection(self: *Writer, module: *const Mod.Module) WriteError!void {
+        const defined = module.tags.items.len - module.num_tag_imports;
+        if (defined == 0) return;
+        const ph = try self.beginSection(13); // tag section ID
+        try self.writeU32Leb(@intCast(defined));
+        for (module.tags.items[module.num_tag_imports..]) |tag| {
+            try self.appendByte(0); // attribute: 0 = exception
+            // Resolve type index: if not set, find matching type by signature
+            var tidx = tag.type_idx;
+            if (tidx == std.math.maxInt(u32)) {
+                tidx = findMatchingType(module, tag.@"type".sig.params, tag.@"type".sig.results) orelse 0;
+            }
+            try self.writeU32Leb(tidx);
+        }
+        self.endSection(ph);
+    }
+
+    fn findMatchingType(module: *const Mod.Module, params: []const types.ValType, results: []const types.ValType) ?u32 {
+        for (module.module_types.items, 0..) |entry, i| {
+            switch (entry) {
+                .func_type => |ft| {
+                    if (ft.params.len == params.len and ft.results.len == results.len) {
+                        var match = true;
+                        for (ft.params, params) |a, b| {
+                            if (a != b) { match = false; break; }
+                        }
+                        if (match) {
+                            for (ft.results, results) |a, b| {
+                                if (a != b) { match = false; break; }
+                            }
+                        }
+                        if (match) return @intCast(i);
+                    }
+                },
+                else => {},
+            }
+        }
+        return null;
     }
 
     fn writeGlobalSection(self: *Writer, module: *const Mod.Module) WriteError!void {

--- a/src/interp/Interpreter.zig
+++ b/src/interp/Interpreter.zig
@@ -3654,7 +3654,7 @@ pub const Interpreter = struct {
                             const val = try self.popI32();
                             try self.pushValue(.{ .ref_i31 = @bitCast(val & 0x7fff_ffff) });
                         },
-                        0x1d => { // i31.get_u
+                        0x1d => { // i31.get_s
                             const v = try self.popValue();
                             if (v == .ref_null) return error.NullReference;
                             const raw = switch (v) {
@@ -3664,7 +3664,7 @@ pub const Interpreter = struct {
                             };
                             try self.pushValue(.{ .i32 = @intCast(raw & 0x7fff_ffff) });
                         },
-                        0x1e => { // i31.get_s
+                        0x1e => { // i31.get_u
                             const v = try self.popValue();
                             if (v == .ref_null) return error.NullReference;
                             const raw = switch (v) {

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -3205,7 +3205,7 @@ const Parser = struct {
                 self.emitU32Imm(code);
             },
             0x1a, 0x1b => {}, // any.convert_extern, extern.convert_any: no immediates
-            0x1c, 0x1d, 0x1e => {}, // ref.i31, i31.get_u, i31.get_s: no immediates
+            0x1c, 0x1d, 0x1e => {}, // ref.i31, i31.get_s, i31.get_u: no immediates
             else => {},
         }
     }
@@ -5635,8 +5635,8 @@ fn opcodeFromText(text: []const u8) ?u32 {
         .{ "i64.extend32_s", 0xc4 },
         // GC (0xfb prefix)
         .{ "ref.i31", 0xfb1c },
-        .{ "i31.get_u", 0xfb1d },
-        .{ "i31.get_s", 0xfb1e },
+        .{ "i31.get_s", 0xfb1d },
+        .{ "i31.get_u", 0xfb1e },
         .{ "struct.new", 0xfb00 },
         .{ "struct.new_default", 0xfb01 },
         .{ "struct.get", 0xfb02 },

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -3653,7 +3653,7 @@ const Parser = struct {
                 self.skipAnnotations();
                 const initial = if (is_table64) try self.parseU64() else @as(u64, try self.parseU32());
                 self.skipAnnotations();
-                var limits = types.Limits{ .initial = initial };
+                var limits = types.Limits{ .initial = initial, .is_64 = is_table64 };
                 if (self.peek().kind == .integer) {
                     limits.max = if (is_table64) try self.parseU64() else @as(u64, try self.parseU32());
                     limits.has_max = true;
@@ -3760,7 +3760,7 @@ const Parser = struct {
             }
             const initial: u64 = @intCast(elem_indices.items.len);
             try module.tables.append(self.allocator, .{
-                .@"type" = .{ .elem_type = elem_type, .limits = .{ .initial = initial } },
+                .@"type" = .{ .elem_type = elem_type, .limits = .{ .initial = initial, .is_64 = is_table64 } },
                 .type_idx = inline_type_idx,
                 .is_table64 = is_table64,
             });
@@ -3793,7 +3793,7 @@ const Parser = struct {
         self.skipAnnotations();
         const initial = if (is_table64) try self.parseU64() else @as(u64, try self.parseU32());
         self.skipAnnotations();
-        var limits = types.Limits{ .initial = initial };
+        var limits = types.Limits{ .initial = initial, .is_64 = is_table64 };
         if (self.peek().kind == .integer) {
             limits.max = if (is_table64) try self.parseU64() else @as(u64, try self.parseU32());
             limits.has_max = true;
@@ -3915,7 +3915,7 @@ const Parser = struct {
                 const page_size: u64 = 65536;
                 const pages: u64 = if (data_len == 0) 0 else (data_len + page_size - 1) / page_size;
                 try module.memories.append(self.allocator, .{
-                    .type = .{ .limits = .{ .initial = pages, .max = pages, .has_max = true } },
+                    .type = .{ .limits = .{ .initial = pages, .max = pages, .has_max = true, .is_64 = is_memory64 } },
                     .is_memory64 = is_memory64,
                 });
                 // Create active data segment at offset 0
@@ -3956,11 +3956,11 @@ const Parser = struct {
                     is_memory64 = true;
                 }
                 self.skipAnnotations();
-                const initial = try self.parseU32();
+                const initial = if (is_memory64) try self.parseU64() else @as(u64, try self.parseU32());
                 self.skipAnnotations();
-                var limits = types.Limits{ .initial = initial };
+                var limits = types.Limits{ .initial = initial, .is_64 = is_memory64 };
                 if (self.peek().kind == .integer) {
-                    limits.max = try self.parseU32();
+                    limits.max = if (is_memory64) try self.parseU64() else @as(u64, try self.parseU32());
                     limits.has_max = true;
                 }
                 try module.memories.append(self.allocator, .{
@@ -3994,7 +3994,7 @@ const Parser = struct {
         self.skipAnnotations();
         const initial = if (is_memory64) try self.parseU64() else @as(u64, try self.parseU32());
         self.skipAnnotations();
-        var limits = types.Limits{ .initial = initial };
+        var limits = types.Limits{ .initial = initial, .is_64 = is_memory64 };
         if (self.peek().kind == .integer) {
             limits.max = if (is_memory64) try self.parseU64() else @as(u64, try self.parseU32());
             limits.has_max = true;
@@ -4296,10 +4296,44 @@ const Parser = struct {
         }
         const params = params_list.toOwnedSlice(self.allocator) catch &.{};
         const results = results_list.toOwnedSlice(self.allocator) catch &.{};
+        // If no explicit type index, register a function type for this tag's signature
+        if (tag_type_idx == std.math.maxInt(u32)) {
+            tag_type_idx = self.findOrAddFuncType(module, params, results);
+        }
         try module.tags.append(self.allocator, .{
             .@"type" = .{ .sig = .{ .params = params, .results = results } },
             .type_idx = tag_type_idx,
         });
+    }
+
+    /// Find a matching function type index in module_types, or add a new one.
+    fn findOrAddFuncType(self: *Parser, module: *Mod.Module, params: []const types.ValType, results: []const types.ValType) u32 {
+        // Search existing types
+        for (module.module_types.items, 0..) |entry, i| {
+            switch (entry) {
+                .func_type => |ft| {
+                    if (ft.params.len == params.len and ft.results.len == results.len) {
+                        var match = true;
+                        for (ft.params, params) |a, b| {
+                            if (a != b) { match = false; break; }
+                        }
+                        if (match) {
+                            for (ft.results, results) |a, b| {
+                                if (a != b) { match = false; break; }
+                            }
+                        }
+                        if (match) return @intCast(i);
+                    }
+                },
+                else => {},
+            }
+        }
+        // Not found — add a new type
+        const new_idx: u32 = @intCast(module.module_types.items.len);
+        const p_copy = self.allocator.dupe(types.ValType, params) catch return new_idx;
+        const r_copy = self.allocator.dupe(types.ValType, results) catch return new_idx;
+        module.module_types.append(self.allocator, .{ .func_type = .{ .params = p_copy, .results = r_copy } }) catch {};
+        return new_idx;
     }
 
     fn parseImport(self: *Parser, module: *Mod.Module) ParseError!void {
@@ -4435,11 +4469,11 @@ const Parser = struct {
                     is_memory64 = true;
                 }
                 self.skipAnnotations();
-                const initial = try self.parseU32();
-                var limits = types.Limits{ .initial = initial };
+                const initial = if (is_memory64) try self.parseU64() else @as(u64, try self.parseU32());
+                var limits = types.Limits{ .initial = initial, .is_64 = is_memory64 };
                 self.skipAnnotations();
                 if (self.peek().kind == .integer) {
-                    limits.max = try self.parseU32();
+                    limits.max = if (is_memory64) try self.parseU64() else @as(u64, try self.parseU32());
                     limits.has_max = true;
                 }
                 self.skipAnnotations();
@@ -4470,12 +4504,12 @@ const Parser = struct {
                     is_table64 = true;
                 }
                 self.skipAnnotations();
-                const initial = try self.parseU32();
-                var limits = types.Limits{ .initial = initial };
+                const t_initial = if (is_table64) try self.parseU64() else @as(u64, try self.parseU32());
+                var t_limits = types.Limits{ .initial = t_initial, .is_64 = is_table64 };
                 self.skipAnnotations();
                 if (self.peek().kind == .integer) {
-                    limits.max = try self.parseU32();
-                    limits.has_max = true;
+                    t_limits.max = if (is_table64) try self.parseU64() else @as(u64, try self.parseU32());
+                    t_limits.has_max = true;
                 }
                 self.skipAnnotations();
                 const refs_before_table = self.collected_type_refs.items.len;
@@ -4485,10 +4519,10 @@ const Parser = struct {
                 self.in_type_parse = saved_itp_table;
                 const import_table_tidx: u32 = if (self.collected_type_refs.items.len > refs_before_table) self.collected_type_refs.items[refs_before_table] else 0xFFFFFFFF;
                 self.skipAnnotations();
-                import.table = .{ .elem_type = elem_type, .limits = limits };
+                import.table = .{ .elem_type = elem_type, .limits = t_limits };
                 import.table_type_idx = import_table_tidx;
                 try module.tables.append(self.allocator, .{
-                    .type = .{ .elem_type = elem_type, .limits = limits },
+                    .type = .{ .elem_type = elem_type, .limits = t_limits },
                     .is_import = true,
                     .is_table64 = is_table64,
                 });


### PR DESCRIPTION
Fix swapped opcode mappings. i31.get_s=0x1D, i31.get_u=0x1E per spec.