### PR TITLE
ci: only publish stable builds to PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -15,7 +15,10 @@ permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      (github.event_name == 'workflow_dispatch' && !contains(inputs.version, 'dev'))
+      || (github.event.workflow_run.conclusion == 'success'
+          && !contains(github.event.workflow_run.head_branch, 'dev'))
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
Skip dev releases (e.g. \2.0.0-dev.2\) from being published to PyPI.

The build job condition now filters out versions containing \dev\ for both \workflow_run\ and \workflow_dispatch\ triggers. Since \publish\ depends on \uild\, dev releases are fully skipped.