### PR TITLE
fix: add S_IFREG to wheel zip external_attr for executable binary

### DIFF
--- a/scripts/build_wheels.py
+++ b/scripts/build_wheels.py
@@ -70,9 +70,9 @@ PLATFORMS = {
 }
 
 _EXEC_ATTR = (
-    stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
+    stat.S_IFREG | stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
 ) << 16
-_FILE_ATTR = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH) << 16
+_FILE_ATTR = (stat.S_IFREG | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH) << 16
 
 
 def sha256_digest(data: bytes) -> str:


### PR DESCRIPTION
Adds stat.S_IFREG to _EXEC_ATTR and _FILE_ATTR in build_wheels.py. Without it, pip installs wabt binaries as 644 instead of 755 on Unix. Same fix as cataggar/ghr@2fab722.