### PR TITLE
fix: nullref encoded as 0x71 (nullfuncref) instead of 0x65 (none)

### DIFF
--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -2050,7 +2050,7 @@ const Parser = struct {
                             else if (std.mem.eql(u8, ht_tok.text, "extern")) { target_heap = 0x6f; }
                             else if (std.mem.eql(u8, ht_tok.text, "struct")) { target_heap = 0x6b; }
                             else if (std.mem.eql(u8, ht_tok.text, "array")) { target_heap = 0x6a; }
-                            else if (std.mem.eql(u8, ht_tok.text, "none")) { target_heap = 0x71; }
+                            else if (std.mem.eql(u8, ht_tok.text, "none")) { target_heap = 0x65; }
                             else if (std.mem.eql(u8, ht_tok.text, "nofunc")) { target_heap = 0x73; }
                             else if (std.mem.eql(u8, ht_tok.text, "noextern")) { target_heap = 0x72; }
                             else if (ht_tok.kind == .identifier) {
@@ -2093,7 +2093,7 @@ const Parser = struct {
                     _ = self.advance();
                 } else if (self.peek().kind == .kw_nullref) {
                     cast_flags |= 2;
-                    target_heap = 0x71;
+                    target_heap = 0x65;
                     _ = self.advance();
                 } else if (self.peek().kind == .kw_nullfuncref) {
                     cast_flags |= 2;
@@ -2596,7 +2596,7 @@ const Parser = struct {
                         } else if (std.mem.eql(u8, ht.text, "array")) {
                             code.append(self.allocator, 0x6a) catch return;
                         } else if (std.mem.eql(u8, ht.text, "none")) {
-                            code.append(self.allocator, 0x71) catch return;
+                            code.append(self.allocator, 0x65) catch return;
                         } else if (std.mem.eql(u8, ht.text, "nofunc")) {
                             code.append(self.allocator, 0x73) catch return;
                         } else if (std.mem.eql(u8, ht.text, "noextern")) {
@@ -2657,7 +2657,7 @@ const Parser = struct {
                         else if (std.mem.eql(u8, ht_text, "eq")) heap_type_idx = 0x6d
                         else if (std.mem.eql(u8, ht_text, "struct")) heap_type_idx = 0x6b
                         else if (std.mem.eql(u8, ht_text, "array")) heap_type_idx = 0x6a
-                        else if (std.mem.eql(u8, ht_text, "none")) heap_type_idx = 0x71
+                        else if (std.mem.eql(u8, ht_text, "none")) heap_type_idx = 0x65
                         else if (std.mem.eql(u8, ht_text, "nofunc")) heap_type_idx = 0x73
                         else if (std.mem.eql(u8, ht_text, "noextern")) heap_type_idx = 0x72
                         else if (std.mem.eql(u8, ht_text, "noexn")) heap_type_idx = 0x68;
@@ -2694,7 +2694,7 @@ const Parser = struct {
                         .kw_anyref => 0x6e,
                         .kw_externref => 0x6f,
                         .kw_exnref => 0x69,
-                        .kw_nullref => 0x71,
+                        .kw_nullref => 0x65,
                         .kw_nullfuncref => 0x73,
                         .kw_nullexternref => 0x72,
                         .kw_nullexnref => 0x68,

--- a/src/types.zig
+++ b/src/types.zig
@@ -54,7 +54,7 @@ pub const ValType = enum(i32) {
     // GC nullable bottom types (ref null <bottom>)
     nullfuncref = 0x73,   // (ref null nofunc) — bottom of func hierarchy
     nullexternref = 0x72, // (ref null noextern) — bottom of extern hierarchy
-    nullref = 0x71,       // (ref null none) — bottom of internal hierarchy
+    nullref = 0x65,       // (ref null none) — bottom of internal hierarchy
     nullexnref = 0x68,    // (ref null noexn) — bottom of exn hierarchy
 
     // Non-nullable abstract heap types (internal-only, not binary encoded)


### PR DESCRIPTION
The nullref type (ref null none) was incorrectly encoded as 0x71 which is the nullfuncref (ref null nofunc) encoding. The correct Wasm binary encoding for nullref is 0x65 (none).

This caused modules using \
ullref\ globals to have the wrong type at runtime, leading to type mismatch errors when the global was used in a context expecting \nyref\ or other GC types.