### PR TITLE
ci/docs: drop stale 'zig' branch trigger; remove 'dist' installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Zig CI
 
 on:
   push:
-    branches: [zig, main]
+    branches: [main]
   pull_request:
-    branches: [zig, main]
+    branches: [main]
 
 jobs:
   build-and-test:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,14 +34,6 @@ uv tool install wabt-bin
 python3 -m pip install wabt-bin
 ```
 
-## dist
-
-[dist](https://github.com/ekristen/distillery) is a GitHub release installer.
-
-```sh
-dist install cataggar/wabt
-```
-
 ## From source
 
 Requires [Zig](https://ziglang.org/) 0.16. No other dependencies.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install pre-built binaries from GitHub Releases with [ghr](https://github.com/ca
 $ ghr install cataggar/wabt@v3.0.0-dev.1
 ```
 
-See [INSTALL.md](INSTALL.md) for alternative installation methods (uv, pip, dist) and detailed instructions.
+See [INSTALL.md](INSTALL.md) for alternative installation methods (uv, pip) and detailed instructions.
 
 ## Tools
 


### PR DESCRIPTION
- `.github/workflows/ci.yml`: drop the stale `zig` branch from the push and pull_request triggers — the default branch was renamed to `main`, no PRs target `zig` anymore.
- `README.md`: remove the `dist` mention from the INSTALL.md cross-reference.
- `INSTALL.md`: drop the entire `## dist` section.