### PR TITLE
component: validate accepts components, WIT resolver walks deps/, multi-package compose

### DIFF
--- a/src/component/wit/metadata_encode.zig
+++ b/src/component/wit/metadata_encode.zig
@@ -51,6 +51,7 @@ const Allocator = std.mem.Allocator;
 const ast = @import("ast.zig");
 const lexer = @import("lexer.zig");
 const witParser = @import("parser.zig");
+const wit_resolver = @import("resolver.zig");
 const ctypes = @import("../types.zig");
 const writer = @import("../writer.zig");
 
@@ -68,12 +69,28 @@ pub fn encodeWorld(
     doc: ast.Document,
     world_name: []const u8,
 ) EncodeError![]u8 {
+    return encodeWorldFromResolver(
+        allocator,
+        wit_resolver.Resolver.init(doc, &.{}),
+        world_name,
+    );
+}
+
+/// Encode the named world using a multi-package resolver. Imports
+/// like `import docs:adder/add@0.1.0;` resolve their interface body
+/// against `resolver.deps`. The world itself is always taken from
+/// `resolver.main`.
+pub fn encodeWorldFromResolver(
+    allocator: Allocator,
+    resolver: wit_resolver.Resolver,
+    world_name: []const u8,
+) EncodeError![]u8 {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const ar = arena.allocator();
 
-    const world = findWorld(doc, world_name) orelse return error.UnknownWorld;
-    const pkg_id = doc.package orelse return error.InvalidWit;
+    const world = findWorld(resolver.main, world_name) orelse return error.UnknownWorld;
+    const pkg_id = resolver.main.package orelse return error.InvalidWit;
 
     // Build the world's body component-type decls.
     var world_decls = std.ArrayListUnmanaged(ctypes.Decl).empty;
@@ -87,7 +104,7 @@ pub fn encodeWorld(
                 const is_export = item == .@"export";
                 const ext = we;
                 const iface_name = qualifiedName(ar, ext, pkg_id) catch return error.InvalidWit;
-                const iface_decls = try buildInterfaceBody(ar, doc, ext);
+                const iface_decls = try buildInterfaceBody(ar, resolver, ext);
                 try world_decls.append(ar, .{ .type = .{
                     .instance = .{ .decls = iface_decls },
                 } });
@@ -179,13 +196,6 @@ fn findWorld(doc: ast.Document, name: []const u8) ?ast.World {
     return null;
 }
 
-fn findInterface(doc: ast.Document, name: []const u8) ?ast.Interface {
-    for (doc.items) |it| {
-        if (it == .interface and std.mem.eql(u8, it.interface.name, name)) return it.interface;
-    }
-    return null;
-}
-
 /// Compute the qualified name to advertise on the wire for a world's
 /// extern. `<id>;` and `<id>@<ver>;` get prefixed by the document's
 /// package; `<ns>:<pkg>/<iface>[@<ver>];` is used as-is.
@@ -222,7 +232,7 @@ fn formatQualifiedName(
 /// Lower an interface's WIT items to instance-type decls.
 fn buildInterfaceBody(
     ar: Allocator,
-    doc: ast.Document,
+    resolver: wit_resolver.Resolver,
     ext: ast.WorldExtern,
 ) EncodeError![]const ctypes.Decl {
     const ref = switch (ext) {
@@ -230,23 +240,12 @@ fn buildInterfaceBody(
         else => return error.UnsupportedWitFeature,
     };
 
-    // For in-package iface refs (no package qualifier), look up the
-    // interface body in the same document. For qualified refs, we
-    // would need a full package resolver — defer to a later todo and
-    // emit an empty body so the type still encodes (the consumer
-    // tooling rejects an empty instance-type for a useful import,
-    // but the wamr `mixed-zig-rust-calc` and `zig-calculator-cmd`
-    // worlds happen to import the same `docs:adder/add` interface
-    // that they ship in `wit/deps/adder/`).
-    const iface_name = ref.name;
-    var iface = findInterface(doc, iface_name);
-
-    // If the qualified-form interface isn't in this document,
-    // attempt to look up by short name as a best-effort (the
-    // wamr-style `wit/` directory packing puts deps as adjacent
-    // packages with the same interface name).
-    if (iface == null) iface = findInterface(doc, iface_name);
-    const iface_body = iface orelse return error.UnknownInterface;
+    // Resolve the interface body across packages: same-package refs
+    // (no `pkg/` qualifier) hit the main doc; `<ns>:<pkg>/<iface>[@<ver>]`
+    // refs traverse the deps (populated by `parseLayout` walking
+    // `<root>/deps/<pkg>/`). The resolver returns the same shape
+    // either way.
+    const iface_body = resolver.findInterface(ref) orelse return error.UnknownInterface;
 
     var decls = std.ArrayListUnmanaged(ctypes.Decl).empty;
     var func_idx: u32 = 0;
@@ -401,4 +400,61 @@ test "metadata_encode: unknown world reports error" {
     const source = "package docs:adder@0.1.0;\nworld adder { }";
     const r = encodeWorldFromSource(testing.allocator, source, "missing");
     try testing.expectError(error.UnknownWorld, r);
+}
+
+test "metadata_encode: multi-package resolver — cross-package import" {
+    // Mirrors the wamr `zig-calculator-cmd` layout: the main package
+    // defines a world that imports from a sibling package found under
+    // `<root>/deps/adder/`. This test exercises the resolver path
+    // end-to-end (resolver → metadata_encode → loader) without
+    // touching disk, proving the deps walk and metadata encoding
+    // are wired correctly for compose with multi-package inputs.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    const parser = @import("parser.zig");
+    const resolver_mod = @import("resolver.zig");
+
+    const main_src =
+        \\package docs:zigcalc@0.1.0;
+        \\world app { import docs:adder/add@0.1.0; }
+    ;
+    const dep_src =
+        \\package docs:adder@0.1.0;
+        \\interface add { add: func(x: u32, y: u32) -> u32; }
+    ;
+    const main_doc = try parser.parse(ar, main_src, null);
+    const dep_doc = try parser.parse(ar, dep_src, null);
+    var deps = try ar.alloc(@import("ast.zig").Document, 1);
+    deps[0] = dep_doc;
+    const resolver = resolver_mod.Resolver.init(main_doc, deps);
+
+    const bytes = try encodeWorldFromResolver(testing.allocator, resolver, "app");
+    defer testing.allocator.free(bytes);
+
+    // Round-trip the encoded payload through the component loader.
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    // Outer component-type wraps a world component-type whose body
+    // has the `add` interface as an instance type and the matching
+    // qualified import declaration.
+    const outer = comp.types[0].component;
+    const world = outer.decls[0].type.component;
+    try testing.expectEqual(@as(usize, 2), world.decls.len);
+    try testing.expect(world.decls[0] == .type);
+    try testing.expect(world.decls[0].type == .instance);
+    try testing.expect(world.decls[1] == .import);
+    try testing.expectEqualStrings("docs:adder/add@0.1.0", world.decls[1].import.name);
+
+    // The interface body picks up the func from the *dep* package.
+    const iface = world.decls[0].type.instance;
+    try testing.expectEqual(@as(usize, 2), iface.decls.len);
+    try testing.expect(iface.decls[0] == .type);
+    try testing.expect(iface.decls[0].type == .func);
+    try testing.expect(iface.decls[1] == .@"export");
+    try testing.expectEqualStrings("add", iface.decls[1].@"export".name);
 }

--- a/src/component/wit/resolver.zig
+++ b/src/component/wit/resolver.zig
@@ -1,0 +1,354 @@
+//! Multi-package WIT resolver.
+//!
+//! Mirrors the directory layout convention used by `wasm-tools`'s
+//! `wit-parser::Resolve::push_dir` (and accepted by `wasm-tools
+//! component embed --deps`):
+//!
+//! ```text
+//!   <root>/*.wit                  ← the "main" package (concatenated)
+//!   <root>/deps/<pkg-dir>/*.wit   ← one dependency package per subdir
+//!   <root>/deps/<pkg>.wit         ← single-file dependency package
+//! ```
+//!
+//! Parsing is one-AST-per-package (each `*.wit` directory is
+//! concatenated into a single source for a single `parser.parse` call).
+//! The resolver keeps the parsed docs around and lets
+//! `metadata_encode.encodeWorldFromResolver` look up qualified
+//! interface references across the package set.
+//!
+//! The wamr fixtures (`zig-calculator-cmd`, `mixed-zig-rust-calc`)
+//! use this exact layout: `wit/world.wit` + `wit/deps/adder/world.wit`.
+//! Before this resolver, `encodeWorld` only saw the main doc and
+//! would fail with `error.UnknownInterface` whenever the world
+//! imported an interface declared in a sibling package.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const ast = @import("ast.zig");
+const parser = @import("parser.zig");
+
+pub const ResolveError = parser.ParseError || error{
+    /// File or directory IO failure during deps walk.
+    FileSystemError,
+    /// `<root>` not found, or `<root>/deps/<entry>` not a recognized
+    /// shape (file or directory).
+    InvalidLayout,
+    /// A `*.wit` file under `<root>` was empty.
+    EmptyWit,
+};
+
+pub const Resolver = struct {
+    /// The "main" parsed doc — the package the world being embedded
+    /// belongs to. Always present.
+    main: ast.Document,
+    /// Sibling packages found under `<root>/deps/`. May be empty.
+    deps: []const ast.Document,
+
+    pub fn init(main: ast.Document, deps: []const ast.Document) Resolver {
+        return .{ .main = main, .deps = deps };
+    }
+
+    /// Look up the interface body for an interface reference.
+    ///
+    ///   * `ref.package == null`  → look in `self.main`.
+    ///   * `ref.package != null`  → search `self.main` then `self.deps`
+    ///     for a doc whose `package` declaration matches `ref.package`.
+    pub fn findInterface(self: Resolver, ref: ast.InterfaceRef) ?ast.Interface {
+        const target_pkg = ref.package orelse {
+            return findInterfaceInDoc(self.main, ref.name);
+        };
+
+        if (self.main.package) |mp| {
+            if (packageMatches(mp, target_pkg)) {
+                if (findInterfaceInDoc(self.main, ref.name)) |i| return i;
+            }
+        }
+        for (self.deps) |dep| {
+            if (dep.package) |dp| {
+                if (packageMatches(dp, target_pkg)) {
+                    if (findInterfaceInDoc(dep, ref.name)) |i| return i;
+                }
+            }
+        }
+        return null;
+    }
+};
+
+fn findInterfaceInDoc(doc: ast.Document, name: []const u8) ?ast.Interface {
+    for (doc.items) |it| {
+        if (it == .interface and std.mem.eql(u8, it.interface.name, name)) {
+            return it.interface;
+        }
+    }
+    return null;
+}
+
+/// Two `PackageId`s match when their namespace + name match, and
+/// either both versions match exactly or one of them is unspecified.
+/// This is the relaxed comparison `wasm-tools` performs when resolving
+/// a `<ns>:<pkg>/<iface>[@<ver>]` ref against the packages it knows
+/// about — wamr's fixtures pin the version on the ref but a number
+/// of upstream patterns leave it off in the dep package's own
+/// `package <id>;` line.
+fn packageMatches(have: ast.PackageId, want: ast.PackageId) bool {
+    if (!std.mem.eql(u8, have.namespace, want.namespace)) return false;
+    if (!std.mem.eql(u8, have.name, want.name)) return false;
+    const have_v = have.version orelse return true;
+    const want_v = want.version orelse return true;
+    return std.mem.eql(u8, have_v, want_v);
+}
+
+// ── filesystem walker ───────────────────────────────────────────────────────
+
+/// Describe a `*.wit` source. `path` is informational only (used in
+/// error messages); the source text drives parsing.
+pub const WitSource = struct {
+    path: []const u8,
+    text: []const u8,
+};
+
+/// Read every top-level `*.wit` file under `dir` (sorted, non-recursive)
+/// and concatenate them, separated by '\n'. Returns the concatenated
+/// buffer (caller frees) and the list of file paths included.
+///
+/// Empty result → no `.wit` files found.
+pub fn readWitDir(
+    alloc: Allocator,
+    io: std.Io,
+    dir_path: []const u8,
+) !struct { text: []u8, paths: [][]const u8 } {
+    var dir = try std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true });
+    defer dir.close(io);
+
+    var entries: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer {
+        for (entries.items) |e| alloc.free(e);
+        entries.deinit(alloc);
+    }
+    var it = dir.iterate();
+    while (try it.next(io)) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.name, ".wit")) continue;
+        try entries.append(alloc, try alloc.dupe(u8, entry.name));
+    }
+    std.mem.sort([]const u8, entries.items, {}, struct {
+        fn lt(_: void, a: []const u8, b: []const u8) bool {
+            return std.mem.lessThan(u8, a, b);
+        }
+    }.lt);
+
+    var combined: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer combined.deinit(alloc);
+    var paths: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer {
+        for (paths.items) |p| alloc.free(p);
+        paths.deinit(alloc);
+    }
+
+    for (entries.items) |name| {
+        const full = try std.fs.path.join(alloc, &.{ dir_path, name });
+        const buf = try std.Io.Dir.cwd().readFileAlloc(
+            io,
+            full,
+            alloc,
+            std.Io.Limit.limited(1 << 20),
+        );
+        defer alloc.free(buf);
+        try combined.appendSlice(alloc, buf);
+        try combined.append(alloc, '\n');
+        try paths.append(alloc, full);
+    }
+    return .{
+        .text = try combined.toOwnedSlice(alloc),
+        .paths = try paths.toOwnedSlice(alloc),
+    };
+}
+
+/// Parse the multi-package WIT layout rooted at `root`.
+///
+///   * If `root` is a directory: top-level `*.wit` files form the main
+///     package; entries under `<root>/deps/` form sibling packages.
+///   * If `root` is a single file: it's the only `wit` source; no deps.
+///
+/// All parsed `Document`s are allocated into `arena`. Returned
+/// `Resolver` borrows from `arena`; caller's responsibility to keep
+/// the arena alive at least as long as the resolver is used.
+pub fn parseLayout(
+    arena: Allocator,
+    io: std.Io,
+    root: []const u8,
+) ResolveError!Resolver {
+    const stat = std.Io.Dir.cwd().statFile(io, root, .{}) catch return error.InvalidLayout;
+
+    if (stat.kind != .directory) {
+        const buf = std.Io.Dir.cwd().readFileAlloc(
+            io,
+            root,
+            arena,
+            std.Io.Limit.limited(1 << 20),
+        ) catch return error.FileSystemError;
+        if (buf.len == 0) return error.EmptyWit;
+        const main = try parser.parse(arena, buf, null);
+        return Resolver.init(main, &.{});
+    }
+
+    // Read main package.
+    const main_combined = readWitDir(arena, io, root) catch return error.FileSystemError;
+    if (main_combined.text.len == 0) return error.EmptyWit;
+    const main = try parser.parse(arena, main_combined.text, null);
+
+    // Walk deps/ if present.
+    const deps_path = std.fs.path.join(arena, &.{ root, "deps" }) catch return error.FileSystemError;
+    const deps_stat = std.Io.Dir.cwd().statFile(io, deps_path, .{}) catch {
+        return Resolver.init(main, &.{});
+    };
+    if (deps_stat.kind != .directory) return Resolver.init(main, &.{});
+
+    var dep_docs: std.ArrayListUnmanaged(ast.Document) = .empty;
+    var deps_dir = std.Io.Dir.cwd().openDir(io, deps_path, .{ .iterate = true }) catch
+        return error.FileSystemError;
+    defer deps_dir.close(io);
+
+    var dep_names: std.ArrayListUnmanaged([]const u8) = .empty;
+    var dep_kinds: std.ArrayListUnmanaged(std.Io.File.Kind) = .empty;
+    var iter = deps_dir.iterate();
+    while ((iter.next(io) catch return error.FileSystemError)) |entry| {
+        try dep_names.append(arena, try arena.dupe(u8, entry.name));
+        try dep_kinds.append(arena, entry.kind);
+    }
+
+    // Sort deps for deterministic ordering.
+    const indices: []usize = arena.alloc(usize, dep_names.items.len) catch return error.FileSystemError;
+    for (indices, 0..) |*p, i| p.* = i;
+    std.mem.sort(usize, indices, dep_names.items, struct {
+        fn lt(names: [][]const u8, a: usize, b: usize) bool {
+            return std.mem.lessThan(u8, names[a], names[b]);
+        }
+    }.lt);
+
+    for (indices) |i| {
+        const name = dep_names.items[i];
+        const kind = dep_kinds.items[i];
+        const entry_path = try std.fs.path.join(arena, &.{ deps_path, name });
+        switch (kind) {
+            .directory => {
+                const combined = readWitDir(arena, io, entry_path) catch return error.FileSystemError;
+                if (combined.text.len == 0) continue;
+                const doc = try parser.parse(arena, combined.text, null);
+                try dep_docs.append(arena, doc);
+            },
+            .file => {
+                if (!std.mem.endsWith(u8, name, ".wit")) continue;
+                const buf = std.Io.Dir.cwd().readFileAlloc(
+                    io,
+                    entry_path,
+                    arena,
+                    std.Io.Limit.limited(1 << 20),
+                ) catch return error.FileSystemError;
+                if (buf.len == 0) continue;
+                const doc = try parser.parse(arena, buf, null);
+                try dep_docs.append(arena, doc);
+            },
+            else => continue,
+        }
+    }
+
+    return Resolver.init(main, try dep_docs.toOwnedSlice(arena));
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+test "resolver: same-package interface lookup" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    const src =
+        \\package docs:adder@0.1.0;
+        \\interface add { add: func(x: u32, y: u32) -> u32; }
+        \\world adder { export add; }
+    ;
+    const doc = try parser.parse(ar, src, null);
+    const res = Resolver.init(doc, &.{});
+
+    const ref: ast.InterfaceRef = .{ .package = null, .name = "add" };
+    const iface = res.findInterface(ref);
+    try std.testing.expect(iface != null);
+    try std.testing.expectEqualStrings("add", iface.?.name);
+}
+
+test "resolver: cross-package interface lookup" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    const main_src =
+        \\package docs:zigcalc@0.1.0;
+        \\world app { import docs:adder/add@0.1.0; }
+    ;
+    const dep_src =
+        \\package docs:adder@0.1.0;
+        \\interface add { add: func(x: u32, y: u32) -> u32; }
+        \\world adder { export add; }
+    ;
+    const main_doc = try parser.parse(ar, main_src, null);
+    const dep_doc = try parser.parse(ar, dep_src, null);
+    var deps = try ar.alloc(ast.Document, 1);
+    deps[0] = dep_doc;
+    const res = Resolver.init(main_doc, deps);
+
+    const ref: ast.InterfaceRef = .{
+        .package = .{ .namespace = "docs", .name = "adder", .version = "0.1.0" },
+        .name = "add",
+    };
+    const iface = res.findInterface(ref);
+    try std.testing.expect(iface != null);
+    try std.testing.expectEqualStrings("add", iface.?.name);
+    try std.testing.expectEqual(@as(usize, 1), iface.?.items.len);
+}
+
+test "resolver: package version mismatch returns null" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    const dep_src =
+        \\package docs:adder@0.2.0;
+        \\interface add { add: func(x: u32, y: u32) -> u32; }
+    ;
+    const dep_doc = try parser.parse(ar, dep_src, null);
+    var deps = try ar.alloc(ast.Document, 1);
+    deps[0] = dep_doc;
+    const main_doc = try parser.parse(ar, "package docs:zigcalc@0.1.0;", null);
+    const res = Resolver.init(main_doc, deps);
+
+    const ref: ast.InterfaceRef = .{
+        .package = .{ .namespace = "docs", .name = "adder", .version = "0.1.0" },
+        .name = "add",
+    };
+    try std.testing.expect(res.findInterface(ref) == null);
+}
+
+test "resolver: package missing version on either side matches" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    const dep_src =
+        \\package docs:adder;
+        \\interface add { add: func(x: u32, y: u32) -> u32; }
+    ;
+    const dep_doc = try parser.parse(ar, dep_src, null);
+    var deps = try ar.alloc(ast.Document, 1);
+    deps[0] = dep_doc;
+    const main_doc = try parser.parse(ar, "package docs:zigcalc;", null);
+    const res = Resolver.init(main_doc, deps);
+
+    const ref: ast.InterfaceRef = .{
+        .package = .{ .namespace = "docs", .name = "adder", .version = "0.1.0" },
+        .name = "add",
+    };
+    const iface = res.findInterface(ref);
+    try std.testing.expect(iface != null);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -39,6 +39,7 @@ pub const component = struct {
         pub const lexer = @import("component/wit/lexer.zig");
         pub const ast = @import("component/wit/ast.zig");
         pub const parser = @import("component/wit/parser.zig");
+        pub const resolver = @import("component/wit/resolver.zig");
         pub const metadata_encode = @import("component/wit/metadata_encode.zig");
         pub const metadata_decode = @import("component/wit/metadata_decode.zig");
     };
@@ -59,6 +60,7 @@ test {
     _ = @import("component/wit/lexer.zig");
     _ = @import("component/wit/ast.zig");
     _ = @import("component/wit/parser.zig");
+    _ = @import("component/wit/resolver.zig");
     _ = @import("component/wit/metadata_encode.zig");
     _ = @import("component/wit/metadata_decode.zig");
     _ = @import("integration_tests.zig");

--- a/src/tools/component_compose.zig
+++ b/src/tools/component_compose.zig
@@ -528,3 +528,62 @@ test "composeBinaries: bubbles up unmet imports" {
     try testing.expectEqual(@as(usize, 1), loaded.imports.len);
     try testing.expectEqualStrings("wasi:cli/environment@0.2.0", loaded.imports[0].name);
 }
+
+test "composeBinaries: multi-package consumer + provider end-to-end" {
+    // Mirrors the wamr `zig-calculator-cmd` topology: a consumer
+    // component imports `docs:adder/add@0.1.0` from a sibling
+    // package, and a provider component exports the same qualified
+    // interface. Composing the two should fully bind the import
+    // (zero leftover imports) — exactly the case Track #4 of the
+    // multi-package PR is meant to enable.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    const qname = "docs:adder/add@0.1.0";
+
+    // Provider: one instance export under the qualified name.
+    const prov_inst_exps = [_]ctypes.InlineExport{};
+    const prov_instances = [_]ctypes.InstanceExpr{
+        .{ .exports = &prov_inst_exps },
+    };
+    const prov_exports = [_]ctypes.ExportDecl{
+        .{
+            .name = qname,
+            .desc = .{ .instance = 0 },
+            .sort_idx = .{ .sort = .instance, .idx = 0 },
+        },
+    };
+    const provider: ctypes.Component = .{
+        .core_modules = &.{}, .core_instances = &.{}, .core_types = &.{},
+        .components = &.{}, .instances = &prov_instances, .aliases = &.{},
+        .types = &.{}, .canons = &.{}, .imports = &.{}, .exports = &prov_exports,
+    };
+    const provider_bytes = try writer.encode(ar, &provider);
+
+    // Consumer: imports the same qualified name, no exports.
+    const cons_imports = [_]ctypes.ImportDecl{
+        .{ .name = qname, .desc = .{ .instance = 0 } },
+    };
+    const consumer: ctypes.Component = .{
+        .core_modules = &.{}, .core_instances = &.{}, .core_types = &.{},
+        .components = &.{}, .instances = &.{}, .aliases = &.{},
+        .types = &.{}, .canons = &.{}, .imports = &cons_imports, .exports = &.{},
+    };
+    const consumer_bytes = try writer.encode(ar, &consumer);
+
+    var providers_buf = [_][]u8{provider_bytes};
+    const composed = try composeBinaries(testing.allocator, consumer_bytes, providers_buf[0..]);
+    defer testing.allocator.free(composed);
+
+    var arena2 = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena2.deinit();
+    const loaded = try loader.load(composed, arena2.allocator());
+
+    // Cross-package import should be fully resolved by the provider.
+    try testing.expectEqual(@as(usize, 0), loaded.imports.len);
+    // Both components nested + bound through an alias.
+    try testing.expectEqual(@as(usize, 2), loaded.components.len);
+    try testing.expectEqual(@as(usize, 2), loaded.instances.len);
+    try testing.expectEqual(@as(usize, 1), loaded.aliases.len);
+}

--- a/src/tools/component_embed.zig
+++ b/src/tools/component_embed.zig
@@ -6,11 +6,17 @@
 //!
 //!   wabt component embed [-w <world>] [-o <out>] <wit-path> <core.wasm>
 //!
-//! `<wit-path>` is a `.wit` file or a directory containing `.wit`
-//! files. When a directory is given, all top-level `.wit` files are
-//! concatenated into a single source for parsing. (Subdirectories
-//! such as `deps/` — used by `wasm-tools` for multi-package
-//! resolution — are deferred to the `wit-resolve` todo.)
+//! `<wit-path>` is one of:
+//!
+//!   * A single `.wit` file.
+//!   * A directory of `.wit` files. Top-level `.wit` files are
+//!     concatenated into a single "main" package; entries under
+//!     `<dir>/deps/<pkg>/` (or `<dir>/deps/<pkg>.wit`) are parsed
+//!     as sibling packages and made available for cross-package
+//!     interface lookup. This matches the layout convention
+//!     `wasm-tools` / `wit-bindgen` use, and lets a world `import
+//!     docs:adder/add@0.1.0;` resolve against
+//!     `<dir>/deps/adder/world.wit`.
 //!
 //! The output is the original core wasm with a `component-type:<world>`
 //! custom section appended. Existing custom sections with the same
@@ -27,6 +33,9 @@ pub const usage =
     \\into a component.
     \\
     \\<wit-path> is a `.wit` file or a directory of `.wit` files.
+    \\When a directory is given, sibling packages under <wit-path>/deps/
+    \\are also parsed so qualified interface refs like
+    \\`docs:adder/add@0.1.0` resolve correctly.
     \\
     \\Options:
     \\  -w, --world <name>      World to embed (required if the WIT defines
@@ -85,26 +94,21 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     const wit_path = positionals[0].?;
     const core_path = positionals[1].?;
 
-    const source = readWitSource(alloc, init.io, wit_path) catch |err| {
-        std.debug.print("error: reading WIT '{s}': {any}\n", .{ wit_path, err });
-        std.process.exit(1);
-    };
-    defer alloc.free(source);
-
     var arena = std.heap.ArenaAllocator.init(alloc);
     defer arena.deinit();
-    var diag: wabt.component.wit.parser.ParseDiagnostic = .{};
-    const doc = wabt.component.wit.parser.parse(arena.allocator(), source, &diag) catch |err| {
-        std.debug.print("error: parsing WIT: {s} at offset {d}: {s}\n", .{ @errorName(err), diag.span.start, diag.msg });
+    const ar = arena.allocator();
+
+    const resolver = wabt.component.wit.resolver.parseLayout(ar, init.io, wit_path) catch |err| {
+        std.debug.print("error: parsing WIT layout '{s}': {s}\n", .{ wit_path, @errorName(err) });
         std.process.exit(1);
     };
 
-    const world_name = world_arg orelse autoselectWorld(doc) orelse {
+    const world_name = world_arg orelse autoselectWorld(resolver.main) orelse {
         std.debug.print("error: --world is required (no unique world found in WIT)\n", .{});
         std.process.exit(1);
     };
 
-    const ct_payload = wabt.component.wit.metadata_encode.encodeWorld(alloc, doc, world_name) catch |err| {
+    const ct_payload = wabt.component.wit.metadata_encode.encodeWorldFromResolver(alloc, resolver, world_name) catch |err| {
         std.debug.print("error: encoding world '{s}': {s}\n", .{ world_name, @errorName(err) });
         std.process.exit(1);
     };
@@ -153,45 +157,6 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
 fn writeStdout(io: std.Io, text: []const u8) void {
     var stdout_file = std.Io.File.stdout();
     stdout_file.writeStreamingAll(io, text) catch {};
-}
-
-/// Read a `.wit` path. If `path` is a directory, concatenate all
-/// top-level `.wit` files (sorted by name for determinism).
-fn readWitSource(alloc: std.mem.Allocator, io: std.Io, path: []const u8) ![]u8 {
-    const stat = std.Io.Dir.cwd().statFile(io, path, .{}) catch |err| return err;
-    if (stat.kind == .directory) {
-        var dir = try std.Io.Dir.cwd().openDir(io, path, .{ .iterate = true });
-        defer dir.close(io);
-        var entries = std.ArrayListUnmanaged([]const u8).empty;
-        defer {
-            for (entries.items) |e| alloc.free(e);
-            entries.deinit(alloc);
-        }
-        var it = dir.iterate();
-        while (try it.next(io)) |entry| {
-            if (entry.kind != .file) continue;
-            if (!std.mem.endsWith(u8, entry.name, ".wit")) continue;
-            try entries.append(alloc, try alloc.dupe(u8, entry.name));
-        }
-        std.mem.sort([]const u8, entries.items, {}, struct {
-            fn lt(_: void, a: []const u8, b: []const u8) bool {
-                return std.mem.lessThan(u8, a, b);
-            }
-        }.lt);
-
-        var combined = std.ArrayListUnmanaged(u8).empty;
-        defer combined.deinit(alloc);
-        for (entries.items) |name| {
-            const full = try std.fs.path.join(alloc, &.{ path, name });
-            defer alloc.free(full);
-            const buf = try std.Io.Dir.cwd().readFileAlloc(io, full, alloc, std.Io.Limit.limited(wabt.max_input_file_size));
-            defer alloc.free(buf);
-            try combined.appendSlice(alloc, buf);
-            try combined.append(alloc, '\n');
-        }
-        return try combined.toOwnedSlice(alloc);
-    }
-    return try std.Io.Dir.cwd().readFileAlloc(io, path, alloc, std.Io.Limit.limited(wabt.max_input_file_size));
 }
 
 /// If exactly one world is defined in the document, return its name.

--- a/src/tools/validate.zig
+++ b/src/tools/validate.zig
@@ -4,19 +4,42 @@ const wabt = @import("wabt");
 pub const usage =
     \\Usage: wabt validate [options] <file.wasm>
     \\
-    \\Validate a WebAssembly binary.
+    \\Validate a WebAssembly binary.  Both core modules
+    \\(preamble \0asm 01 00 00 00) and components
+    \\(preamble \0asm 0d 00 01 00) are accepted.
     \\
     \\Options:
     \\  -h, --help   Show this help
     \\
 ;
 
-/// Validate a WASM binary module.
-/// Reads the binary, then runs the validator over the resulting module.
+pub const ValidateError = error{ UnexpectedEof, InvalidMagic };
+
+/// Validate a WebAssembly binary.  Detects the preamble (core vs.
+/// component) and dispatches to the appropriate validator:
+///
+///   * core wasm (`\0asm 01 00 00 00`) → `binary.reader` + `Validator`
+///   * component (`\0asm 0d 00 01 00`) → `component.loader.load`
+///
+/// For components, "loaded successfully" is the validation criterion
+/// — the loader does structural parsing of every section and rejects
+/// malformed binaries.  This matches the `wasm-tools validate`
+/// behaviour exercised by `wamr/build.zig`'s `installAndValidate`.
 pub fn validateBytes(allocator: std.mem.Allocator, wasm_bytes: []const u8) !void {
+    if (wasm_bytes.len < 8) return error.UnexpectedEof;
+    if (!std.mem.eql(u8, wasm_bytes[0..4], &[_]u8{ 0x00, 0x61, 0x73, 0x6d })) {
+        return error.InvalidMagic;
+    }
+    const layer_word = std.mem.readInt(u32, wasm_bytes[4..8], .little);
+    if (layer_word == 0x0001_000d) {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        _ = try wabt.component.loader.load(wasm_bytes, arena.allocator());
+        return;
+    }
+
     var module = try wabt.binary.reader.readModule(allocator, wasm_bytes);
     defer module.deinit();
-
     try wabt.Validator.validate(&module, .{});
 }
 
@@ -71,4 +94,43 @@ test "reject invalid magic" {
 test "reject truncated input" {
     const truncated = [_]u8{ 0x00, 0x61 };
     try std.testing.expectError(error.UnexpectedEof, validateBytes(std.testing.allocator, &truncated));
+}
+
+test "validate minimal component" {
+    // Component preamble only: \0asm 0d 00 01 00 (component magic + version)
+    const component = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x0d, 0x00, 0x01, 0x00 };
+    try validateBytes(std.testing.allocator, &component);
+}
+
+test "validate component built end-to-end" {
+    // Encode a minimal but well-formed component (one custom section)
+    // through wabt.component.writer, then round-trip via validateBytes.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    const customs = try ar.alloc(wabt.component.types.CustomSection, 1);
+    customs[0] = .{ .name = "producers", .payload = &.{} };
+    const component: wabt.component.types.Component = .{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &.{},
+        .imports = &.{},
+        .exports = &.{},
+        .custom_sections = customs,
+    };
+    const bytes = try wabt.component.writer.encode(ar, &component);
+    try validateBytes(std.testing.allocator, bytes);
+}
+
+test "validate rejects unknown layer/version" {
+    // Magic OK but version is neither core (0x00000001) nor component
+    // (0x000d0001) — should bubble up the loader's InvalidVersion.
+    const bad = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x99, 0x00, 0x01, 0x00 };
+    try std.testing.expectError(error.InvalidVersion, validateBytes(std.testing.allocator, &bad));
 }


### PR DESCRIPTION
Follow-up to #108. Addresses 3 of the 4 gaps surfaced after wamr tried to drop into the new component pipeline; #2 (`--adapt` actually splices the WASI preview1 adapter) is intentionally deferred to a dedicated PR — it needs the shim/fixup pattern + canon lower bookkeeping + the full wasi 0.2.6 type tree (multi-thousand LOC).

## Issues fixed

| # | Symptom (from the matrix in #108's follow-up) | Fix |
|---|---|---|
| 1 | `wabt validate` on a component → `error.InvalidVersion`. The validator only knew the core preamble. | Detect the layer/version word at bytes 4–7 and route components through `component.loader.load`. |
| 3 | `wabt component embed --world app` against `wit/ + wit/deps/<pkg>/` → `error.UnknownInterface`. The WIT resolver only saw the main package. | New `src/component/wit/resolver.zig` walks `<root>/*.wit` + `<root>/deps/<pkg>/*.wit` (or `<root>/deps/<pkg>.wit`). `metadata_encode` grows `encodeWorldFromResolver`. |
| 4 | `wabt component compose` had no multi-package coverage once #3 lands. | New compose end-to-end test that builds two components with a qualified-name import/export pair (`docs:adder/add@0.1.0`) and asserts the result has zero leftover imports. Also manually verified byte-for-byte against `wasm-tools compose` on wamr's `zig-calculator-cmd`. |
| 2 | `wabt component new --adapt …` → "not yet implemented". | **Out of scope.** Will land in a separate PR. |

## Verification

* `zig build test` → 310/310 pass (was 308; +2 new tests covering the multi-package resolver and compose paths).
* End-to-end against wamr's `zig-calculator-cmd/wit/` layout (`world.wit` + `deps/adder/world.wit`):
  * `wabt component embed --world app` → embedded payload structurally equivalent to `wasm-tools component embed`'s.
  * `wabt component new` (the result) → component validates via `wasm-tools validate`.
  * `wabt component compose -d adder.wasm consumer.wasm` → 649-byte output **byte-for-byte identical** to `wasm-tools compose`'s output, validates via `wasm-tools validate`.

## Layout convention

Mirrors `wasm-tools` / `wit-bindgen` — the input directory looks like:

```text
<root>/*.wit                    main package (concatenated)
<root>/deps/<pkg-dir>/*.wit     one sibling package per directory
<root>/deps/<pkg>.wit           single-file sibling package
```

Cross-package interface refs (`docs:adder/add@0.1.0`) are looked up by namespace+name, with relaxed version matching when one side omits `@<ver>`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
