### PR TITLE
docs: round assertion count, add INSTALL.md, pin ghr install to v3.0.0-dev.1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,55 @@
+# Installing wabt
+
+Pre-built binaries are published to [GitHub Releases](https://github.com/cataggar/wabt/releases) and [PyPI](https://pypi.org/project/wabt-bin/).
+
+## ghr (recommended)
+
+[ghr](https://github.com/cataggar/ghr) is an installer for GitHub releases. It downloads the right binary for your platform, places it on `PATH`, and can upgrade it later.
+
+```sh
+ghr install cataggar/wabt
+```
+
+To install a specific version:
+
+```sh
+ghr install cataggar/wabt@v3.0.0-dev.1
+```
+
+Upgrade to the latest release:
+
+```sh
+ghr upgrade wabt
+```
+
+## uv
+
+```sh
+uv tool install wabt-bin
+```
+
+## pip
+
+```sh
+python3 -m pip install wabt-bin
+```
+
+## dist
+
+[dist](https://github.com/ekristen/distillery) is a GitHub release installer.
+
+```sh
+dist install cataggar/wabt
+```
+
+## From source
+
+Requires [Zig](https://ziglang.org/) 0.16. No other dependencies.
+
+```sh
+git clone --recursive https://github.com/cataggar/wabt
+cd wabt
+zig build -Doptimize=ReleaseSafe
+```
+
+Binaries are written to `zig-out/bin/`.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
 # WABT: The WebAssembly Binary Toolkit
 
-A fork of [WebAssembly/wabt](https://github.com/WebAssembly/wabt) ported from C++ to Zig and maintained with AI assistance. It supports the Wasm 3.0 proposals and passes the [WebAssembly/testsuite](https://github.com/WebAssembly/testsuite) at 65,011/65,011 assertions.
+A fork of [WebAssembly/wabt](https://github.com/WebAssembly/wabt) ported from C++ to Zig and maintained with AI assistance. It supports the Wasm 3.0 proposals and passes the [WebAssembly/testsuite](https://github.com/WebAssembly/testsuite) at 65k+ assertions.
 
 ## Install
 
 Install pre-built binaries from GitHub Releases with [ghr](https://github.com/cataggar/ghr):
 
 ```console
-$ ghr install cataggar/wabt
+$ ghr install cataggar/wabt@v3.0.0-dev.1
 ```
 
-Wheels are also published to [PyPI](https://pypi.org/project/wabt-bin/):
-
-```console
-$ uv tool install wabt-bin
-```
+See [INSTALL.md](INSTALL.md) for alternative installation methods (uv, pip, dist) and detailed instructions.
 
 ## Tools
 
@@ -77,10 +73,16 @@ Unit tests:
 $ zig build test
 ```
 
-Wasm 3.0 spec tests:
+Wasm 3.0 spec tests — run the full [WebAssembly/testsuite](https://github.com/WebAssembly/testsuite) (257 `.wast` files, 65k+ assertions) and compare against the pinned baseline at [`test/spec-baseline.tsv`](test/spec-baseline.tsv):
 
 ```console
 $ zig build -Doptimize=ReleaseSafe
+$ python3 scripts/check_spec_baseline.py
+```
+
+To run a single file:
+
+```console
 $ ./zig-out/bin/wabt spectest third_party/testsuite/i32.wast
 ```
 


### PR DESCRIPTION
- **README**: `65,011/65,011` → `65k+` assertions. Drop the `uv tool install wabt-bin` block (moved into INSTALL.md). Pin the example `ghr install` to `cataggar/wabt@v3.0.0-dev.1` so it works while v3.0.0-dev pre-releases are the latest tag.
- **README → Running tests**: replace the single-file `wabt spectest i32.wast` with `scripts/check_spec_baseline.py`, which runs the full 257-file WebAssembly testsuite and gates against the pinned baseline at `test/spec-baseline.tsv`. Keep the single-file invocation below for ad-hoc debugging.
- **INSTALL.md** (new, modeled on `cataggar/wamr`): documents ghr (recommended), uv, pip, dist, and from-source installation.