### PR TITLE
component new: implement --adapt to splice the WASI preview1 adapter

### DIFF
--- a/src/component/adapter/abi.zig
+++ b/src/component/adapter/abi.zig
@@ -166,14 +166,63 @@ fn resolveTypeIdxIn(
 fn resolveAlias(a: ctypes.Alias, outer_decls: []const ctypes.Decl) ?ctypes.TypeDef {
     return switch (a) {
         .outer => |o| if (o.sort == .type)
-            resolveTypeIdxIn(outer_decls, o.idx, &.{})
+            resolveOuterType(outer_decls, o.idx)
         else
             null,
-        // `(alias export <inst-idx> <name> (type T))` inside an
-        // instance type body would be unusual; we don't try to
-        // resolve cross-instance refs here. Treat as opaque.
-        .instance_export => null,
+        // `(alias export <inst-idx> <name> (type T))` resolves into
+        // the instance type body for `inst-idx` to find a named
+        // type export. Used heavily by WASI types that pull other
+        // namespaces' types in (e.g. wasi:filesystem/types
+        // pulling datetime from wasi:clocks/wall-clock).
+        .instance_export => |ie| resolveInstanceTypeExport(outer_decls, ie.instance_idx, ie.name),
     };
+}
+
+/// Resolve a type idx in the OUTER (world) scope, including any
+/// alias chains that resolve to other parts of the same world. The
+/// outer scope is its own "outer" — there is no further outer here.
+fn resolveOuterType(outer_decls: []const ctypes.Decl, target: u32) ?ctypes.TypeDef {
+    return resolveTypeIdxIn(outer_decls, target, outer_decls);
+}
+
+/// At the world level, locate the instance type body backing the
+/// instance at `instance_idx` in the world's instance indexspace,
+/// then look up `name` as a type export in that body and resolve
+/// its bound back to a `TypeDef`.
+fn resolveInstanceTypeExport(world_decls: []const ctypes.Decl, instance_idx: u32, name: []const u8) ?ctypes.TypeDef {
+    const inst_decls = findInstanceBodyAtIdx(world_decls, instance_idx) orelse return null;
+    for (inst_decls) |d| switch (d) {
+        .@"export" => |e| {
+            if (e.desc != .type) continue;
+            if (!std.mem.eql(u8, e.name, name)) continue;
+            return resolveTypeBound(e.desc.type, inst_decls, world_decls);
+        },
+        else => {},
+    };
+    return null;
+}
+
+/// Walk world-level decls and find the body of the instance type
+/// at the given world-level instance indexspace position. Counts
+/// instance imports + instance type defs (and instance-typed
+/// exports / aliases, for completeness) per the spec's instance
+/// indexspace ordering.
+fn findInstanceBodyAtIdx(world_decls: []const ctypes.Decl, target: u32) ?[]const ctypes.Decl {
+    var cursor: u32 = 0;
+    for (world_decls) |d| switch (d) {
+        .import => |im| {
+            if (im.desc == .instance) {
+                if (cursor == target) {
+                    const td = resolveOuterType(world_decls, im.desc.instance) orelse return null;
+                    if (td != .instance) return null;
+                    return td.instance.decls;
+                }
+                cursor += 1;
+            }
+        },
+        else => {},
+    };
+    return null;
 }
 
 fn resolveTypeBound(
@@ -482,38 +531,190 @@ pub fn classifyFunc(ftr: FuncTypeRef) Classification {
 /// then `(memory option)` adds nothing extra to the core sig
 /// because `(memory)` is a per-call option, not a param).
 ///
+/// Slot types follow the canon-ABI flattening rules:
+/// `bool`/`s8`/`u8`/`s16`/`u16`/`s32`/`u32`/`char`/handle → `i32`,
+/// `s64`/`u64` → `i64`, `f32` → `f32`, `f64` → `f64`,
+/// `string`/`list` → `(i32, i32)` (ptr, len),
+/// `record`/`tuple` → field-wise concatenation,
+/// `variant`/`option`/`result` → `i32` discriminant + `join`ed
+/// payload across cases (`join(t,t)=t`, `join(i32,f32)=i32`,
+/// otherwise `i64`).
+///
 /// Caveat: when results-flat > MAX_FLAT_RESULTS, the canon ABI
 /// passes results through a returned pointer, which means the core
 /// sig actually has 0 results and one extra `i32` param (the output
 /// pointer). We model that here.
 pub fn lowerCoreSig(
     arena: Allocator,
-    cls: Classification,
+    ftr: FuncTypeRef,
 ) Error!struct {
-    params: []const @import("../../types.zig").ValType,
-    results: []const @import("../../types.zig").ValType,
+    params: []const wtypes.ValType,
+    results: []const wtypes.ValType,
 } {
-    const wtypes = @import("../../types.zig");
-    const params_flat = cls.params_flat;
-    const ret_via_pointer = cls.results_flat > MAX_FLAT_RESULTS;
+    const ft = ftr.func;
+    const resolver = ftr.resolver;
 
-    const total_params: u32 = if (ret_via_pointer)
-        saturatingAdd(params_flat, 1)
-    else
-        params_flat;
+    var params = std.ArrayListUnmanaged(wtypes.ValType).empty;
+    for (ft.params) |p| try flattenSlots(arena, p.type, resolver, 0, &params);
 
-    const total_results: u32 = if (ret_via_pointer)
-        0
-    else
-        cls.results_flat;
+    var results = std.ArrayListUnmanaged(wtypes.ValType).empty;
+    switch (ft.results) {
+        .none => {},
+        .unnamed => |vt| try flattenSlots(arena, vt, resolver, 0, &results),
+        .named => |list| for (list) |nv|
+            try flattenSlots(arena, nv.type, resolver, 0, &results),
+    }
 
-    const params = try arena.alloc(wtypes.ValType, total_params);
-    for (params) |*p| p.* = .i32;
+    if (results.items.len > MAX_FLAT_RESULTS) {
+        // Indirect result: callee writes into caller-supplied
+        // pointer. Core sig becomes (params + ret_ptr) -> ().
+        try params.append(arena, .i32);
+        results.clearRetainingCapacity();
+    }
 
-    const results = try arena.alloc(wtypes.ValType, total_results);
-    for (results) |*r| r.* = .i32;
+    return .{
+        .params = try params.toOwnedSlice(arena),
+        .results = try results.toOwnedSlice(arena),
+    };
+}
 
-    return .{ .params = params, .results = results };
+const wtypes = @import("../../types.zig");
+
+/// Append the canon-ABI flat slot types of `vt` into `out`.
+fn flattenSlots(
+    arena: Allocator,
+    vt: ctypes.ValType,
+    resolver: TypeResolver,
+    depth: u32,
+    out: *std.ArrayListUnmanaged(wtypes.ValType),
+) Error!void {
+    if (depth > 32) {
+        try out.append(arena, .i32);
+        return;
+    }
+    switch (vt) {
+        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .char => try out.append(arena, .i32),
+        .s64, .u64 => try out.append(arena, .i64),
+        .f32 => try out.append(arena, .f32),
+        .f64 => try out.append(arena, .f64),
+        .own, .borrow => try out.append(arena, .i32),
+        .string => {
+            try out.append(arena, .i32);
+            try out.append(arena, .i32);
+        },
+        .list => {
+            try out.append(arena, .i32);
+            try out.append(arena, .i32);
+        },
+        .type_idx,
+        .record,
+        .variant,
+        .tuple,
+        .flags,
+        .option,
+        .result,
+        => |idx| {
+            if (resolver.resolveLocal(idx)) |td| {
+                try flattenTypeDefSlots(arena, td, resolver, depth + 1, out);
+            } else {
+                // Unresolvable (likely outer-aliased resource handle).
+                // Default depends on the leaf shape.
+                switch (vt) {
+                    .variant, .option, .result => {
+                        try out.append(arena, .i32);
+                        try out.append(arena, .i32);
+                    },
+                    else => try out.append(arena, .i32),
+                }
+            }
+        },
+        .enum_ => try out.append(arena, .i32),
+    }
+}
+
+fn flattenTypeDefSlots(
+    arena: Allocator,
+    td: ctypes.TypeDef,
+    resolver: TypeResolver,
+    depth: u32,
+    out: *std.ArrayListUnmanaged(wtypes.ValType),
+) Error!void {
+    switch (td) {
+        .val => |vt| try flattenSlots(arena, vt, resolver, depth, out),
+        .record => |r| {
+            for (r.fields) |f| try flattenSlots(arena, f.type, resolver, depth, out);
+        },
+        .tuple => |t| {
+            for (t.fields) |fty| try flattenSlots(arena, fty, resolver, depth, out);
+        },
+        .flags => |f| {
+            const slots = (f.names.len + 31) / 32;
+            const slots_u32: u32 = if (slots == 0) 1 else @intCast(slots);
+            var i: u32 = 0;
+            while (i < slots_u32) : (i += 1) try out.append(arena, .i32);
+        },
+        .enum_ => try out.append(arena, .i32),
+        .variant => |v| {
+            // i32 discriminant + slot-wise join across case payloads.
+            try out.append(arena, .i32);
+            var payload = std.ArrayListUnmanaged(wtypes.ValType).empty;
+            for (v.cases) |c| {
+                if (c.type) |vt| {
+                    var case_slots = std.ArrayListUnmanaged(wtypes.ValType).empty;
+                    try flattenSlots(arena, vt, resolver, depth, &case_slots);
+                    try joinInto(arena, &payload, case_slots.items);
+                }
+            }
+            try out.appendSlice(arena, payload.items);
+        },
+        .option => |o| {
+            try out.append(arena, .i32);
+            try flattenSlots(arena, o.inner, resolver, depth, out);
+        },
+        .result => |r| {
+            try out.append(arena, .i32);
+            var payload = std.ArrayListUnmanaged(wtypes.ValType).empty;
+            inline for (.{ r.ok, r.err }) |maybe_vt| {
+                if (maybe_vt) |vt| {
+                    var case_slots = std.ArrayListUnmanaged(wtypes.ValType).empty;
+                    try flattenSlots(arena, vt, resolver, depth, &case_slots);
+                    try joinInto(arena, &payload, case_slots.items);
+                }
+            }
+            try out.appendSlice(arena, payload.items);
+        },
+        .list => |l| {
+            try out.append(arena, .i32);
+            try out.append(arena, .i32);
+            _ = l;
+        },
+        .resource => try out.append(arena, .i32),
+        .func, .component, .instance => try out.append(arena, .i32),
+    }
+}
+
+/// Join `case_slots` into `acc` slot-wise per the canon-ABI rule:
+/// extend `acc` if `case_slots` is longer; for overlapping slots,
+/// use `joinValType`.
+fn joinInto(
+    arena: Allocator,
+    acc: *std.ArrayListUnmanaged(wtypes.ValType),
+    case_slots: []const wtypes.ValType,
+) Error!void {
+    var i: usize = 0;
+    while (i < case_slots.len) : (i += 1) {
+        if (i < acc.items.len) {
+            acc.items[i] = joinValType(acc.items[i], case_slots[i]);
+        } else {
+            try acc.append(arena, case_slots[i]);
+        }
+    }
+}
+
+fn joinValType(a: wtypes.ValType, b: wtypes.ValType) wtypes.ValType {
+    if (a == b) return a;
+    if ((a == .i32 and b == .f32) or (a == .f32 and b == .i32)) return .i32;
+    return .i64;
 }
 
 // ── tests ──────────────────────────────────────────────────────────────────
@@ -730,30 +931,63 @@ test "classifyFunc: () -> own<resource> is direct (handle is i32)" {
     try testing.expectEqual(@as(u32, 1), cls.results_flat);
 }
 
-test "lowerCoreSig: 2-flat result becomes (i32 in, no out) with output pointer" {
+test "lowerCoreSig: option<u32> result becomes ret-ptr (i32) -> ()" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const sig = try lowerCoreSig(arena.allocator(), .{
-        .class = .indirect,
-        .opts = .{ .memory = true, .realloc = false, .string_encoding = false },
-        .params_flat = 1,
-        .results_flat = 2,
-        .has_result = true,
-    });
-    try testing.expectEqual(@as(usize, 2), sig.params.len); // 1 real + 1 ret-ptr
+    const a = arena.allocator();
+
+    var inst_decls = try a.alloc(ctypes.Decl, 3);
+    inst_decls[0] = .{ .type = .{ .option = .{ .inner = .u32 } } };
+    inst_decls[1] = .{ .type = .{ .func = .{
+        .params = &.{},
+        .results = .{ .unnamed = .{ .type_idx = 0 } },
+    } } };
+    inst_decls[2] = .{ .@"export" = .{ .name = "f", .desc = .{ .func = 1 } } };
+
+    const world = try buildSyntheticWorld(a, inst_decls, 1);
+    const ftr = try findFuncImport(world, 0, "f");
+    const sig = try lowerCoreSig(a, ftr);
+    try testing.expectEqual(@as(usize, 1), sig.params.len);
+    try testing.expectEqual(wtypes.ValType.i32, sig.params[0]);
     try testing.expectEqual(@as(usize, 0), sig.results.len);
 }
 
 test "lowerCoreSig: 1-flat result keeps 1 result, no extra param" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const sig = try lowerCoreSig(arena.allocator(), .{
-        .class = .direct,
-        .opts = .{ .memory = false, .realloc = false, .string_encoding = false },
-        .params_flat = 0,
-        .results_flat = 1,
-        .has_result = true,
-    });
+    const a = arena.allocator();
+
+    var inst_decls = try a.alloc(ctypes.Decl, 2);
+    inst_decls[0] = .{ .type = .{ .func = .{
+        .params = &.{},
+        .results = .{ .unnamed = .u32 },
+    } } };
+    inst_decls[1] = .{ .@"export" = .{ .name = "f", .desc = .{ .func = 0 } } };
+
+    const world = try buildSyntheticWorld(a, inst_decls, 0);
+    const ftr = try findFuncImport(world, 0, "f");
+    const sig = try lowerCoreSig(a, ftr);
     try testing.expectEqual(@as(usize, 0), sig.params.len);
     try testing.expectEqual(@as(usize, 1), sig.results.len);
+    try testing.expectEqual(wtypes.ValType.i32, sig.results[0]);
+}
+
+test "lowerCoreSig: u64 params lower to i64" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var inst_decls = try a.alloc(ctypes.Decl, 2);
+    inst_decls[0] = .{ .type = .{ .func = .{
+        .params = &.{ .{ .name = "a", .type = .u64 }, .{ .name = "b", .type = .u32 } },
+        .results = .none,
+    } } };
+    inst_decls[1] = .{ .@"export" = .{ .name = "f", .desc = .{ .func = 0 } } };
+
+    const world = try buildSyntheticWorld(a, inst_decls, 0);
+    const ftr = try findFuncImport(world, 0, "f");
+    const sig = try lowerCoreSig(a, ftr);
+    try testing.expectEqual(@as(usize, 2), sig.params.len);
+    try testing.expectEqual(wtypes.ValType.i64, sig.params[0]);
+    try testing.expectEqual(wtypes.ValType.i32, sig.params[1]);
 }

--- a/src/component/adapter/abi.zig
+++ b/src/component/adapter/abi.zig
@@ -1,0 +1,759 @@
+//! Canonical-ABI flattening for adapter import classification.
+//!
+//! For each WASI function the adapter declares as a *core import*,
+//! the splicer needs to decide whether to:
+//!
+//!   * `(canon lower)` directly at the component level — works when
+//!     the lowered call needs no memory I/O and fits in one flat
+//!     return register (e.g. `() -> own<output-stream>`); or
+//!   * route through the **shim + fixup** machinery — required when
+//!     either the params or the results need memory access (any
+//!     `string` / `list` somewhere in the tree, OR more than one
+//!     flat result, since a multi-result call returns through a
+//!     pointer the caller allocates).
+//!
+//! `wit-component` makes the same decision; this module mirrors its
+//! flattening rules over our `Component` AST. We classify against
+//! the encoded-world's body decls so the input is exactly what
+//! `decode.zig` already produced — no re-parsing.
+//!
+//! Outer-alias chains inside an instance type body always resolve to
+//! resources (handles) in WASI 0.2.6 — `output-stream`, `descriptor`,
+//! `datetime`, etc. We treat any type idx we can't fully resolve as
+//! a resource handle (1 flat `i32`, no memory). For WASI 0.2.6 this
+//! is precise; for adapters carrying a richer type tree the
+//! splicer would need to follow outer aliases through more layers
+//! (a follow-up if needed).
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const ctypes = @import("../types.zig");
+const decode = @import("decode.zig");
+
+pub const Error = error{ OutOfMemory, FuncNotFound, NotAFuncExport, UnsupportedShape };
+
+/// Classification result for a single adapter wasi func import.
+pub const Class = enum {
+    /// Lowered directly as `(canon lower (func F))` with no opts —
+    /// takes no memory I/O and returns at most one flat scalar.
+    direct,
+    /// Lowered via shim+fixup. The wrapping component lowers with
+    /// `(memory M) [+ (realloc R)] [+ string-encoding=utf8]` opts and
+    /// the fixup writes the lowered func into the shim's table.
+    indirect,
+};
+
+/// Aggregate flatness info of a WIT value type (recursively walked).
+pub const FlatInfo = struct {
+    /// Number of i32/i64/f32/f64 the value lowers to in the flat
+    /// canon-ABI representation. Always `>= 0`. We saturate at
+    /// 32 to keep the math bounded — anything bigger is well past
+    /// `MAX_FLAT_PARAMS`/`MAX_FLAT_RESULTS` anyway.
+    flat: u32 = 0,
+    /// True if the value (or any child) needs caller-memory access
+    /// to lower / lift — i.e. contains `string`, `list`, or any
+    /// compound whose flat repr exceeds the register cutoff in a
+    /// way that would force pass-by-pointer.
+    needs_memory: bool = false,
+    /// True if the value needs callee-side allocation in caller
+    /// memory — i.e. a `string` or `list` appears somewhere in this
+    /// (sub)tree. Used to decide whether the canon-lower needs a
+    /// `(realloc <cabi_import_realloc>)` opt.
+    needs_realloc_alloc: bool = false,
+    /// True if a `string` appears anywhere in this (sub)tree.
+    contains_string: bool = false,
+};
+
+pub const FuncOpts = struct {
+    /// True iff lowering the func needs `(memory <main_memory>)`.
+    /// Required when params have list/string, when result needs
+    /// pass-by-pointer (`flat_results > 1`), or when result has
+    /// list/string.
+    memory: bool,
+    /// True iff lowering the func needs
+    /// `(realloc <adapter_cabi_import_realloc>)`. Required when the
+    /// result contains list/string (callee allocates the result data
+    /// into caller memory).
+    realloc: bool,
+    /// True iff `string-encoding=utf8` is required (any param OR
+    /// result contains string).
+    string_encoding: bool,
+};
+
+pub const FuncTypeRef = struct {
+    /// Component-level FuncType the import points at.
+    func: ctypes.FuncType,
+    /// Resolver carrying the instance type body and outer scope for
+    /// type-idx resolution.
+    resolver: TypeResolver,
+};
+
+/// View of the type indexspace as seen from inside an instance type
+/// body. Lets `flatten` resolve `.type_idx` references back to a
+/// concrete `TypeDef`, recursing through outer aliases when needed.
+pub const TypeResolver = struct {
+    /// Decls of the instance body itself.
+    inst_decls: []const ctypes.Decl,
+    /// Decls of the world body (one level out from the instance).
+    world_decls: []const ctypes.Decl,
+
+    /// Resolve a local type idx in the instance scope to the
+    /// underlying `TypeDef`, following outer aliases into the world
+    /// body. Returns null if the idx points outside what's
+    /// resolvable here (treat as scalar handle by the caller).
+    pub fn resolveLocal(self: TypeResolver, idx: u32) ?ctypes.TypeDef {
+        return resolveTypeIdxIn(self.inst_decls, idx, self.world_decls);
+    }
+
+    /// Resolve a type idx in the world scope. Used when an outer
+    /// alias points at a world-body type idx and we want to follow
+    /// it to its definition.
+    pub fn resolveWorld(self: TypeResolver, idx: u32) ?ctypes.TypeDef {
+        return resolveTypeIdxIn(self.world_decls, idx, &.{});
+    }
+};
+
+/// Walk `decls` (instance or world body) and return the `TypeDef` at
+/// type-indexspace position `target`, following outer aliases into
+/// `outer_decls` when present.
+fn resolveTypeIdxIn(
+    decls: []const ctypes.Decl,
+    target: u32,
+    outer_decls: []const ctypes.Decl,
+) ?ctypes.TypeDef {
+    var cursor: u32 = 0;
+    for (decls) |d| {
+        switch (d) {
+            .type => |td| {
+                if (cursor == target) return td;
+                cursor += 1;
+            },
+            .core_type => {
+                cursor += 1;
+            },
+            .alias => |a| {
+                const sort: ctypes.Sort = switch (a) {
+                    .instance_export => |ie| ie.sort,
+                    .outer => |o| o.sort,
+                };
+                if (sort == .type) {
+                    if (cursor == target) {
+                        return resolveAlias(a, outer_decls);
+                    }
+                    cursor += 1;
+                }
+            },
+            .@"export" => |e| {
+                // Exports of types in an instance body contribute to
+                // the type indexspace too (type re-exports).
+                switch (e.desc) {
+                    .type => |bound| {
+                        if (cursor == target) {
+                            return resolveTypeBound(bound, decls, outer_decls);
+                        }
+                        cursor += 1;
+                    },
+                    else => {},
+                }
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn resolveAlias(a: ctypes.Alias, outer_decls: []const ctypes.Decl) ?ctypes.TypeDef {
+    return switch (a) {
+        .outer => |o| if (o.sort == .type)
+            resolveTypeIdxIn(outer_decls, o.idx, &.{})
+        else
+            null,
+        // `(alias export <inst-idx> <name> (type T))` inside an
+        // instance type body would be unusual; we don't try to
+        // resolve cross-instance refs here. Treat as opaque.
+        .instance_export => null,
+    };
+}
+
+fn resolveTypeBound(
+    bound: ctypes.TypeBound,
+    decls: []const ctypes.Decl,
+    outer_decls: []const ctypes.Decl,
+) ?ctypes.TypeDef {
+    return switch (bound) {
+        .eq => |idx| resolveTypeIdxIn(decls, idx, outer_decls),
+        .sub_resource => ctypes.TypeDef{ .resource = .{} },
+    };
+}
+
+/// Locate the func type referenced by `(export "<name>" (func F))`
+/// inside the instance whose type idx is `inst_type_idx` in the
+/// world body, and return both the FuncType and a resolver scoped
+/// to that instance.
+pub fn findFuncImport(
+    world: decode.AdapterWorld,
+    inst_type_idx: u32,
+    func_name: []const u8,
+) Error!FuncTypeRef {
+    const inst_decls = try findInstanceTypeBody(world.body_decls, inst_type_idx);
+    const func_type_idx = (try findFuncExportTypeIdx(inst_decls, func_name)) orelse
+        return error.FuncNotFound;
+    const td = resolveTypeIdxIn(inst_decls, func_type_idx, world.body_decls) orelse
+        return error.UnsupportedShape;
+    if (td != .func) return error.NotAFuncExport;
+    return .{
+        .func = td.func,
+        .resolver = .{
+            .inst_decls = inst_decls,
+            .world_decls = world.body_decls,
+        },
+    };
+}
+
+fn findInstanceTypeBody(
+    world_decls: []const ctypes.Decl,
+    inst_type_idx: u32,
+) Error![]const ctypes.Decl {
+    const td = resolveTypeIdxIn(world_decls, inst_type_idx, &.{}) orelse
+        return error.UnsupportedShape;
+    if (td != .instance) return error.UnsupportedShape;
+    return td.instance.decls;
+}
+
+fn findFuncExportTypeIdx(
+    inst_decls: []const ctypes.Decl,
+    func_name: []const u8,
+) Error!?u32 {
+    for (inst_decls) |d| switch (d) {
+        .@"export" => |e| {
+            if (e.desc == .func and std.mem.eql(u8, e.name, func_name)) {
+                return e.desc.func;
+            }
+        },
+        else => {},
+    };
+    return null;
+}
+
+/// Walk a `ValType` and aggregate flat / memory / realloc / string
+/// info. `is_param` matters because list/string in a param needs
+/// memory but does NOT need realloc; in a result, it needs both.
+pub fn flatten(vt: ctypes.ValType, resolver: TypeResolver) FlatInfo {
+    return flattenInner(vt, resolver, 0);
+}
+
+fn flattenInner(vt: ctypes.ValType, resolver: TypeResolver, depth: u32) FlatInfo {
+    if (depth > 32) return .{ .flat = 1 }; // recursion guard
+    return switch (vt) {
+        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .char => .{ .flat = 1 },
+        .s64, .u64 => .{ .flat = 1 },
+        .f32, .f64 => .{ .flat = 1 },
+        .own, .borrow => .{ .flat = 1 },
+        .string => .{
+            .flat = 2,
+            .needs_memory = true,
+            .needs_realloc_alloc = true,
+            .contains_string = true,
+        },
+        .list => |idx| blk: {
+            // list always flattens to (ptr, len) regardless of
+            // element. Element walk only needed to propagate
+            // contains_string.
+            const elem_info = if (resolver.resolveLocal(idx)) |td|
+                flattenTypeDef(td, resolver, depth + 1)
+            else
+                FlatInfo{ .flat = 1 };
+            break :blk .{
+                .flat = 2,
+                .needs_memory = true,
+                .needs_realloc_alloc = true,
+                .contains_string = elem_info.contains_string,
+            };
+        },
+        .type_idx => |idx| if (resolver.resolveLocal(idx)) |td|
+            flattenTypeDef(td, resolver, depth + 1)
+        else
+            // Likely an outer alias to a resource — treat as i32 handle.
+            .{ .flat = 1 },
+        .record => |idx| if (resolver.resolveLocal(idx)) |td|
+            flattenTypeDef(td, resolver, depth + 1)
+        else
+            .{ .flat = 1 },
+        .variant => |idx| if (resolver.resolveLocal(idx)) |td|
+            flattenTypeDef(td, resolver, depth + 1)
+        else
+            .{ .flat = 2 },
+        .tuple => |idx| if (resolver.resolveLocal(idx)) |td|
+            flattenTypeDef(td, resolver, depth + 1)
+        else
+            .{ .flat = 1 },
+        .flags => |idx| if (resolver.resolveLocal(idx)) |td|
+            flattenTypeDef(td, resolver, depth + 1)
+        else
+            .{ .flat = 1 },
+        .enum_ => .{ .flat = 1 },
+        .option => |idx| if (resolver.resolveLocal(idx)) |td|
+            flattenTypeDef(td, resolver, depth + 1)
+        else
+            .{ .flat = 2 },
+        .result => |idx| if (resolver.resolveLocal(idx)) |td|
+            flattenTypeDef(td, resolver, depth + 1)
+        else
+            .{ .flat = 2 },
+    };
+}
+
+fn flattenTypeDef(td: ctypes.TypeDef, resolver: TypeResolver, depth: u32) FlatInfo {
+    return switch (td) {
+        .val => |vt| flattenInner(vt, resolver, depth),
+        .record => |r| blk: {
+            var info = FlatInfo{};
+            for (r.fields) |f| {
+                const fi = flattenInner(f.type, resolver, depth);
+                info.flat = saturatingAdd(info.flat, fi.flat);
+                info.needs_memory = info.needs_memory or fi.needs_memory;
+                info.needs_realloc_alloc = info.needs_realloc_alloc or fi.needs_realloc_alloc;
+                info.contains_string = info.contains_string or fi.contains_string;
+            }
+            break :blk info;
+        },
+        .variant => |v| blk: {
+            // Variant flat = 1 (disc) + max(case flat).
+            var info = FlatInfo{ .flat = 1 };
+            var max_case: u32 = 0;
+            for (v.cases) |c| {
+                if (c.type) |vt| {
+                    const ci = flattenInner(vt, resolver, depth);
+                    if (ci.flat > max_case) max_case = ci.flat;
+                    info.needs_memory = info.needs_memory or ci.needs_memory;
+                    info.needs_realloc_alloc = info.needs_realloc_alloc or ci.needs_realloc_alloc;
+                    info.contains_string = info.contains_string or ci.contains_string;
+                }
+            }
+            info.flat = saturatingAdd(info.flat, max_case);
+            break :blk info;
+        },
+        .list => |l| blk: {
+            const elem_info = flattenInner(l.element, resolver, depth);
+            break :blk .{
+                .flat = 2,
+                .needs_memory = true,
+                .needs_realloc_alloc = true,
+                .contains_string = elem_info.contains_string,
+            };
+        },
+        .tuple => |t| blk: {
+            var info = FlatInfo{};
+            for (t.fields) |fty| {
+                const fi = flattenInner(fty, resolver, depth);
+                info.flat = saturatingAdd(info.flat, fi.flat);
+                info.needs_memory = info.needs_memory or fi.needs_memory;
+                info.needs_realloc_alloc = info.needs_realloc_alloc or fi.needs_realloc_alloc;
+                info.contains_string = info.contains_string or fi.contains_string;
+            }
+            break :blk info;
+        },
+        .flags => |f| blk: {
+            const slots = (f.names.len + 31) / 32;
+            const slots_u32: u32 = if (slots == 0) 1 else @intCast(slots);
+            break :blk .{ .flat = slots_u32 };
+        },
+        .enum_ => .{ .flat = 1 },
+        .option => |o| blk: {
+            const inner = flattenInner(o.inner, resolver, depth);
+            break :blk .{
+                .flat = saturatingAdd(1, inner.flat),
+                .needs_memory = inner.needs_memory,
+                .needs_realloc_alloc = inner.needs_realloc_alloc,
+                .contains_string = inner.contains_string,
+            };
+        },
+        .result => |r| blk: {
+            var info = FlatInfo{ .flat = 1 };
+            var max_case: u32 = 0;
+            inline for (.{ r.ok, r.err }) |maybe_vt| {
+                if (maybe_vt) |vt| {
+                    const ci = flattenInner(vt, resolver, depth);
+                    if (ci.flat > max_case) max_case = ci.flat;
+                    info.needs_memory = info.needs_memory or ci.needs_memory;
+                    info.needs_realloc_alloc = info.needs_realloc_alloc or ci.needs_realloc_alloc;
+                    info.contains_string = info.contains_string or ci.contains_string;
+                }
+            }
+            info.flat = saturatingAdd(info.flat, max_case);
+            break :blk info;
+        },
+        .resource => .{ .flat = 1 },
+        // Func / component / instance are not value types; reaching
+        // them through a `.type_idx` is malformed but treat as scalar.
+        .func, .component, .instance => .{ .flat = 1 },
+    };
+}
+
+fn saturatingAdd(a: u32, b: u32) u32 {
+    const sum = @as(u64, a) + @as(u64, b);
+    return if (sum > 32) 32 else @intCast(sum);
+}
+
+/// Maximum number of flat values that fit in registers — beyond
+/// these, the canon ABI passes through memory pointers.
+pub const MAX_FLAT_PARAMS: u32 = 16;
+pub const MAX_FLAT_RESULTS: u32 = 1;
+
+pub const Classification = struct {
+    class: Class,
+    opts: FuncOpts,
+    /// Sum of flat params (capped). Useful for shim sig generation.
+    params_flat: u32,
+    /// Result flat count (capped). Useful for shim sig generation.
+    results_flat: u32,
+    /// Whether the result is non-empty (`results != .none`).
+    has_result: bool,
+};
+
+/// Classify a func signature into direct-vs-indirect and produce
+/// the canon-lower opt list flags.
+pub fn classifyFunc(ftr: FuncTypeRef) Classification {
+    const ft = ftr.func;
+    const resolver = ftr.resolver;
+
+    var params_flat: u32 = 0;
+    var params_have_string_or_list_via_memory = false;
+    var any_string = false;
+    for (ft.params) |p| {
+        const info = flatten(p.type, resolver);
+        params_flat = saturatingAdd(params_flat, info.flat);
+        if (info.needs_memory) params_have_string_or_list_via_memory = true;
+        if (info.contains_string) any_string = true;
+    }
+
+    var results_flat: u32 = 0;
+    var results_have_string_or_list = false;
+    var has_result = false;
+    switch (ft.results) {
+        .none => {},
+        .unnamed => |vt| {
+            const info = flatten(vt, resolver);
+            results_flat = info.flat;
+            results_have_string_or_list = info.needs_realloc_alloc;
+            if (info.contains_string) any_string = true;
+            has_result = true;
+        },
+        .named => |list| {
+            for (list) |nv| {
+                const info = flatten(nv.type, resolver);
+                results_flat = saturatingAdd(results_flat, info.flat);
+                if (info.needs_realloc_alloc) results_have_string_or_list = true;
+                if (info.contains_string) any_string = true;
+            }
+            has_result = list.len > 0;
+        },
+    }
+
+    const need_memory =
+        params_have_string_or_list_via_memory or
+        results_flat > MAX_FLAT_RESULTS or
+        results_have_string_or_list;
+
+    const need_realloc = results_have_string_or_list;
+
+    const class: Class = if (need_memory or params_flat > MAX_FLAT_PARAMS)
+        .indirect
+    else
+        .direct;
+
+    return .{
+        .class = class,
+        .opts = .{
+            .memory = need_memory,
+            .realloc = need_realloc,
+            .string_encoding = any_string,
+        },
+        .params_flat = params_flat,
+        .results_flat = results_flat,
+        .has_result = has_result,
+    };
+}
+
+/// Compute the flat core-wasm signature an indirect import lowers
+/// to. Used by the splicer when sizing the shim's trampoline slots
+/// (which must match the lowered call's flat repr — params first,
+/// then `(memory option)` adds nothing extra to the core sig
+/// because `(memory)` is a per-call option, not a param).
+///
+/// Caveat: when results-flat > MAX_FLAT_RESULTS, the canon ABI
+/// passes results through a returned pointer, which means the core
+/// sig actually has 0 results and one extra `i32` param (the output
+/// pointer). We model that here.
+pub fn lowerCoreSig(
+    arena: Allocator,
+    cls: Classification,
+) Error!struct {
+    params: []const @import("../../types.zig").ValType,
+    results: []const @import("../../types.zig").ValType,
+} {
+    const wtypes = @import("../../types.zig");
+    const params_flat = cls.params_flat;
+    const ret_via_pointer = cls.results_flat > MAX_FLAT_RESULTS;
+
+    const total_params: u32 = if (ret_via_pointer)
+        saturatingAdd(params_flat, 1)
+    else
+        params_flat;
+
+    const total_results: u32 = if (ret_via_pointer)
+        0
+    else
+        cls.results_flat;
+
+    const params = try arena.alloc(wtypes.ValType, total_params);
+    for (params) |*p| p.* = .i32;
+
+    const results = try arena.alloc(wtypes.ValType, total_results);
+    for (results) |*r| r.* = .i32;
+
+    return .{ .params = params, .results = results };
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+const metadata_encode = @import("../wit/metadata_encode.zig");
+
+/// Build a small mock `AdapterWorld` whose body has exactly one
+/// imported instance with one func export of the given signature.
+/// Use to test the classifier against synthetic types
+/// (`metadata_encode` doesn't support list/option/result yet).
+fn buildSyntheticWorld(
+    arena: Allocator,
+    inst_decls_ext: []const ctypes.Decl,
+    inner_func_idx: u32,
+) !decode.AdapterWorld {
+    // World body decls:
+    //   .type = .{ .instance = { decls = inst_decls_ext } }    // type idx 0
+    //   .import "mock:abi/in1@0.1.0" (instance 0)              // instance idx 0
+    const inst_td = try arena.create(ctypes.TypeDef);
+    inst_td.* = .{ .instance = .{ .decls = inst_decls_ext } };
+
+    const decls = try arena.alloc(ctypes.Decl, 2);
+    decls[0] = .{ .type = inst_td.* };
+    decls[1] = .{ .import = .{ .name = "mock:abi/in1@0.1.0", .desc = .{ .instance = 0 } } };
+
+    const imports = try arena.alloc(decode.ImportEntry, 1);
+    imports[0] = .{
+        .name = "mock:abi/in1@0.1.0",
+        .body_decl_idx = 1,
+        .body_type_idx = 0,
+        .body_instance_idx = 0,
+    };
+
+    _ = inner_func_idx; // silence unused
+
+    return .{
+        .component = undefined, // not used by the classifier
+        .body_decls = decls,
+        .body_type_count = 1,
+        .imports = imports,
+        .exports = &.{},
+        .world_qualified_name = "mock:abi/abi-mock@0.1.0",
+    };
+}
+
+test "classifyFunc: scalar-returning func is direct, no opts" {
+    // Build a minimal world where one interface has func() -> u32.
+    const ct = try metadata_encode.encodeWorldFromSource(testing.allocator,
+        \\package mock:abi@0.1.0;
+        \\interface in1 { ping: func() -> u32; }
+        \\world abi-mock { import in1; }
+    , "abi-mock");
+    defer testing.allocator.free(ct);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const w = try decode.parse(a, ct);
+    try testing.expectEqual(@as(usize, 1), w.imports.len);
+    const ftr = try findFuncImport(w, w.imports[0].body_type_idx, "ping");
+    const cls = classifyFunc(ftr);
+
+    try testing.expectEqual(Class.direct, cls.class);
+    try testing.expect(!cls.opts.memory);
+    try testing.expect(!cls.opts.realloc);
+    try testing.expect(!cls.opts.string_encoding);
+    try testing.expectEqual(@as(u32, 0), cls.params_flat);
+    try testing.expectEqual(@as(u32, 1), cls.results_flat);
+}
+
+test "classifyFunc: list<u8> param triggers indirect with memory only" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // instance body:
+    //   .type = .{ .list = u8 }          // local type idx 0
+    //   .type = .{ .func ... }           // local type idx 1
+    //   .export "eat" (func 1)
+    const inst_decls = try a.alloc(ctypes.Decl, 3);
+    inst_decls[0] = .{ .type = .{ .list = .{ .element = .u8 } } };
+    const params = try a.alloc(ctypes.NamedValType, 1);
+    params[0] = .{ .name = "buf", .type = .{ .type_idx = 0 } };
+    inst_decls[1] = .{ .type = .{ .func = .{
+        .params = params,
+        .results = .{ .unnamed = .u32 },
+    } } };
+    inst_decls[2] = .{ .@"export" = .{ .name = "eat", .desc = .{ .func = 1 } } };
+
+    const w = try buildSyntheticWorld(a, inst_decls, 1);
+
+    const ftr = try findFuncImport(w, w.imports[0].body_type_idx, "eat");
+    const cls = classifyFunc(ftr);
+
+    try testing.expectEqual(Class.indirect, cls.class);
+    try testing.expect(cls.opts.memory);
+    try testing.expect(!cls.opts.realloc);
+    try testing.expect(!cls.opts.string_encoding);
+    try testing.expectEqual(@as(u32, 2), cls.params_flat);
+}
+
+test "classifyFunc: list<u8> result triggers indirect with memory + realloc" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // instance body:
+    //   .type = .{ .list = u8 }          // local type idx 0
+    //   .type = .{ .func () -> 0 }       // local type idx 1
+    //   .export "make" (func 1)
+    const inst_decls = try a.alloc(ctypes.Decl, 3);
+    inst_decls[0] = .{ .type = .{ .list = .{ .element = .u8 } } };
+    inst_decls[1] = .{ .type = .{ .func = .{
+        .params = &.{},
+        .results = .{ .unnamed = .{ .type_idx = 0 } },
+    } } };
+    inst_decls[2] = .{ .@"export" = .{ .name = "make", .desc = .{ .func = 1 } } };
+
+    const w = try buildSyntheticWorld(a, inst_decls, 1);
+
+    const ftr = try findFuncImport(w, w.imports[0].body_type_idx, "make");
+    const cls = classifyFunc(ftr);
+
+    try testing.expectEqual(Class.indirect, cls.class);
+    try testing.expect(cls.opts.memory);
+    try testing.expect(cls.opts.realloc);
+    try testing.expect(!cls.opts.string_encoding);
+}
+
+test "classifyFunc: string in result triggers utf8 encoding" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // instance body:
+    //   .type = .{ .func () -> string }   // local type idx 0
+    //   .export "name" (func 0)
+    const inst_decls = try a.alloc(ctypes.Decl, 2);
+    inst_decls[0] = .{ .type = .{ .func = .{
+        .params = &.{},
+        .results = .{ .unnamed = .string },
+    } } };
+    inst_decls[1] = .{ .@"export" = .{ .name = "name", .desc = .{ .func = 0 } } };
+
+    const w = try buildSyntheticWorld(a, inst_decls, 0);
+
+    const ftr = try findFuncImport(w, w.imports[0].body_type_idx, "name");
+    const cls = classifyFunc(ftr);
+
+    try testing.expectEqual(Class.indirect, cls.class);
+    try testing.expect(cls.opts.memory);
+    try testing.expect(cls.opts.realloc);
+    try testing.expect(cls.opts.string_encoding);
+}
+
+test "classifyFunc: option<u32> result has flat=2, indirect" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // option<u32> flattens to (disc i32, val i32) → 2 flat returns →
+    // indirect via memory pointer.
+    const inst_decls = try a.alloc(ctypes.Decl, 3);
+    inst_decls[0] = .{ .type = .{ .option = .{ .inner = .u32 } } };
+    inst_decls[1] = .{ .type = .{ .func = .{
+        .params = &.{},
+        .results = .{ .unnamed = .{ .type_idx = 0 } },
+    } } };
+    inst_decls[2] = .{ .@"export" = .{ .name = "maybe", .desc = .{ .func = 1 } } };
+
+    const w = try buildSyntheticWorld(a, inst_decls, 1);
+
+    const ftr = try findFuncImport(w, w.imports[0].body_type_idx, "maybe");
+    const cls = classifyFunc(ftr);
+
+    try testing.expectEqual(Class.indirect, cls.class);
+    try testing.expect(cls.opts.memory);
+    try testing.expect(!cls.opts.realloc);
+    try testing.expect(!cls.opts.string_encoding);
+    try testing.expectEqual(@as(u32, 2), cls.results_flat);
+}
+
+test "classifyFunc: () -> own<resource> is direct (handle is i32)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // instance body:
+    //   .export "stream" (type (sub resource))    // local type idx 0
+    //   .type = .{ .val (.own 0) }                 // local type idx 1
+    //   .type = .{ .func () -> 1 }                 // local type idx 2
+    //   .export "open" (func 0)
+    const inst_decls = try a.alloc(ctypes.Decl, 4);
+    inst_decls[0] = .{ .@"export" = .{
+        .name = "stream",
+        .desc = .{ .type = .sub_resource },
+    } };
+    inst_decls[1] = .{ .type = .{ .val = .{ .own = 0 } } };
+    inst_decls[2] = .{ .type = .{ .func = .{
+        .params = &.{},
+        .results = .{ .unnamed = .{ .type_idx = 1 } },
+    } } };
+    inst_decls[3] = .{ .@"export" = .{ .name = "open", .desc = .{ .func = 2 } } };
+
+    const w = try buildSyntheticWorld(a, inst_decls, 2);
+
+    const ftr = try findFuncImport(w, w.imports[0].body_type_idx, "open");
+    const cls = classifyFunc(ftr);
+
+    try testing.expectEqual(Class.direct, cls.class);
+    try testing.expect(!cls.opts.memory);
+    try testing.expectEqual(@as(u32, 1), cls.results_flat);
+}
+
+test "lowerCoreSig: 2-flat result becomes (i32 in, no out) with output pointer" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const sig = try lowerCoreSig(arena.allocator(), .{
+        .class = .indirect,
+        .opts = .{ .memory = true, .realloc = false, .string_encoding = false },
+        .params_flat = 1,
+        .results_flat = 2,
+        .has_result = true,
+    });
+    try testing.expectEqual(@as(usize, 2), sig.params.len); // 1 real + 1 ret-ptr
+    try testing.expectEqual(@as(usize, 0), sig.results.len);
+}
+
+test "lowerCoreSig: 1-flat result keeps 1 result, no extra param" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const sig = try lowerCoreSig(arena.allocator(), .{
+        .class = .direct,
+        .opts = .{ .memory = false, .realloc = false, .string_encoding = false },
+        .params_flat = 0,
+        .results_flat = 1,
+        .has_result = true,
+    });
+    try testing.expectEqual(@as(usize, 0), sig.params.len);
+    try testing.expectEqual(@as(usize, 1), sig.results.len);
+}

--- a/src/component/adapter/adapter.zig
+++ b/src/component/adapter/adapter.zig
@@ -1,0 +1,1310 @@
+//! WASI preview1 → component adapter splicer.
+//!
+//! Top-level entry point: `splice(gpa, embed_bytes, adapter_bytes,
+//! adapter_name) ![]u8`. Mirrors `wasm-tools component new --adapt
+//! wasi_snapshot_preview1=<file>`. Output is structurally
+//! equivalent to the `wasm-tools` reference but not byte-identical
+//! (we lay out sections in our own order and defer adapter GC).
+//!
+//! Architecture (all four core modules embedded in the wrapping
+//! component):
+//!
+//!     ┌─ shim ─┐  trampoline funcs that index into `$imports`
+//!     │        │  table — patched by fixup at start time.
+//!     ├─ embed │  (the user's program; imports
+//!     │        │  `wasi_snapshot_preview1.<name>` from the shim).
+//!     ├─adapter│  preview1 → component adapter; imports
+//!     │        │  `__main_module__.<name>` from embed, `env.memory`
+//!     │        │  from embed, and one inline-instance per WASI
+//!     │        │  namespace (component `canon lower`'d).
+//!     └─ fixup ┘  imports shim's `$imports` table, imports the
+//!                 adapter's preview1 exports + canon-lowered indirect
+//!                 wasi imports, and stores them into the shim table
+//!                 via an active element segment.
+//!
+//! See plan.md for the full choreography and the dissection of
+//! `/tmp/tiny_component.wasm` (wasm-tools reference output for
+//! zig-hello).
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const ctypes = @import("../types.zig");
+const writer = @import("../writer.zig");
+const wtypes = @import("../../types.zig");
+
+const decode = @import("decode.zig");
+const types_import = @import("types_import.zig");
+const core_imports = @import("core_imports.zig");
+const shim = @import("shim.zig");
+const fixup = @import("fixup.zig");
+const abi = @import("abi.zig");
+
+pub const SpliceError = error{
+    OutOfMemory,
+    NotCoreWasm,
+    InvalidAdapterCore,
+    MissingEncodedWorld,
+    UnsupportedAdapterShape,
+    AdapterMissingRunExport,
+    AdapterMissingPreview1Export,
+    EmbedMissingRequiredExport,
+    AdapterMissingReallocExport,
+    FuncNotFound,
+    NotAFuncExport,
+    UnsupportedShape,
+    ValueTooLarge,
+    LebOverflow,
+    LebTruncated,
+} || writer.EncodeError;
+
+/// Splice a preview1 embed and an adapter into a wrapping component.
+/// Caller frees the returned slice via `gpa`.
+pub fn splice(
+    gpa: Allocator,
+    embed_bytes: []const u8,
+    adapter_bytes: []const u8,
+    adapter_name: []const u8,
+) ![]u8 {
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // ── Phase A: decode + classify ─────────────────────────────────────────
+    const world = try decode.parseFromAdapterCore(a, adapter_bytes);
+    const hoisted = try types_import.hoist(a, world);
+
+    var adapter_owned = try core_imports.extract(gpa, adapter_bytes);
+    defer adapter_owned.deinit();
+    var embed_owned = try core_imports.extract(gpa, embed_bytes);
+    defer embed_owned.deinit();
+
+    // The embed may carry its own `component-type` custom section
+    // (produced by `wasm-tools component embed --world …`). When
+    // present we use its declared FuncTypes to preserve original
+    // param names on lifted top-level imports. Absent (e.g. for a
+    // raw zig-hello core wasm), we synthesize p0/p1 names from the
+    // core sigs alone.
+    const embed_world: ?decode.AdapterWorld = blk: {
+        const ct = decode.extractEncodedWorld(embed_bytes) catch break :blk null;
+        const payload = ct orelse break :blk null;
+        break :blk decode.parse(a, payload) catch null;
+    };
+
+    const preview1_slots = try collectPreview1Slots(a, embed_owned.interface, adapter_name);
+    const buckets = try classifyAdapterImports(a, adapter_owned.interface, world, hoisted);
+    const indirect_slots = try collectIndirectSlots(a, buckets);
+
+    var all_slots = try a.alloc(shim.Slot, preview1_slots.len + indirect_slots.len);
+    for (preview1_slots, 0..) |p1, i| {
+        all_slots[i] = .{ .params = p1.params, .results = p1.results };
+    }
+    @memcpy(all_slots[preview1_slots.len..], indirect_slots);
+
+    // ── Phase B: build shim + fixup core modules ──────────────────────────
+    const shim_bytes = try shim.build(a, all_slots);
+    const fixup_bytes = try fixup.build(a, all_slots);
+
+    // ── Phase C: assemble + encode ────────────────────────────────────────
+    return try assemble(.{
+        .gpa = gpa,
+        .arena = a,
+        .embed_bytes = try stripComponentTypeSections(a, embed_bytes),
+        .adapter_bytes = try arenaDup(a, adapter_bytes),
+        .shim_bytes = shim_bytes,
+        .fixup_bytes = fixup_bytes,
+        .adapter_name = adapter_name,
+        .world = world,
+        .embed_world = embed_world,
+        .hoisted = hoisted,
+        .embed_iface = embed_owned.interface,
+        .adapter_iface = adapter_owned.interface,
+        .preview1_slots = preview1_slots,
+        .buckets = buckets,
+    });
+}
+
+// ── Slot / bucket collection ──────────────────────────────────────────────
+
+const Preview1Slot = struct {
+    name: []const u8,
+    params: []const wtypes.ValType,
+    results: []const wtypes.ValType,
+};
+
+fn collectPreview1Slots(
+    arena: Allocator,
+    embed_iface: core_imports.CoreInterface,
+    adapter_name: []const u8,
+) SpliceError![]const Preview1Slot {
+    var out = std.ArrayListUnmanaged(Preview1Slot).empty;
+    for (embed_iface.imports) |im| {
+        if (im.kind != .func) continue;
+        if (!std.mem.eql(u8, im.module_name, adapter_name)) continue;
+        const sig = im.sig orelse continue;
+        try out.append(arena, .{
+            .name = im.field_name,
+            .params = sig.params,
+            .results = sig.results,
+        });
+    }
+    return out.toOwnedSlice(arena);
+}
+
+const ResourceDrop = struct {
+    resource_name: []const u8,
+};
+
+const IndirectFunc = struct {
+    name: []const u8,
+    /// Slot index in `shim_slots`, RELATIVE to the start of the
+    /// indirect block (i.e. excluding preview1 slots). Filled in.
+    slot_idx: u32 = 0,
+    cls: abi.Classification,
+    ftr: abi.FuncTypeRef,
+};
+
+const DirectFunc = struct {
+    name: []const u8,
+    cls: abi.Classification,
+    ftr: abi.FuncTypeRef,
+};
+
+const NamespaceBucket = struct {
+    name: []const u8,
+    instance_idx: u32,
+    body_type_idx: u32,
+    resource_drops: []ResourceDrop,
+    indirect_funcs: []IndirectFunc,
+    direct_funcs: []DirectFunc,
+};
+
+fn classifyAdapterImports(
+    arena: Allocator,
+    adapter_iface: core_imports.CoreInterface,
+    world: decode.AdapterWorld,
+    hoisted: types_import.Hoisted,
+) SpliceError![]NamespaceBucket {
+    var bucket_names = std.ArrayListUnmanaged([]const u8).empty;
+    var seen = std.StringHashMapUnmanaged(void).empty;
+    defer seen.deinit(arena);
+
+    for (adapter_iface.imports) |im| {
+        if (im.kind != .func) continue;
+        if (std.mem.eql(u8, im.module_name, "env")) continue;
+        if (std.mem.eql(u8, im.module_name, "__main_module__")) continue;
+        const gop = try seen.getOrPut(arena, im.module_name);
+        if (!gop.found_existing) try bucket_names.append(arena, im.module_name);
+    }
+
+    const buckets = try arena.alloc(NamespaceBucket, bucket_names.items.len);
+
+    for (bucket_names.items, 0..) |bn, bi| {
+        var rd_list = std.ArrayListUnmanaged(ResourceDrop).empty;
+        var ind_list = std.ArrayListUnmanaged(IndirectFunc).empty;
+        var dir_list = std.ArrayListUnmanaged(DirectFunc).empty;
+
+        const slot = findInstanceSlot(hoisted, bn) orelse return error.UnsupportedAdapterShape;
+
+        for (adapter_iface.imports) |im| {
+            if (im.kind != .func) continue;
+            if (!std.mem.eql(u8, im.module_name, bn)) continue;
+            if (std.mem.startsWith(u8, im.field_name, "[resource-drop]")) {
+                const rname = im.field_name["[resource-drop]".len..];
+                try rd_list.append(arena, .{ .resource_name = rname });
+                continue;
+            }
+
+            const ftr = abi.findFuncImport(world, slot.type_idx, im.field_name) catch
+                return error.UnsupportedAdapterShape;
+            const cls = abi.classifyFunc(ftr);
+            switch (cls.class) {
+                .direct => try dir_list.append(arena, .{
+                    .name = im.field_name,
+                    .cls = cls,
+                    .ftr = ftr,
+                }),
+                .indirect => try ind_list.append(arena, .{
+                    .name = im.field_name,
+                    .cls = cls,
+                    .ftr = ftr,
+                }),
+            }
+        }
+
+        buckets[bi] = .{
+            .name = bn,
+            .instance_idx = slot.instance_idx,
+            .body_type_idx = slot.type_idx,
+            .resource_drops = try rd_list.toOwnedSlice(arena),
+            .indirect_funcs = try ind_list.toOwnedSlice(arena),
+            .direct_funcs = try dir_list.toOwnedSlice(arena),
+        };
+    }
+
+    var slot_cursor: u32 = 0;
+    for (buckets) |*b| {
+        for (b.indirect_funcs) |*f| {
+            f.slot_idx = slot_cursor;
+            slot_cursor += 1;
+        }
+    }
+    return buckets;
+}
+
+fn findInstanceSlot(h: types_import.Hoisted, name: []const u8) ?types_import.InstanceSlot {
+    for (h.instances) |s| if (std.mem.eql(u8, s.name, name)) return s;
+    return null;
+}
+
+fn collectIndirectSlots(arena: Allocator, buckets: []const NamespaceBucket) SpliceError![]shim.Slot {
+    var out = std.ArrayListUnmanaged(shim.Slot).empty;
+    for (buckets) |b| {
+        for (b.indirect_funcs) |f| {
+            const sig = try abi.lowerCoreSig(arena, f.ftr);
+            try out.append(arena, .{ .params = sig.params, .results = sig.results });
+        }
+    }
+    return out.toOwnedSlice(arena);
+}
+
+fn arenaDup(arena: Allocator, src: []const u8) SpliceError![]u8 {
+    const buf = try arena.alloc(u8, src.len);
+    @memcpy(buf, src);
+    return buf;
+}
+
+// ── Component assembly ────────────────────────────────────────────────────
+
+const Inputs = struct {
+    gpa: Allocator,
+    arena: Allocator,
+    embed_bytes: []const u8,
+    adapter_bytes: []const u8,
+    shim_bytes: []const u8,
+    fixup_bytes: []const u8,
+    adapter_name: []const u8,
+    world: decode.AdapterWorld,
+    embed_world: ?decode.AdapterWorld,
+    hoisted: types_import.Hoisted,
+    embed_iface: core_imports.CoreInterface,
+    adapter_iface: core_imports.CoreInterface,
+    preview1_slots: []const Preview1Slot,
+    buckets: []NamespaceBucket,
+};
+
+/// `Builder` accumulates per-section arrays + section_order entries
+/// + running indexspace cursors. Every "add…" returns the
+/// indexspace position of the freshly added item so the caller can
+/// reference it from later items (canons, instantiate args, etc.).
+const Builder = struct {
+    arena: Allocator,
+
+    types: std.ArrayListUnmanaged(ctypes.TypeDef) = .empty,
+    aliases: std.ArrayListUnmanaged(ctypes.Alias) = .empty,
+    imports: std.ArrayListUnmanaged(ctypes.ImportDecl) = .empty,
+    core_modules: std.ArrayListUnmanaged(ctypes.CoreModule) = .empty,
+    core_instances: std.ArrayListUnmanaged(ctypes.CoreInstanceExpr) = .empty,
+    canons: std.ArrayListUnmanaged(ctypes.Canon) = .empty,
+    components: std.ArrayListUnmanaged(*ctypes.Component) = .empty,
+    instances: std.ArrayListUnmanaged(ctypes.InstanceExpr) = .empty,
+    exports: std.ArrayListUnmanaged(ctypes.ExportDecl) = .empty,
+    section_order: std.ArrayListUnmanaged(ctypes.SectionEntry) = .empty,
+
+    /// Indexspace cursors. Updated as items are appended.
+    type_cursor: u32 = 0,
+    instance_cursor: u32 = 0,
+    func_cursor: u32 = 0,
+    core_func_cursor: u32 = 0,
+    core_table_cursor: u32 = 0,
+    core_mem_cursor: u32 = 0,
+
+    /// Add a section_order entry for the most recent append. Merges
+    /// with the previous entry if same kind + contiguous range.
+    fn addSection(self: *Builder, kind: ctypes.SectionKind, start: u32) !void {
+        if (self.section_order.items.len > 0) {
+            const last = &self.section_order.items[self.section_order.items.len - 1];
+            if (last.kind == kind and last.start + last.count == start) {
+                last.count += 1;
+                return;
+            }
+        }
+        try self.section_order.append(self.arena, .{ .kind = kind, .start = start, .count = 1 });
+    }
+
+    fn addType(self: *Builder, td: ctypes.TypeDef) !u32 {
+        const start: u32 = @intCast(self.types.items.len);
+        try self.types.append(self.arena, td);
+        try self.addSection(.type, start);
+        const idx = self.type_cursor;
+        self.type_cursor += 1;
+        return idx;
+    }
+
+    fn addAlias(self: *Builder, al: ctypes.Alias) !u32 {
+        const start: u32 = @intCast(self.aliases.items.len);
+        try self.aliases.append(self.arena, al);
+        try self.addSection(.alias, start);
+
+        const sort: ctypes.Sort = switch (al) {
+            .instance_export => |ie| ie.sort,
+            .outer => |o| o.sort,
+        };
+        return switch (sort) {
+            .core => |cs| switch (cs) {
+                .func => blk: {
+                    const i = self.core_func_cursor;
+                    self.core_func_cursor += 1;
+                    break :blk i;
+                },
+                .table => blk: {
+                    const i = self.core_table_cursor;
+                    self.core_table_cursor += 1;
+                    break :blk i;
+                },
+                .memory => blk: {
+                    const i = self.core_mem_cursor;
+                    self.core_mem_cursor += 1;
+                    break :blk i;
+                },
+                else => 0,
+            },
+            .func => blk: {
+                const i = self.func_cursor;
+                self.func_cursor += 1;
+                break :blk i;
+            },
+            .type => blk: {
+                const i = self.type_cursor;
+                self.type_cursor += 1;
+                break :blk i;
+            },
+            .instance => blk: {
+                const i = self.instance_cursor;
+                self.instance_cursor += 1;
+                break :blk i;
+            },
+            else => 0,
+        };
+    }
+
+    fn addCoreModule(self: *Builder, m: ctypes.CoreModule) !u32 {
+        const start: u32 = @intCast(self.core_modules.items.len);
+        try self.core_modules.append(self.arena, m);
+        try self.addSection(.core_module, start);
+        return start;
+    }
+
+    fn addCoreInstance(self: *Builder, e: ctypes.CoreInstanceExpr) !u32 {
+        const start: u32 = @intCast(self.core_instances.items.len);
+        try self.core_instances.append(self.arena, e);
+        try self.addSection(.core_instance, start);
+        return start;
+    }
+
+    fn addCanon(self: *Builder, c: ctypes.Canon) !u32 {
+        const start: u32 = @intCast(self.canons.items.len);
+        try self.canons.append(self.arena, c);
+        try self.addSection(.canon, start);
+        switch (c) {
+            .lift => {
+                const i = self.func_cursor;
+                self.func_cursor += 1;
+                return i;
+            },
+            .lower, .resource_drop, .resource_new, .resource_rep => {
+                const i = self.core_func_cursor;
+                self.core_func_cursor += 1;
+                return i;
+            },
+        }
+    }
+
+    fn addNestedComponent(self: *Builder, c: *ctypes.Component) !u32 {
+        const start: u32 = @intCast(self.components.items.len);
+        try self.components.append(self.arena, c);
+        try self.addSection(.component, start);
+        return start;
+    }
+
+    fn addInstance(self: *Builder, e: ctypes.InstanceExpr) !u32 {
+        const start: u32 = @intCast(self.instances.items.len);
+        try self.instances.append(self.arena, e);
+        try self.addSection(.instance, start);
+        const idx = self.instance_cursor;
+        self.instance_cursor += 1;
+        return idx;
+    }
+
+    fn addExport(self: *Builder, e: ctypes.ExportDecl) !void {
+        const start: u32 = @intCast(self.exports.items.len);
+        try self.exports.append(self.arena, e);
+        try self.addSection(.@"export", start);
+    }
+
+    /// Append a top-level component-level import. The caller is
+    /// responsible for any preceding type defs the import references.
+    /// Returns the indexspace position the import lives at, in the
+    /// indexspace it occupies (instance / func / type / component
+    /// depending on `desc`). For `.instance` desc, returns the
+    /// instance-indexspace position.
+    fn addImport(self: *Builder, im: ctypes.ImportDecl) !u32 {
+        const start: u32 = @intCast(self.imports.items.len);
+        try self.imports.append(self.arena, im);
+        try self.addSection(.import, start);
+        return switch (im.desc) {
+            .instance => blk: {
+                const i = self.instance_cursor;
+                self.instance_cursor += 1;
+                break :blk i;
+            },
+            .func => blk: {
+                const i = self.func_cursor;
+                self.func_cursor += 1;
+                break :blk i;
+            },
+            .type => blk: {
+                const i = self.type_cursor;
+                self.type_cursor += 1;
+                break :blk i;
+            },
+            else => 0,
+        };
+    }
+};
+
+fn assemble(in: Inputs) ![]u8 {
+    const a = in.arena;
+
+    var b = Builder{ .arena = a };
+
+    // ── Step 1: hoisted body decls ──────────────────────────────────────
+    // We adopt the hoisted slices directly (no copy) and EXTEND them
+    // with our additions. The hoisted body's section_order is included
+    // verbatim except we DROP `.@"export"` entries — those represent
+    // the world body's `(export "wasi:cli/run@<ver>" instance)` decl
+    // which the splicer replaces with a top-level instance export.
+    try b.types.appendSlice(a, in.hoisted.types);
+    try b.aliases.appendSlice(a, in.hoisted.aliases);
+    try b.imports.appendSlice(a, in.hoisted.imports);
+    b.type_cursor = in.hoisted.type_count;
+    b.instance_cursor = @intCast(in.hoisted.instances.len);
+    for (in.hoisted.section_order) |se| {
+        if (se.kind == .@"export") continue;
+        try b.section_order.append(a, se);
+    }
+
+    // The hoisted body's `imports` field becomes the wrapping
+    // component's `imports[]`. It's referenced by section_order
+    // entries with kind=.import, which we keep as-is.
+
+    // ── Step 2: NEW types for canon-lift run ──────────────────────────
+    // (result), (func () -> result)
+    const run_result_type_idx = try b.addType(.{ .result = .{ .ok = null, .err = null } });
+    const run_func_type_idx = try b.addType(.{ .func = .{
+        .params = &.{},
+        .results = .{ .unnamed = .{ .type_idx = run_result_type_idx } },
+    } });
+
+    // ── Step 3: core modules (main=0, adapter=1, shim=2, fixup=3) ─────
+    const main_module_idx = try b.addCoreModule(.{ .data = in.embed_bytes });
+    const adapter_module_idx = try b.addCoreModule(.{ .data = in.adapter_bytes });
+    const shim_module_idx = try b.addCoreModule(.{ .data = in.shim_bytes });
+    const fixup_module_idx = try b.addCoreModule(.{ .data = in.fixup_bytes });
+
+    // ── Step 4: shim instance ────────────────────────────────────────
+    const shim_inst = try b.addCoreInstance(.{ .instantiate = .{
+        .module_idx = shim_module_idx,
+        .args = &.{},
+    } });
+
+    // ── Step 5: preview1 inline-export instance for embed ────────────
+    var preview1_inline = std.ArrayListUnmanaged(ctypes.CoreInlineExport).empty;
+    for (in.preview1_slots, 0..) |p1, i| {
+        const stub_name = try std.fmt.allocPrint(a, "{d}", .{i});
+        const f_idx = try b.addAlias(.{ .instance_export = .{
+            .sort = .{ .core = .func },
+            .instance_idx = shim_inst,
+            .name = stub_name,
+        } });
+        try preview1_inline.append(a, .{
+            .name = p1.name,
+            .sort_idx = .{ .sort = .func, .idx = f_idx },
+        });
+    }
+    const preview1_inst = try b.addCoreInstance(.{ .exports = try preview1_inline.toOwnedSlice(a) });
+
+    // ── Step 5b: lift non-WASI embed imports to component imports ─────
+    // The embed may import core funcs from namespaces beyond the
+    // WASI adapter (e.g. `docs:adder/add@0.1.0` for the calculator
+    // fixture). These don't go through the adapter — instead, lift
+    // each module-level group to a top-level component instance
+    // import, alias each func, canon-lower it, and bundle into an
+    // inline-export instance the embed can consume directly.
+    const embed_extra_args = try buildEmbedExtraImports(&b, a, in);
+
+    // ── Step 6: instantiate main with wasi_snapshot_preview1 + extras ─
+    const main_args = try a.alloc(ctypes.CoreInstantiateArg, 1 + embed_extra_args.len);
+    main_args[0] = .{ .name = in.adapter_name, .instance_idx = preview1_inst };
+    for (embed_extra_args, 0..) |ea, i| {
+        main_args[1 + i] = .{ .name = ea.name, .instance_idx = ea.inst_idx };
+    }
+    const main_inst = try b.addCoreInstance(.{ .instantiate = .{
+        .module_idx = main_module_idx,
+        .args = main_args,
+    } });
+
+    // ── Step 7: env (memory) and __main_module__ inline instances ────
+    const memory_idx = try b.addAlias(.{ .instance_export = .{
+        .sort = .{ .core = .memory },
+        .instance_idx = main_inst,
+        .name = "memory",
+    } });
+    const env_inst = blk: {
+        const exps = try a.alloc(ctypes.CoreInlineExport, 1);
+        exps[0] = .{ .name = "memory", .sort_idx = .{ .sort = .memory, .idx = memory_idx } };
+        break :blk try b.addCoreInstance(.{ .exports = exps });
+    };
+
+    // The adapter imports `__main_module__.<entry>` for whatever the
+    // main module exports as its entry point. zig-hello / Rust's
+    // wasip1 builds export `_start`. Pass through every export the
+    // embed has of name we can find — but in practice this is the
+    // single `_start` symbol. If your embed uses a different name,
+    // expose all exports we can recognize; the adapter ignores
+    // anything it doesn't import.
+    const main_module_inst = blk: {
+        // Mirror the wasm-tools reference: alias every __main_module__
+        // import the adapter requires. If the embed has a matching
+        // export, alias the embed. Otherwise alias the fallback module.
+        var exps = std.ArrayListUnmanaged(ctypes.CoreInlineExport).empty;
+
+        // Determine if we need a fallback core module (i.e. any
+        // __main_module__ import the embed lacks). Currently that's
+        // typically `cabi_realloc` for embeds that don't export it.
+        var needs_fallback = false;
+        for (in.adapter_iface.imports) |im| {
+            if (im.kind != .func) continue;
+            if (!std.mem.eql(u8, im.module_name, "__main_module__")) continue;
+            if (in.embed_iface.findExport(im.field_name) == null) {
+                needs_fallback = true;
+                break;
+            }
+        }
+
+        var fallback_inst: u32 = undefined;
+        if (needs_fallback) {
+            const fallback_bytes = try buildMainModuleFallback(a, in.adapter_iface);
+            const fallback_module_idx = try b.addCoreModule(.{ .data = fallback_bytes });
+            fallback_inst = try b.addCoreInstance(.{ .instantiate = .{
+                .module_idx = fallback_module_idx,
+                .args = &.{},
+            } });
+        }
+
+        for (in.adapter_iface.imports) |im| {
+            if (im.kind != .func) continue;
+            if (!std.mem.eql(u8, im.module_name, "__main_module__")) continue;
+            const have_in_embed = in.embed_iface.findExport(im.field_name) != null;
+            const src_inst = if (have_in_embed) main_inst else fallback_inst;
+            const f_idx = try b.addAlias(.{ .instance_export = .{
+                .sort = .{ .core = .func },
+                .instance_idx = src_inst,
+                .name = im.field_name,
+            } });
+            try exps.append(a, .{
+                .name = im.field_name,
+                .sort_idx = .{ .sort = .func, .idx = f_idx },
+            });
+        }
+        break :blk try b.addCoreInstance(.{ .exports = try exps.toOwnedSlice(a) });
+    };
+
+    // ── Step 8: per-namespace bundles ────────────────────────────────
+    var bucket_inst_idx = try a.alloc(u32, in.buckets.len);
+    for (in.buckets, 0..) |*bucket, bi| {
+        var bundle = std.ArrayListUnmanaged(ctypes.CoreInlineExport).empty;
+
+        for (bucket.resource_drops) |rd| {
+            const t_idx = try b.addAlias(.{ .instance_export = .{
+                .sort = .type,
+                .instance_idx = bucket.instance_idx,
+                .name = rd.resource_name,
+            } });
+            const cf_idx = try b.addCanon(.{ .resource_drop = t_idx });
+            const ename = try std.fmt.allocPrint(a, "[resource-drop]{s}", .{rd.resource_name});
+            try bundle.append(a, .{
+                .name = ename,
+                .sort_idx = .{ .sort = .func, .idx = cf_idx },
+            });
+        }
+
+        for (bucket.direct_funcs) |df| {
+            const f_idx = try b.addAlias(.{ .instance_export = .{
+                .sort = .func,
+                .instance_idx = bucket.instance_idx,
+                .name = df.name,
+            } });
+            const cf_idx = try b.addCanon(.{ .lower = .{
+                .func_idx = f_idx,
+                .opts = &.{},
+            } });
+            try bundle.append(a, .{
+                .name = df.name,
+                .sort_idx = .{ .sort = .func, .idx = cf_idx },
+            });
+        }
+
+        for (bucket.indirect_funcs) |idf| {
+            const slot_total: u32 = @as(u32, @intCast(in.preview1_slots.len)) + idf.slot_idx;
+            const slot_name = try std.fmt.allocPrint(a, "{d}", .{slot_total});
+            const cf_idx = try b.addAlias(.{ .instance_export = .{
+                .sort = .{ .core = .func },
+                .instance_idx = shim_inst,
+                .name = slot_name,
+            } });
+            try bundle.append(a, .{
+                .name = idf.name,
+                .sort_idx = .{ .sort = .func, .idx = cf_idx },
+            });
+        }
+
+        bucket_inst_idx[bi] = try b.addCoreInstance(.{ .exports = try bundle.toOwnedSlice(a) });
+    }
+
+    // ── Step 9: instantiate adapter ──────────────────────────────────
+    var adapter_args = std.ArrayListUnmanaged(ctypes.CoreInstantiateArg).empty;
+    try adapter_args.append(a, .{ .name = "env", .instance_idx = env_inst });
+    try adapter_args.append(a, .{ .name = "__main_module__", .instance_idx = main_module_inst });
+    for (in.buckets, 0..) |bk, bi| {
+        try adapter_args.append(a, .{ .name = bk.name, .instance_idx = bucket_inst_idx[bi] });
+    }
+    const adapter_inst = try b.addCoreInstance(.{ .instantiate = .{
+        .module_idx = adapter_module_idx,
+        .args = try adapter_args.toOwnedSlice(a),
+    } });
+
+    // ── Step 10: fixup bundle ────────────────────────────────────────
+    // Realloc opt source if any indirect canon-lower needs it.
+    var any_realloc = false;
+    for (in.buckets) |bk| for (bk.indirect_funcs) |idf| {
+        if (idf.cls.opts.realloc) any_realloc = true;
+    };
+
+    var realloc_idx: u32 = 0;
+    if (any_realloc) {
+        if (in.adapter_iface.findExport("cabi_import_realloc") == null) {
+            return error.AdapterMissingReallocExport;
+        }
+        realloc_idx = try b.addAlias(.{ .instance_export = .{
+            .sort = .{ .core = .func },
+            .instance_idx = adapter_inst,
+            .name = "cabi_import_realloc",
+        } });
+    }
+
+    var fixup_inline = std.ArrayListUnmanaged(ctypes.CoreInlineExport).empty;
+
+    // shim's $imports table.
+    const table_idx = try b.addAlias(.{ .instance_export = .{
+        .sort = .{ .core = .table },
+        .instance_idx = shim_inst,
+        .name = "$imports",
+    } });
+    try fixup_inline.append(a, .{
+        .name = "$imports",
+        .sort_idx = .{ .sort = .table, .idx = table_idx },
+    });
+
+    // Funcs 0..P-1: adapter exports for embed's preview1 imports.
+    for (in.preview1_slots, 0..) |p1, i| {
+        if (in.adapter_iface.findExport(p1.name) == null) {
+            return error.AdapterMissingPreview1Export;
+        }
+        const f_idx = try b.addAlias(.{ .instance_export = .{
+            .sort = .{ .core = .func },
+            .instance_idx = adapter_inst,
+            .name = p1.name,
+        } });
+        const slot_name = try std.fmt.allocPrint(a, "{d}", .{i});
+        try fixup_inline.append(a, .{
+            .name = slot_name,
+            .sort_idx = .{ .sort = .func, .idx = f_idx },
+        });
+    }
+
+    // Funcs P..P+I-1: canon lower(memory, [realloc], [string-encoding])
+    // of each indirect adapter wasi import.
+    {
+        var indirect_idx: u32 = 0;
+        for (in.buckets) |bk| {
+            for (bk.indirect_funcs) |idf| {
+                const f_idx = try b.addAlias(.{ .instance_export = .{
+                    .sort = .func,
+                    .instance_idx = bk.instance_idx,
+                    .name = idf.name,
+                } });
+                const opts = try buildCanonLowerOpts(a, idf.cls.opts, memory_idx, realloc_idx);
+                const cf_idx = try b.addCanon(.{ .lower = .{
+                    .func_idx = f_idx,
+                    .opts = opts,
+                } });
+                const slot_total: u32 = @as(u32, @intCast(in.preview1_slots.len)) + indirect_idx;
+                const slot_name = try std.fmt.allocPrint(a, "{d}", .{slot_total});
+                try fixup_inline.append(a, .{
+                    .name = slot_name,
+                    .sort_idx = .{ .sort = .func, .idx = cf_idx },
+                });
+                indirect_idx += 1;
+            }
+        }
+    }
+
+    const fixup_bundle_inst = try b.addCoreInstance(.{ .exports = try fixup_inline.toOwnedSlice(a) });
+
+    // Instantiate fixup with bundle as `""` namespace.
+    const fixup_args = try a.alloc(ctypes.CoreInstantiateArg, 1);
+    fixup_args[0] = .{ .name = "", .instance_idx = fixup_bundle_inst };
+    _ = try b.addCoreInstance(.{ .instantiate = .{
+        .module_idx = fixup_module_idx,
+        .args = fixup_args,
+    } });
+
+    // ── Step 11: canon lift of wasi:cli/run@<ver>#run ────────────────
+    const run_ie = try findRunInstanceExport(in.hoisted, a);
+    if (in.adapter_iface.findExport(run_ie.core_export_name) == null) {
+        return error.AdapterMissingRunExport;
+    }
+    const run_core_func_idx = try b.addAlias(.{ .instance_export = .{
+        .sort = .{ .core = .func },
+        .instance_idx = adapter_inst,
+        .name = run_ie.core_export_name,
+    } });
+    const lifted_run_func_idx = try b.addCanon(.{ .lift = .{
+        .core_func_idx = run_core_func_idx,
+        .type_idx = run_func_type_idx,
+        .opts = &.{},
+    } });
+
+    // ── Step 12: inline sub-component wrapping `run` ────────────────
+    const sub = try buildRunSubComponent(a);
+    const sub_idx = try b.addNestedComponent(sub);
+
+    const sub_args = try a.alloc(ctypes.InstantiateArg, 1);
+    sub_args[0] = .{
+        .name = "import-func-run",
+        .sort_idx = .{ .sort = .func, .idx = lifted_run_func_idx },
+    };
+    const wrap_inst_idx = try b.addInstance(.{ .instantiate = .{
+        .component_idx = sub_idx,
+        .args = sub_args,
+    } });
+
+    // ── Step 13: top-level export ────────────────────────────────────
+    try b.addExport(.{
+        .name = run_ie.qualified_name,
+        .desc = .{ .instance = run_ie.body_type_idx },
+        .sort_idx = .{ .sort = .instance, .idx = wrap_inst_idx },
+    });
+
+    // ── Encode ───────────────────────────────────────────────────────
+    const comp = ctypes.Component{
+        .core_modules = try b.core_modules.toOwnedSlice(a),
+        .core_instances = try b.core_instances.toOwnedSlice(a),
+        .core_types = &.{},
+        .components = try b.components.toOwnedSlice(a),
+        .instances = try b.instances.toOwnedSlice(a),
+        .aliases = try b.aliases.toOwnedSlice(a),
+        .types = try b.types.toOwnedSlice(a),
+        .canons = try b.canons.toOwnedSlice(a),
+        .imports = try b.imports.toOwnedSlice(a),
+        .exports = try b.exports.toOwnedSlice(a),
+        .section_order = try b.section_order.toOwnedSlice(a),
+    };
+
+    return writer.encode(in.gpa, &comp);
+}
+
+fn buildCanonLowerOpts(
+    arena: Allocator,
+    o: abi.FuncOpts,
+    memory_core_idx: u32,
+    realloc_core_idx: u32,
+) SpliceError![]const ctypes.CanonOpt {
+    var n: usize = 0;
+    if (o.memory) n += 1;
+    if (o.realloc) n += 1;
+    if (o.string_encoding) n += 1;
+
+    const opts = try arena.alloc(ctypes.CanonOpt, n);
+    var i: usize = 0;
+    if (o.memory) {
+        opts[i] = .{ .memory = memory_core_idx };
+        i += 1;
+    }
+    if (o.realloc) {
+        opts[i] = .{ .realloc = realloc_core_idx };
+        i += 1;
+    }
+    if (o.string_encoding) {
+        opts[i] = .{ .string_encoding = .utf8 };
+        i += 1;
+    }
+    return opts;
+}
+
+const RunInstanceExport = struct {
+    qualified_name: []const u8,
+    core_export_name: []const u8,
+    body_type_idx: u32,
+};
+
+fn findRunInstanceExport(h: types_import.Hoisted, arena: Allocator) SpliceError!RunInstanceExport {
+    for (h.exports) |e| {
+        if (std.mem.startsWith(u8, e.name, "wasi:cli/run")) {
+            return .{
+                .qualified_name = e.name,
+                .core_export_name = try std.fmt.allocPrint(arena, "{s}#run", .{e.name}),
+                .body_type_idx = e.type_idx,
+            };
+        }
+    }
+    return error.AdapterMissingRunExport;
+}
+
+// ── Sub-component construction ────────────────────────────────────────────
+
+/// Build the inline sub-component that wraps a single imported func
+/// and re-exports it as `run`. Mirrors wit-component's layout:
+///
+///   (component
+///     (type (;0;) (result))
+///     (type (;1;) (func (result 0)))
+///     (import "import-func-run" (func (;0;) (type (eq 1))))
+///     (export (;1;) "run" (func 0)))
+fn buildRunSubComponent(arena: Allocator) SpliceError!*ctypes.Component {
+    const types_arr = try arena.alloc(ctypes.TypeDef, 2);
+    types_arr[0] = .{ .result = .{ .ok = null, .err = null } };
+    types_arr[1] = .{ .func = .{
+        .params = &.{},
+        .results = .{ .unnamed = .{ .type_idx = 0 } },
+    } };
+
+    const imports = try arena.alloc(ctypes.ImportDecl, 1);
+    imports[0] = .{ .name = "import-func-run", .desc = .{ .func = 1 } };
+
+    const exports = try arena.alloc(ctypes.ExportDecl, 1);
+    exports[0] = .{
+        .name = "run",
+        .desc = .{ .func = 1 },
+        .sort_idx = .{ .sort = .func, .idx = 0 },
+    };
+
+    const c = try arena.create(ctypes.Component);
+    c.* = .{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = types_arr,
+        .canons = &.{},
+        .imports = imports,
+        .exports = exports,
+    };
+    return c;
+}
+
+// ── Embed extra (non-WASI) imports ────────────────────────────────────────
+
+const EmbedExtraArg = struct {
+    /// Module name as the embed declared it (becomes the `<with>`
+    /// name on the embed's instantiation).
+    name: []const u8,
+    /// Core instance idx of the inline-export bundle satisfying it.
+    inst_idx: u32,
+};
+
+/// For each non-WASI-adapter module the embed imports, synthesize a
+/// top-level component instance import (with primitive-typed funcs
+/// derived from the core wasm sigs), canon-lower each func, and
+/// bundle the lowered funcs into a core instance the embed can
+/// consume. Returns one `EmbedExtraArg` per such module.
+///
+/// Works for primitive-only signatures (i32/i64/f32/f64). Funcs
+/// that need `string`/`list`/records cannot be expressed through
+/// this synthesis; for those the user should `wasm-tools component
+/// embed --world` first to embed a richer component-type and then
+/// use the no-adapter path.
+fn buildEmbedExtraImports(b: *Builder, a: Allocator, in: Inputs) SpliceError![]const EmbedExtraArg {
+    // Collect distinct namespaces in declaration order, excluding
+    // the adapter and the env / __main_module__ "alias" namespaces.
+    var ns_names = std.ArrayListUnmanaged([]const u8).empty;
+    var seen = std.StringHashMapUnmanaged(void).empty;
+    defer seen.deinit(a);
+
+    for (in.embed_iface.imports) |im| {
+        if (im.kind != .func) continue;
+        if (std.mem.eql(u8, im.module_name, in.adapter_name)) continue;
+        if (std.mem.eql(u8, im.module_name, "env")) continue;
+        if (std.mem.eql(u8, im.module_name, "__main_module__")) continue;
+        const gop = try seen.getOrPut(a, im.module_name);
+        if (!gop.found_existing) try ns_names.append(a, im.module_name);
+    }
+
+    if (ns_names.items.len == 0) return &.{};
+
+    var out = std.ArrayListUnmanaged(EmbedExtraArg).empty;
+
+    for (ns_names.items) |ns| {
+        // Gather funcs in this namespace.
+        var funcs = std.ArrayListUnmanaged(struct {
+            name: []const u8,
+            sig: core_imports.FuncSig,
+        }).empty;
+        for (in.embed_iface.imports) |im| {
+            if (im.kind != .func) continue;
+            if (!std.mem.eql(u8, im.module_name, ns)) continue;
+            const sig = im.sig orelse continue;
+            try funcs.append(a, .{ .name = im.field_name, .sig = sig });
+        }
+        if (funcs.items.len == 0) continue;
+
+        // Build the instance type: one (export "<name>" (func F))
+        // per func, with each func having a fresh component-level
+        // FuncType. Prefer pulling the FuncType verbatim from the
+        // embed's component-type if available (preserves original
+        // param names + non-primitive types). Otherwise synthesize
+        // a p0/p1-named primitive sig from the core import sig.
+        var inst_decls = std.ArrayListUnmanaged(ctypes.Decl).empty;
+        var local_type_idx: u32 = 0;
+        for (funcs.items) |f| {
+            const ft: ctypes.FuncType = lookupEmbedFuncType(in.embed_world, ns, f.name) orelse blk_ft: {
+                const params = try a.alloc(ctypes.NamedValType, f.sig.params.len);
+                for (f.sig.params, 0..) |p, pi| {
+                    const pname = try std.fmt.allocPrint(a, "p{d}", .{pi});
+                    params[pi] = .{ .name = pname, .type = coreToCompValType(p) };
+                }
+                const results: ctypes.FuncType.ResultList = if (f.sig.results.len == 0) .none else blk: {
+                    if (f.sig.results.len == 1) {
+                        break :blk .{ .unnamed = coreToCompValType(f.sig.results[0]) };
+                    }
+                    const named = try a.alloc(ctypes.NamedValType, f.sig.results.len);
+                    for (f.sig.results, 0..) |r, ri| {
+                        const rname = try std.fmt.allocPrint(a, "r{d}", .{ri});
+                        named[ri] = .{ .name = rname, .type = coreToCompValType(r) };
+                    }
+                    break :blk .{ .named = named };
+                };
+                break :blk_ft .{ .params = params, .results = results };
+            };
+
+            try inst_decls.append(a, .{ .type = .{ .func = ft } });
+            const ftype_idx = local_type_idx;
+            local_type_idx += 1;
+            try inst_decls.append(a, .{ .@"export" = .{
+                .name = f.name,
+                .desc = .{ .func = ftype_idx },
+            } });
+        }
+
+        const inst_type_idx = try b.addType(.{ .instance = .{
+            .decls = try inst_decls.toOwnedSlice(a),
+        } });
+        const imp_inst_idx = try b.addImport(.{
+            .name = ns,
+            .desc = .{ .instance = inst_type_idx },
+        });
+
+        // For each func: alias from the imported instance, canon
+        // lower (no opts — primitives only).
+        var inline_exps = std.ArrayListUnmanaged(ctypes.CoreInlineExport).empty;
+        for (funcs.items) |f| {
+            const fn_idx = try b.addAlias(.{ .instance_export = .{
+                .sort = .func,
+                .instance_idx = imp_inst_idx,
+                .name = f.name,
+            } });
+            const cf_idx = try b.addCanon(.{ .lower = .{
+                .func_idx = fn_idx,
+                .opts = &.{},
+            } });
+            try inline_exps.append(a, .{
+                .name = f.name,
+                .sort_idx = .{ .sort = .func, .idx = cf_idx },
+            });
+        }
+
+        const bundle_inst = try b.addCoreInstance(.{ .exports = try inline_exps.toOwnedSlice(a) });
+        try out.append(a, .{ .name = ns, .inst_idx = bundle_inst });
+    }
+
+    return out.toOwnedSlice(a);
+}
+
+fn coreToCompValType(v: wtypes.ValType) ctypes.ValType {
+    return switch (v) {
+        .i32 => .u32,
+        .i64 => .u64,
+        .f32 => .f32,
+        .f64 => .f64,
+        else => .u32,
+    };
+}
+
+/// Walk the embed's world body to find an exported func type by
+/// `(namespace, func_name)`. Returns null if not present (e.g. the
+/// embed has no `component-type` section, the namespace isn't an
+/// instance import, or the export wasn't found).
+fn lookupEmbedFuncType(maybe_world: ?decode.AdapterWorld, ns: []const u8, func_name: []const u8) ?ctypes.FuncType {
+    const w = maybe_world orelse return null;
+    for (w.imports) |im| {
+        if (!std.mem.eql(u8, im.name, ns)) continue;
+        const inst_td = resolveTypeIdxAtTopLevel(w.body_decls, im.body_type_idx) orelse return null;
+        if (inst_td != .instance) return null;
+        for (inst_td.instance.decls) |d| switch (d) {
+            .@"export" => |e| {
+                if (e.desc != .func) continue;
+                if (!std.mem.eql(u8, e.name, func_name)) continue;
+                const ftd = resolveTypeIdxAtTopLevel(inst_td.instance.decls, e.desc.func) orelse return null;
+                if (ftd != .func) return null;
+                return ftd.func;
+            },
+            else => {},
+        };
+        return null;
+    }
+    return null;
+}
+
+/// Walk a decl list and return the TypeDef at the given indexspace
+/// position, following `(eq …)` aliases inside the same scope.
+/// Used at "top level" (a world body or instance body) where there
+/// is no outer alias chain to follow.
+fn resolveTypeIdxAtTopLevel(decls: []const ctypes.Decl, target: u32) ?ctypes.TypeDef {
+    var cursor: u32 = 0;
+    for (decls) |d| switch (d) {
+        .type => |td| {
+            if (cursor == target) return td;
+            cursor += 1;
+        },
+        .core_type => cursor += 1,
+        .alias => |al| {
+            const sort: ctypes.Sort = switch (al) {
+                .instance_export => |ie| ie.sort,
+                .outer => |o| o.sort,
+            };
+            if (sort == .type) {
+                if (cursor == target) {
+                    return switch (al) {
+                        .outer => |o| if (o.sort == .type)
+                            resolveTypeIdxAtTopLevel(decls, o.idx)
+                        else
+                            null,
+                        else => null,
+                    };
+                }
+                cursor += 1;
+            }
+        },
+        .@"export" => |e| {
+            if (e.desc == .type) {
+                if (cursor == target) {
+                    return switch (e.desc.type) {
+                        .eq => |i| resolveTypeIdxAtTopLevel(decls, i),
+                        .sub_resource => ctypes.TypeDef{ .resource = .{} },
+                    };
+                }
+                cursor += 1;
+            }
+        },
+        else => {},
+    };
+    return null;
+}
+
+
+
+/// Synthesize a tiny core module that exports trapping versions of
+/// every `__main_module__.<name>` import the adapter requires that
+/// the embed doesn't already export.
+///
+/// For embeds that don't export `cabi_realloc` (very common — Zig
+/// and Rust wasip1 builds usually don't), the adapter still imports
+/// it as a code dependency. We materialise a trap stub: when the
+/// adapter actually invokes it (which only happens when call args
+/// or results need realloc'd buffers, neither of which is exercised
+/// by hello-world style programs), the trap surfaces as a clean
+/// runtime error rather than silent miscompilation.
+// ── Main-module fallback synthesizer ──────────────────────────────────────
+fn buildMainModuleFallback(arena: Allocator, adapter_iface: core_imports.CoreInterface) SpliceError![]u8 {
+    var out = std.ArrayListUnmanaged(u8).empty;
+    try out.appendSlice(arena, &.{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 });
+
+    var unique_sigs = std.ArrayListUnmanaged(core_imports.FuncSig).empty;
+    var sig_for_export = std.ArrayListUnmanaged(struct {
+        name: []const u8,
+        sig_idx: u32,
+    }).empty;
+
+    for (adapter_iface.imports) |im| {
+        if (im.kind != .func) continue;
+        if (!std.mem.eql(u8, im.module_name, "__main_module__")) continue;
+        const sig = im.sig orelse continue;
+
+        var found: ?u32 = null;
+        for (unique_sigs.items, 0..) |u, i| {
+            if (sigEql(u, sig)) {
+                found = @intCast(i);
+                break;
+            }
+        }
+        const idx = found orelse blk: {
+            const i: u32 = @intCast(unique_sigs.items.len);
+            try unique_sigs.append(arena, sig);
+            break :blk i;
+        };
+        try sig_for_export.append(arena, .{ .name = im.field_name, .sig_idx = idx });
+    }
+
+    if (sig_for_export.items.len == 0) {
+        // Nothing to synthesize. Caller shouldn't have asked.
+        try writeSection(arena, &out, 0x01, &.{0x00});
+        return out.toOwnedSlice(arena);
+    }
+
+    // type section
+    {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        try writeU32Leb(arena, &body, @intCast(unique_sigs.items.len));
+        for (unique_sigs.items) |s| {
+            try body.append(arena, 0x60);
+            try writeU32Leb(arena, &body, @intCast(s.params.len));
+            for (s.params) |p| try body.append(arena, valTypeByte(p));
+            try writeU32Leb(arena, &body, @intCast(s.results.len));
+            for (s.results) |r| try body.append(arena, valTypeByte(r));
+        }
+        try writeSection(arena, &out, 0x01, body.items);
+    }
+
+    // function section: one func per export, all using its sig idx
+    {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        try writeU32Leb(arena, &body, @intCast(sig_for_export.items.len));
+        for (sig_for_export.items) |se| try writeU32Leb(arena, &body, se.sig_idx);
+        try writeSection(arena, &out, 0x03, body.items);
+    }
+
+    // export section
+    {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        try writeU32Leb(arena, &body, @intCast(sig_for_export.items.len));
+        for (sig_for_export.items, 0..) |se, fi| {
+            try writeU32Leb(arena, &body, @intCast(se.name.len));
+            try body.appendSlice(arena, se.name);
+            try body.append(arena, 0x00); // export desc: func
+            try writeU32Leb(arena, &body, @intCast(fi));
+        }
+        try writeSection(arena, &out, 0x07, body.items);
+    }
+
+    // code section: each body = `unreachable; end`
+    {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        try writeU32Leb(arena, &body, @intCast(sig_for_export.items.len));
+        for (sig_for_export.items) |_| {
+            // body: locals_count=0 (LEB 0), unreachable (0x00), end (0x0b)
+            const fb = [_]u8{ 0x00, 0x00, 0x0b };
+            try writeU32Leb(arena, &body, @intCast(fb.len));
+            try body.appendSlice(arena, &fb);
+        }
+        try writeSection(arena, &out, 0x0a, body.items);
+    }
+
+    return out.toOwnedSlice(arena);
+}
+
+fn sigEql(a: core_imports.FuncSig, b: core_imports.FuncSig) bool {
+    return std.mem.eql(wtypes.ValType, a.params, b.params) and
+        std.mem.eql(wtypes.ValType, a.results, b.results);
+}
+
+fn valTypeByte(v: wtypes.ValType) u8 {
+    return switch (v) {
+        .i32 => 0x7f,
+        .i64 => 0x7e,
+        .f32 => 0x7d,
+        .f64 => 0x7c,
+        else => 0x7f,
+    };
+}
+
+fn writeSection(arena: Allocator, out: *std.ArrayListUnmanaged(u8), id: u8, body: []const u8) SpliceError!void {
+    try out.append(arena, id);
+    try writeU32Leb(arena, out, @intCast(body.len));
+    try out.appendSlice(arena, body);
+}
+
+// ── Custom-section stripping ──────────────────────────────────────────────
+
+/// Strip `component-type:*` custom sections from a core wasm binary.
+fn stripComponentTypeSections(arena: Allocator, core_bytes: []const u8) SpliceError![]u8 {
+    if (core_bytes.len < 8) return error.InvalidAdapterCore;
+    if (!std.mem.eql(u8, core_bytes[0..4], "\x00asm")) return error.InvalidAdapterCore;
+
+    var out = std.ArrayListUnmanaged(u8).empty;
+    try out.appendSlice(arena, core_bytes[0..8]);
+
+    var i: usize = 8;
+    while (i < core_bytes.len) {
+        const id = core_bytes[i];
+        i += 1;
+        const sz = try readU32Leb(core_bytes, i);
+        i += sz.bytes_read;
+        if (i + sz.value > core_bytes.len) return error.InvalidAdapterCore;
+        const body = core_bytes[i .. i + sz.value];
+        i += sz.value;
+
+        if (id == 0 and body.len > 0) {
+            const n = readU32Leb(body, 0) catch return error.InvalidAdapterCore;
+            if (n.bytes_read + n.value <= body.len) {
+                const sec_name = body[n.bytes_read .. n.bytes_read + n.value];
+                if (std.mem.startsWith(u8, sec_name, "component-type:")) continue;
+            }
+        }
+        try out.append(arena, id);
+        try writeU32Leb(arena, &out, sz.value);
+        try out.appendSlice(arena, body);
+    }
+    return out.toOwnedSlice(arena);
+}
+
+const LebRead = struct { value: u32, bytes_read: usize };
+
+fn readU32Leb(buf: []const u8, start: usize) SpliceError!LebRead {
+    var result: u32 = 0;
+    var shift: u5 = 0;
+    var i: usize = start;
+    while (i < buf.len) : (i += 1) {
+        const b = buf[i];
+        result |= @as(u32, b & 0x7f) << shift;
+        if ((b & 0x80) == 0) {
+            return .{ .value = result, .bytes_read = i + 1 - start };
+        }
+        if (shift >= 25) return error.LebOverflow;
+        shift += 7;
+    }
+    return error.LebTruncated;
+}
+
+fn writeU32Leb(arena: Allocator, out: *std.ArrayListUnmanaged(u8), v: u32) SpliceError!void {
+    var x = v;
+    while (true) {
+        var byte: u8 = @intCast(x & 0x7f);
+        x >>= 7;
+        if (x != 0) byte |= 0x80;
+        try out.append(arena, byte);
+        if (x == 0) break;
+    }
+}

--- a/src/component/adapter/adapter.zig
+++ b/src/component/adapter/adapter.zig
@@ -1308,3 +1308,128 @@ fn writeU32Leb(arena: Allocator, out: *std.ArrayListUnmanaged(u8), v: u32) Splic
         if (x == 0) break;
     }
 }
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "stripComponentTypeSections: drops component-type custom, keeps others" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var src = std.ArrayListUnmanaged(u8).empty;
+    try src.appendSlice(arena, &.{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 });
+
+    // custom section "component-type:wit-bindgen:0.43.0:foo:encoded world"
+    {
+        const name = "component-type:wit-bindgen:0.43.0:foo:encoded world";
+        var body = std.ArrayListUnmanaged(u8).empty;
+        try writeU32Leb(arena, &body, @intCast(name.len));
+        try body.appendSlice(arena, name);
+        try body.appendSlice(arena, "payload");
+        try writeSection(arena, &src, 0x00, body.items);
+    }
+    // unrelated custom section "name"
+    {
+        const name = "name";
+        var body = std.ArrayListUnmanaged(u8).empty;
+        try writeU32Leb(arena, &body, @intCast(name.len));
+        try body.appendSlice(arena, name);
+        try body.appendSlice(arena, "\x00\x00");
+        try writeSection(arena, &src, 0x00, body.items);
+    }
+    // unrelated bare custom "component-type" (intentionally NOT prefixed
+    // with "component-type:" — strip should leave it alone).
+    {
+        const name = "component-type";
+        var body = std.ArrayListUnmanaged(u8).empty;
+        try writeU32Leb(arena, &body, @intCast(name.len));
+        try body.appendSlice(arena, name);
+        try body.appendSlice(arena, "embed-payload");
+        try writeSection(arena, &src, 0x00, body.items);
+    }
+
+    const stripped = try stripComponentTypeSections(arena, src.items);
+
+    // Magic + version preserved.
+    try testing.expectEqualSlices(u8, src.items[0..8], stripped[0..8]);
+    // The dropped section's payload should not appear.
+    try testing.expect(std.mem.indexOf(u8, stripped, "wit-bindgen") == null);
+    // The kept sections' payloads should both still appear.
+    try testing.expect(std.mem.indexOf(u8, stripped, "name") != null);
+    try testing.expect(std.mem.indexOf(u8, stripped, "embed-payload") != null);
+}
+
+test "stripComponentTypeSections: rejects non-core bytes" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    try testing.expectError(error.InvalidAdapterCore, stripComponentTypeSections(arena, "not-wasm"));
+}
+
+test "buildMainModuleFallback: synthesizes trapping export per __main_module__ import" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const realloc_params = [_]wtypes.ValType{ .i32, .i32, .i32, .i32 };
+    const realloc_results = [_]wtypes.ValType{.i32};
+    const start_params = [_]wtypes.ValType{};
+    const start_results = [_]wtypes.ValType{};
+    const imports = [_]core_imports.ImportEntry{
+        .{
+            .module_name = "__main_module__",
+            .field_name = "cabi_realloc",
+            .kind = .func,
+            .sig = .{ .params = &realloc_params, .results = &realloc_results },
+        },
+        .{
+            .module_name = "__main_module__",
+            .field_name = "_start",
+            .kind = .func,
+            .sig = .{ .params = &start_params, .results = &start_results },
+        },
+        // Non-__main_module__ imports must be ignored.
+        .{
+            .module_name = "wasi:cli/environment@0.2.6",
+            .field_name = "get-environment",
+            .kind = .func,
+            .sig = .{ .params = &start_params, .results = &start_results },
+        },
+    };
+    const iface = core_imports.CoreInterface{
+        .imports = &imports,
+        .exports = &.{},
+    };
+
+    const wasm = try buildMainModuleFallback(arena, iface);
+
+    // The result is a valid core wasm and re-parses through core_imports.
+    var owned = try core_imports.extract(testing.allocator, wasm);
+    defer owned.deinit();
+
+    // Two exports, one per __main_module__ import; their sigs match.
+    try testing.expectEqual(@as(usize, 2), owned.interface.exports.len);
+
+    const realloc_e = owned.interface.findExport("cabi_realloc") orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(wtypes.ExternalKind.func, realloc_e.kind);
+    try testing.expect(realloc_e.sig != null);
+    try testing.expectEqualSlices(wtypes.ValType, &realloc_params, realloc_e.sig.?.params);
+    try testing.expectEqualSlices(wtypes.ValType, &realloc_results, realloc_e.sig.?.results);
+
+    const start_e = owned.interface.findExport("_start") orelse return error.TestUnexpectedResult;
+    try testing.expect(start_e.sig != null);
+    try testing.expectEqual(@as(usize, 0), start_e.sig.?.params.len);
+    try testing.expectEqual(@as(usize, 0), start_e.sig.?.results.len);
+
+    // The unrelated wasi import must NOT have been turned into an export.
+    try testing.expect(owned.interface.findExport("get-environment") == null);
+}
+
+test "coreToCompValType: maps numeric wasm types to component analogues" {
+    try testing.expectEqual(ctypes.ValType.u32, coreToCompValType(.i32));
+    try testing.expectEqual(ctypes.ValType.u64, coreToCompValType(.i64));
+    try testing.expectEqual(ctypes.ValType.f32, coreToCompValType(.f32));
+    try testing.expectEqual(ctypes.ValType.f64, coreToCompValType(.f64));
+}

--- a/src/component/adapter/core_imports.zig
+++ b/src/component/adapter/core_imports.zig
@@ -1,0 +1,324 @@
+//! Extract core-wasm import / export tables from the adapter binary.
+//!
+//! The splicer needs to know:
+//!
+//!   * Every `(import "<module>" "<name>" func ...)` the adapter
+//!     declares — these drive shim/fixup synthesis (preview1 imports
+//!     get trapping stubs in the shim, then patched up by the fixup
+//!     start function) and the `canon lower` choreography for the
+//!     adapter's WASI imports.
+//!
+//!   * Every `(export "<name>" ...)` — specifically the
+//!     `wasi_snapshot_preview1.<name>` exports the adapter publishes
+//!     and the `wasi:cli/run@<ver>#run` style exports that the
+//!     wrapping component lifts.
+//!
+//! This module is a thin façade over `binary/reader.zig` — it parses
+//! the adapter core wasm into a `Module` and reorganises the
+//! relevant slices into a flat `CoreInterface` value with stable
+//! views (string/sig data still owns from the underlying `Module`).
+//! Callers must keep the `Module` alive for the lifetime of any
+//! returned slice (we expose a small `Owned` wrapper that bundles
+//! the two so callers don't accidentally free the backing buffer).
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const reader = @import("../../binary/reader.zig");
+const Module = @import("../../Module.zig").Module;
+const wtypes = @import("../../types.zig");
+
+pub const Error = reader.ReadError || error{NotCoreWasm};
+
+pub const FuncSig = struct {
+    params: []const wtypes.ValType,
+    results: []const wtypes.ValType,
+};
+
+pub const ImportEntry = struct {
+    module_name: []const u8,
+    field_name: []const u8,
+    /// Only `.func` is interesting for the splicer; other kinds
+    /// (table/memory/global) are surfaced for completeness so a
+    /// caller can warn-and-skip.
+    kind: wtypes.ExternalKind,
+    /// Function signature when `kind == .func`, else null.
+    sig: ?FuncSig,
+};
+
+pub const ExportEntry = struct {
+    name: []const u8,
+    kind: wtypes.ExternalKind,
+    /// Function signature when `kind == .func`, else null.
+    sig: ?FuncSig,
+};
+
+pub const CoreInterface = struct {
+    imports: []const ImportEntry,
+    exports: []const ExportEntry,
+
+    /// Iterate imports whose module field equals `module_name`.
+    pub fn importsFromModule(
+        self: CoreInterface,
+        module_name: []const u8,
+    ) ImportFromIterator {
+        return .{ .all = self.imports, .filter = module_name, .i = 0 };
+    }
+
+    pub const ImportFromIterator = struct {
+        all: []const ImportEntry,
+        filter: []const u8,
+        i: usize,
+
+        pub fn next(self: *ImportFromIterator) ?ImportEntry {
+            while (self.i < self.all.len) : (self.i += 1) {
+                const e = self.all[self.i];
+                if (std.mem.eql(u8, e.module_name, self.filter)) {
+                    self.i += 1;
+                    return e;
+                }
+            }
+            return null;
+        }
+    };
+
+    /// Lookup exactly one export by name. Returns null if absent.
+    pub fn findExport(self: CoreInterface, name: []const u8) ?ExportEntry {
+        for (self.exports) |e| if (std.mem.eql(u8, e.name, name)) return e;
+        return null;
+    }
+};
+
+/// Owned bundle: the parsed `Module` plus a `CoreInterface` whose
+/// slices borrow from it. Free with `deinit`.
+pub const Owned = struct {
+    module: Module,
+    interface: CoreInterface,
+    arena: std.heap.ArenaAllocator,
+
+    pub fn deinit(self: *Owned) void {
+        self.module.deinit();
+        self.arena.deinit();
+    }
+};
+
+/// Parse an adapter core wasm and extract its import/export tables.
+///
+/// `gpa` is used both for the underlying `Module` parse and for an
+/// arena that holds the `CoreInterface` slices. Callers `deinit` the
+/// returned `Owned` value when done.
+pub fn extract(gpa: Allocator, core_bytes: []const u8) Error!Owned {
+    if (core_bytes.len < 8 or !std.mem.eql(u8, core_bytes[0..4], "\x00asm")) {
+        return error.NotCoreWasm;
+    }
+
+    var module = try reader.readModule(gpa, core_bytes);
+    errdefer module.deinit();
+
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    errdefer arena.deinit();
+    const a = arena.allocator();
+
+    const imports = try a.alloc(ImportEntry, module.imports.items.len);
+    for (module.imports.items, 0..) |im, i| {
+        imports[i] = .{
+            .module_name = im.module_name,
+            .field_name = im.field_name,
+            .kind = im.kind,
+            .sig = if (im.kind == .func and im.func != null)
+                lookupFuncSig(&module, im.func.?.type_var.index)
+            else
+                null,
+        };
+    }
+
+    var exports_list = std.ArrayListUnmanaged(ExportEntry).empty;
+    try exports_list.ensureTotalCapacity(a, module.exports.items.len);
+    for (module.exports.items) |ex| {
+        var sig: ?FuncSig = null;
+        if (ex.kind == .func) {
+            const fidx = ex.var_.index;
+            if (fidx < module.funcs.items.len) {
+                const f = module.funcs.items[fidx];
+                sig = lookupFuncSig(&module, f.decl.type_var.index);
+            }
+        }
+        exports_list.appendAssumeCapacity(.{
+            .name = ex.name,
+            .kind = ex.kind,
+            .sig = sig,
+        });
+    }
+
+    return .{
+        .module = module,
+        .arena = arena,
+        .interface = .{
+            .imports = imports,
+            .exports = try exports_list.toOwnedSlice(a),
+        },
+    };
+}
+
+/// Resolve a func type index to its signature via the module's type
+/// table. Returns null on out-of-bounds or non-func type entry —
+/// shouldn't happen for a validated module but the splicer prefers a
+/// soft failure to surfacing internal indices to its callers.
+fn lookupFuncSig(module: *const Module, type_idx: u32) ?FuncSig {
+    if (type_idx >= module.module_types.items.len) return null;
+    const entry = module.module_types.items[type_idx];
+    return switch (entry) {
+        .func_type => |ft| .{ .params = ft.params, .results = ft.results },
+        else => null,
+    };
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+const leb = @import("../../leb128.zig");
+
+/// Hand-build a tiny core wasm with one type, one import
+/// (`adapter_in.ping: () -> i32`), and one func/export
+/// (`wasi_snapshot_preview1.fd_write: (i32, i32, i32, i32) -> i32`).
+fn buildMockAdapterCore(allocator: Allocator) ![]u8 {
+    var out = std.ArrayListUnmanaged(u8).empty;
+    defer out.deinit(allocator);
+
+    // Magic + version
+    try out.appendSlice(allocator, &.{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 });
+
+    const Section = struct {
+        fn write(buf: *std.ArrayListUnmanaged(u8), alloc: Allocator, id: u8, body: []const u8) !void {
+            try buf.append(alloc, id);
+            var len_buf: [leb.max_u32_bytes]u8 = undefined;
+            const n = leb.writeU32Leb128(&len_buf, @intCast(body.len));
+            try buf.appendSlice(alloc, len_buf[0..n]);
+            try buf.appendSlice(alloc, body);
+        }
+    };
+
+    // Type section: 2 types — () -> i32 and (i32 i32 i32 i32) -> i32
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02); // count
+        // type 0: () -> i32
+        try b.append(allocator, 0x60); // func
+        try b.append(allocator, 0x00); // 0 params
+        try b.append(allocator, 0x01); // 1 result
+        try b.append(allocator, 0x7f); // i32
+        // type 1: (i32 i32 i32 i32) -> i32
+        try b.append(allocator, 0x60);
+        try b.append(allocator, 0x04);
+        try b.appendSlice(allocator, &.{ 0x7f, 0x7f, 0x7f, 0x7f });
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x7f);
+        try Section.write(&out, allocator, 0x01, b.items);
+    }
+
+    // Import section: adapter_in.ping (typeidx 0)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01); // count
+        const mod_name = "adapter_in";
+        const fld_name = "ping";
+        try b.append(allocator, @intCast(mod_name.len));
+        try b.appendSlice(allocator, mod_name);
+        try b.append(allocator, @intCast(fld_name.len));
+        try b.appendSlice(allocator, fld_name);
+        try b.append(allocator, 0x00); // import desc: func
+        try b.append(allocator, 0x00); // typeidx 0
+        try Section.write(&out, allocator, 0x02, b.items);
+    }
+
+    // Function section: 1 func with type idx 1
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x01); // typeidx 1
+        try Section.write(&out, allocator, 0x03, b.items);
+    }
+
+    // Export section: "wasi_snapshot_preview1.fd_write" -> func idx 1
+    // (idx 0 is the imported `adapter_in.ping`; defined func is idx 1)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        const ex_name = "wasi_snapshot_preview1.fd_write";
+        try b.append(allocator, @intCast(ex_name.len));
+        try b.appendSlice(allocator, ex_name);
+        try b.append(allocator, 0x00); // export desc: func
+        try b.append(allocator, 0x01); // funcidx 1
+        try Section.write(&out, allocator, 0x07, b.items);
+    }
+
+    // Code section: the defined func is `i32.const 0; end`
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);                     // 1 body
+        try b.append(allocator, 0x04);                     // body size
+        try b.append(allocator, 0x00);                     // 0 locals
+        try b.appendSlice(allocator, &.{ 0x41, 0x00, 0x0b }); // i32.const 0; end
+        try Section.write(&out, allocator, 0x0a, b.items);
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+test "extract: surfaces imports and exports with sigs" {
+    const core = try buildMockAdapterCore(testing.allocator);
+    defer testing.allocator.free(core);
+
+    var owned = try extract(testing.allocator, core);
+    defer owned.deinit();
+
+    try testing.expectEqual(@as(usize, 1), owned.interface.imports.len);
+    try testing.expectEqualStrings("adapter_in", owned.interface.imports[0].module_name);
+    try testing.expectEqualStrings("ping", owned.interface.imports[0].field_name);
+    try testing.expectEqual(wtypes.ExternalKind.func, owned.interface.imports[0].kind);
+    try testing.expect(owned.interface.imports[0].sig != null);
+    try testing.expectEqual(@as(usize, 0), owned.interface.imports[0].sig.?.params.len);
+    try testing.expectEqual(@as(usize, 1), owned.interface.imports[0].sig.?.results.len);
+
+    try testing.expectEqual(@as(usize, 1), owned.interface.exports.len);
+    try testing.expectEqualStrings("wasi_snapshot_preview1.fd_write", owned.interface.exports[0].name);
+    try testing.expect(owned.interface.exports[0].sig != null);
+    try testing.expectEqual(@as(usize, 4), owned.interface.exports[0].sig.?.params.len);
+}
+
+test "extract: importsFromModule iterator filters correctly" {
+    const core = try buildMockAdapterCore(testing.allocator);
+    defer testing.allocator.free(core);
+
+    var owned = try extract(testing.allocator, core);
+    defer owned.deinit();
+
+    var it = owned.interface.importsFromModule("adapter_in");
+    var n: usize = 0;
+    while (it.next() != null) : (n += 1) {}
+    try testing.expectEqual(@as(usize, 1), n);
+
+    it = owned.interface.importsFromModule("not_a_module");
+    try testing.expect(it.next() == null);
+}
+
+test "extract: findExport works" {
+    const core = try buildMockAdapterCore(testing.allocator);
+    defer testing.allocator.free(core);
+
+    var owned = try extract(testing.allocator, core);
+    defer owned.deinit();
+
+    const e = owned.interface.findExport("wasi_snapshot_preview1.fd_write");
+    try testing.expect(e != null);
+    try testing.expect(owned.interface.findExport("missing") == null);
+}
+
+test "extract: rejects non-core wasm bytes" {
+    try testing.expectError(error.NotCoreWasm, extract(testing.allocator, "\x00\x00\x00\x00\x01\x00\x00\x00"));
+}

--- a/src/component/adapter/decode.zig
+++ b/src/component/adapter/decode.zig
@@ -125,14 +125,16 @@ pub fn extractEncodedWorld(adapter_core_bytes: []const u8) DecodeError!?[]const 
         const name_len = n.value;
         if (n.bytes_read + name_len > body.len) return error.InvalidAdapterCore;
         const sec_name = body[n.bytes_read .. n.bytes_read + name_len];
-        // Match by suffix to track wit-bindgen version drift.
+        // Match either the wit-bindgen-style `:encoded world`
+        // suffix (used by adapters) or the bare `component-type`
+        // name (used by `wasm-tools component embed --world …`).
         const suffix = ":encoded world";
-        if (sec_name.len < suffix.len) continue;
-        if (!std.mem.eql(u8, sec_name[sec_name.len - suffix.len ..], suffix)) continue;
-        // Custom section also requires the conventional
-        // `component-type:` prefix to avoid matching unrelated
-        // customs that happen to end in `:encoded world`.
-        if (!std.mem.startsWith(u8, sec_name, "component-type:")) continue;
+        const prefix = "component-type:";
+        const is_encoded_world = sec_name.len >= suffix.len and
+            std.mem.eql(u8, sec_name[sec_name.len - suffix.len ..], suffix) and
+            std.mem.startsWith(u8, sec_name, prefix);
+        const is_bare = std.mem.eql(u8, sec_name, "component-type");
+        if (!is_encoded_world and !is_bare) continue;
         return body[n.bytes_read + name_len ..];
     }
     return null;

--- a/src/component/adapter/decode.zig
+++ b/src/component/adapter/decode.zig
@@ -1,0 +1,343 @@
+//! Decode the WASI preview1 → component adapter's metadata.
+//!
+//! The wasi-preview1 adapter is a core wasm module produced by
+//! `wit-bindgen` from the wasmtime tree. It carries an embedded
+//! `component-type:wit-bindgen:<ver>:wasi:cli@<ver>:command:encoded
+//! world` custom section whose payload is itself a component binary
+//! describing the full WASI 0.2.6 type tree, every component-level
+//! instance the adapter consumes (`wasi:cli/environment@0.2.6` etc.),
+//! and the `wasi:cli/run@0.2.6` instance the adapter exports.
+//!
+//! This module:
+//!
+//!   * locates the `…:encoded world` custom section by suffix match
+//!     (the `wit-bindgen:<ver>` prefix changes between releases — we
+//!     match the trailing `":encoded world"` so future-version
+//!     adapters are accepted unchanged),
+//!   * loads the payload through wabt's existing component loader
+//!     (which already handles resources, compound types, and outer
+//!     aliases — verified empirically against the v36.0.9 adapter),
+//!   * walks the decoded shape and returns a flat `AdapterWorld` the
+//!     splicer can hoist into the wrapping component's top-level
+//!     section list.
+//!
+//! The shape we expect (matches every adapter we've seen and is
+//! invariant under the wit-component encoding rule):
+//!
+//!   types[0]    = component-type — the OUTER WRAPPER
+//!     decls[0]  = type = component-type — the WORLD BODY
+//!       (interleaved type defs / imports / alias-export decls)
+//!     decls[1]  = export "<world-qualified-name>" component 0
+//!   exports[0]  = "<world-name>" type=eq{0}    (top-level)
+//!
+//! Anything that doesn't match is rejected with
+//! `error.UnsupportedAdapterShape` — the splicer is brittle enough
+//! that bailing early with a clear error is preferable to producing
+//! a malformed wrapping component.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const ctypes = @import("../types.zig");
+const loader = @import("../loader.zig");
+const leb128 = @import("../../leb128.zig");
+
+pub const DecodeError = error{
+    InvalidAdapterCore,
+    MissingEncodedWorld,
+    UnsupportedAdapterShape,
+} || loader.LoadError;
+
+/// One import the adapter declares at the world level.
+pub const ImportEntry = struct {
+    /// Qualified name on the wire, e.g. `wasi:cli/environment@0.2.6`.
+    name: []const u8,
+    /// Index of the `.import` decl within
+    /// `AdapterWorld.body_decls`. The preceding entry is the
+    /// `.type = .{ .instance = … }` that types this import.
+    body_decl_idx: u32,
+    /// Index into the world body's *type indexspace* of the instance
+    /// type used by this import. Equal to the count of type-producing
+    /// decls (type/alias) preceding `body_decl_idx`.
+    body_type_idx: u32,
+    /// Component-instance-indexspace position of this import within
+    /// the world body. Imports appear in declaration order and are
+    /// the only contributors to the instance indexspace inside a
+    /// component-type body, so this is just the running import count.
+    body_instance_idx: u32,
+};
+
+/// One export the adapter declares at the world level.
+pub const ExportEntry = struct {
+    name: []const u8,
+    body_decl_idx: u32,
+    body_type_idx: u32,
+};
+
+/// Parsed shape of the adapter's `:encoded world` payload.
+///
+/// `component`, `body_decls`, and the `*name` slices all borrow from
+/// the arena passed to `parse`.
+pub const AdapterWorld = struct {
+    /// The fully-loaded component carried by the adapter's
+    /// `:encoded world` custom section. Useful as a witness that the
+    /// payload was loadable; callers should reach decls via
+    /// `body_decls` to keep the index math consistent.
+    component: ctypes.Component,
+    /// Decl list of the world body (the inner component-type inside
+    /// the outer wrapper).
+    body_decls: []const ctypes.Decl,
+    /// Number of slots in the world body's type indexspace —
+    /// produced by every `.type` def, `.core_type` def, and `.alias`
+    /// of sort `.type`. Equal to the type-idx the next type-producing
+    /// decl would occupy.
+    body_type_count: u32,
+    /// All imports declared by the world body, in declaration order.
+    imports: []const ImportEntry,
+    /// All exports declared by the world body. Adapters typically
+    /// have exactly one export (`wasi:cli/run@0.2.6` for the command
+    /// adapter); the array is kept open to also accommodate adapters
+    /// that export multiple instances (e.g. command + something else).
+    exports: []const ExportEntry,
+    /// Qualified world name, e.g. `wasi:cli/command@0.2.6`. Pulled
+    /// from the outer wrapper's export decl.
+    world_qualified_name: []const u8,
+};
+
+/// Locate the `…:encoded world` custom section in an adapter's core
+/// wasm and return its payload (the inner component bytes).
+pub fn extractEncodedWorld(adapter_core_bytes: []const u8) DecodeError!?[]const u8 {
+    if (adapter_core_bytes.len < 8) return error.InvalidAdapterCore;
+    if (!std.mem.eql(u8, adapter_core_bytes[0..4], "\x00asm")) return error.InvalidAdapterCore;
+
+    var i: usize = 8;
+    while (i < adapter_core_bytes.len) {
+        const id = adapter_core_bytes[i];
+        i += 1;
+        const sz = readU32Leb(adapter_core_bytes, i) catch return error.InvalidAdapterCore;
+        i += sz.bytes_read;
+        if (i + sz.value > adapter_core_bytes.len) return error.InvalidAdapterCore;
+        const body = adapter_core_bytes[i .. i + sz.value];
+        i += sz.value;
+
+        if (id != 0) continue;
+        const n = readU32Leb(body, 0) catch return error.InvalidAdapterCore;
+        const name_len = n.value;
+        if (n.bytes_read + name_len > body.len) return error.InvalidAdapterCore;
+        const sec_name = body[n.bytes_read .. n.bytes_read + name_len];
+        // Match by suffix to track wit-bindgen version drift.
+        const suffix = ":encoded world";
+        if (sec_name.len < suffix.len) continue;
+        if (!std.mem.eql(u8, sec_name[sec_name.len - suffix.len ..], suffix)) continue;
+        // Custom section also requires the conventional
+        // `component-type:` prefix to avoid matching unrelated
+        // customs that happen to end in `:encoded world`.
+        if (!std.mem.startsWith(u8, sec_name, "component-type:")) continue;
+        return body[n.bytes_read + name_len ..];
+    }
+    return null;
+}
+
+/// Parse a `:encoded world` payload into a flat `AdapterWorld`.
+/// Slices in the result borrow from `arena`.
+pub fn parse(arena: Allocator, ct_payload: []const u8) DecodeError!AdapterWorld {
+    const comp = try loader.load(ct_payload, arena);
+
+    if (comp.types.len < 1 or comp.types[0] != .component) {
+        return error.UnsupportedAdapterShape;
+    }
+    const outer = comp.types[0].component;
+    if (outer.decls.len < 2) return error.UnsupportedAdapterShape;
+    if (outer.decls[0] != .type or outer.decls[0].type != .component) {
+        return error.UnsupportedAdapterShape;
+    }
+    if (outer.decls[1] != .@"export") return error.UnsupportedAdapterShape;
+
+    const body = outer.decls[0].type.component;
+    const world_qname = outer.decls[1].@"export".name;
+
+    // Walk body decls, tagging:
+    //   * imports + their preceding instance-type idx,
+    //   * exports + their preceding instance-type idx,
+    //   * type-indexspace cursor.
+    var imports = std.ArrayListUnmanaged(ImportEntry).empty;
+    var exports = std.ArrayListUnmanaged(ExportEntry).empty;
+    var type_idx: u32 = 0;
+    var inst_idx: u32 = 0;
+    for (body.decls, 0..) |d, i| {
+        switch (d) {
+            .type, .core_type => type_idx += 1,
+            .alias => |a| {
+                // `instance_export` of sort `.type` and `outer` of
+                // sort `.type` both contribute to the type
+                // indexspace. Other alias sorts contribute to other
+                // indexspaces and don't bump type_idx.
+                const sort: ctypes.Sort = switch (a) {
+                    .instance_export => |ie| ie.sort,
+                    .outer => |o| o.sort,
+                };
+                if (sort == .type) type_idx += 1;
+            },
+            .import => |im| {
+                const inst_type_idx: u32 = switch (im.desc) {
+                    .instance => |idx| idx,
+                    else => 0,
+                };
+                try imports.append(arena, .{
+                    .name = im.name,
+                    .body_decl_idx = @intCast(i),
+                    .body_type_idx = inst_type_idx,
+                    .body_instance_idx = inst_idx,
+                });
+                inst_idx += 1;
+            },
+            .@"export" => |e| {
+                const inst_type_idx: u32 = switch (e.desc) {
+                    .instance => |idx| idx,
+                    else => 0,
+                };
+                try exports.append(arena, .{
+                    .name = e.name,
+                    .body_decl_idx = @intCast(i),
+                    .body_type_idx = inst_type_idx,
+                });
+            },
+        }
+    }
+
+    return .{
+        .component = comp,
+        .body_decls = body.decls,
+        .body_type_count = type_idx,
+        .imports = try imports.toOwnedSlice(arena),
+        .exports = try exports.toOwnedSlice(arena),
+        .world_qualified_name = world_qname,
+    };
+}
+
+/// Convenience: combines `extractEncodedWorld` + `parse`.
+pub fn parseFromAdapterCore(
+    arena: Allocator,
+    adapter_core_bytes: []const u8,
+) DecodeError!AdapterWorld {
+    const ct = (try extractEncodedWorld(adapter_core_bytes)) orelse return error.MissingEncodedWorld;
+    return parse(arena, ct);
+}
+
+const LebRead = struct { value: u32, bytes_read: usize };
+
+fn readU32Leb(buf: []const u8, start: usize) !LebRead {
+    if (start >= buf.len) return error.UnexpectedEnd;
+    const r = leb128.readU32Leb128(buf[start..]) catch return error.InvalidAdapterCore;
+    return .{ .value = r.value, .bytes_read = r.bytes_read };
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+const writer = @import("../writer.zig");
+const metadata_encode = @import("../wit/metadata_encode.zig");
+
+/// Build a minimal adapter-shaped `component-type:…:encoded world`
+/// payload by re-using `metadata_encode`. The world has one import
+/// and one export, both of single-func interfaces — the smallest
+/// shape that exercises the body-decl walk.
+fn buildMockEncodedWorld(allocator: Allocator) ![]u8 {
+    return metadata_encode.encodeWorldFromSource(allocator,
+        \\package mock:adapter@0.1.0;
+        \\
+        \\interface in {
+        \\    ping: func() -> u32;
+        \\}
+        \\
+        \\interface out {
+        \\    pong: func() -> u32;
+        \\}
+        \\
+        \\world adapter-mock {
+        \\    import in;
+        \\    export out;
+        \\}
+    , "adapter-mock");
+}
+
+/// Wrap a payload as the body of a `component-type:mock:encoded
+/// world` custom section appended to a minimal core wasm preamble —
+/// produces a freestanding "adapter-shaped" core wasm for tests.
+fn wrapAsAdapterCore(allocator: Allocator, ct_payload: []const u8) ![]u8 {
+    const preamble = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 };
+    const sec_name = "component-type:mock:encoded world";
+    var name_leb: [leb128.max_u32_bytes]u8 = undefined;
+    const name_leb_n = leb128.writeU32Leb128(&name_leb, @intCast(sec_name.len));
+    const body_len = name_leb_n + sec_name.len + ct_payload.len;
+    var size_leb: [leb128.max_u32_bytes]u8 = undefined;
+    const size_leb_n = leb128.writeU32Leb128(&size_leb, @intCast(body_len));
+
+    var out = try std.ArrayListUnmanaged(u8).initCapacity(allocator, preamble.len + 1 + size_leb_n + body_len);
+    out.appendSliceAssumeCapacity(&preamble);
+    out.appendAssumeCapacity(0); // custom section id
+    out.appendSliceAssumeCapacity(size_leb[0..size_leb_n]);
+    out.appendSliceAssumeCapacity(name_leb[0..name_leb_n]);
+    out.appendSliceAssumeCapacity(sec_name);
+    out.appendSliceAssumeCapacity(ct_payload);
+    return out.toOwnedSlice(allocator);
+}
+
+test "extractEncodedWorld: matches by suffix and prefix" {
+    const ct = try buildMockEncodedWorld(testing.allocator);
+    defer testing.allocator.free(ct);
+    const core = try wrapAsAdapterCore(testing.allocator, ct);
+    defer testing.allocator.free(core);
+
+    const found = try extractEncodedWorld(core);
+    try testing.expect(found != null);
+    try testing.expectEqualSlices(u8, ct, found.?);
+}
+
+test "extractEncodedWorld: rejects non-adapter custom sections" {
+    // Core wasm with a custom section whose name doesn't match
+    // either prefix or suffix.
+    const core = [_]u8{
+        0x00, 0x61, 0x73, 0x6d,
+        0x01, 0x00, 0x00, 0x00,
+        0x00, 0x07, // custom section, body size 7
+        0x05, 'h', 'e', 'l', 'l', 'o', 0x00,
+    };
+    const found = try extractEncodedWorld(&core);
+    try testing.expect(found == null);
+}
+
+test "parse: walks mock world body and surfaces imports/exports" {
+    const ct = try buildMockEncodedWorld(testing.allocator);
+    defer testing.allocator.free(ct);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const w = try parse(arena.allocator(), ct);
+
+    try testing.expectEqual(@as(usize, 1), w.imports.len);
+    try testing.expectEqualStrings("mock:adapter/in@0.1.0", w.imports[0].name);
+    try testing.expectEqual(@as(u32, 0), w.imports[0].body_instance_idx);
+
+    try testing.expectEqual(@as(usize, 1), w.exports.len);
+    try testing.expectEqualStrings("mock:adapter/out@0.1.0", w.exports[0].name);
+
+    try testing.expectEqualStrings("mock:adapter/adapter-mock@0.1.0", w.world_qualified_name);
+
+    // body_type_count counts every type-producing body decl. The
+    // world has 2 instance-type defs.
+    try testing.expectEqual(@as(u32, 2), w.body_type_count);
+}
+
+test "parseFromAdapterCore: end-to-end through extract + load" {
+    const ct = try buildMockEncodedWorld(testing.allocator);
+    defer testing.allocator.free(ct);
+    const core = try wrapAsAdapterCore(testing.allocator, ct);
+    defer testing.allocator.free(core);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const w = try parseFromAdapterCore(arena.allocator(), core);
+    try testing.expectEqual(@as(usize, 1), w.imports.len);
+    try testing.expectEqual(@as(usize, 1), w.exports.len);
+}

--- a/src/component/adapter/fixup.zig
+++ b/src/component/adapter/fixup.zig
@@ -5,8 +5,10 @@
 //! (after main + adapter). Its job is to write the adapter's
 //! preview1 exports into the shim's funcref table so that calls
 //! through the shim trampolines reach real adapter funcs instead of
-//! trapping. Once the fixup's start function runs, the shim is
-//! "fully wired".
+//! trapping. We use an *active* element segment that initialises
+//! the imported table with the imported funcs at offset 0 — this
+//! runs implicitly during instantiation and avoids the need for a
+//! start function (matching `wit-component`'s emitter exactly).
 //!
 //! Wire shape:
 //!
@@ -14,19 +16,12 @@
 //!   │ types: one (func ...) per UNIQUE preview1-import signature  │
 //!   │   (matches the shim's type list, in the same order)         │
 //!   │ imports:                                                    │
-//!   │   "" "$imports" table funcref       (the shim's table)      │
 //!   │   "" "0" func sig0                  (adapter export 0)      │
 //!   │   "" "1" func sig1                  (adapter export 1)      │
 //!   │   …                                                         │
-//!   │ elem 0: declarative funcref, [func 0, func 1, …]            │
-//!   │   (declares every imported adapter func so ref.func is      │
-//!   │    legal)                                                   │
-//!   │ func N: the start function — body                           │
-//!   │   for each i in 0..N:                                       │
-//!   │     i32.const i                                             │
-//!   │     ref.func i                                              │
-//!   │     table.set 0                                             │
-//!   │ start: func N                                               │
+//!   │   "" "\$imports" table funcref      (the shim's table)      │
+//!   │ elem 0: active (table 0, offset i32.const 0)                │
+//!   │   funcs: [0, 1, 2, …, N-1]                                  │
 //!   └─────────────────────────────────────────────────────────────┘
 //!
 //! Slot order matches `shim.zig`'s slot order — same i'th index
@@ -44,16 +39,14 @@ pub const Error = error{OutOfMemory};
 /// Build the fixup core wasm bytes.
 ///
 /// The slots must match the shim's slots — same length, same order,
-/// same signatures — because the fixup's start function pairs up
-/// imported adapter func i with shim table slot i.
+/// same signatures — because the fixup pairs imported adapter func
+/// i with shim table slot i.
 pub fn build(gpa: Allocator, slots: []const Slot) Error![]u8 {
     var out = std.ArrayListUnmanaged(u8).empty;
     errdefer out.deinit(gpa);
 
     try out.appendSlice(gpa, &.{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 });
 
-    // Deduplicate sigs (parallel to shim's logic; we just need the
-    // type table to match each imported func to a typeidx).
     var sig_idx_for_slot = try gpa.alloc(u32, slots.len);
     defer gpa.free(sig_idx_for_slot);
 
@@ -80,8 +73,7 @@ pub fn build(gpa: Allocator, slots: []const Slot) Error![]u8 {
     {
         var body = std.ArrayListUnmanaged(u8).empty;
         defer body.deinit(gpa);
-        // Plus the start func's () -> () type as the LAST entry.
-        try writeU32Leb(gpa, &body, @intCast(unique_sigs.items.len + 1));
+        try writeU32Leb(gpa, &body, @intCast(unique_sigs.items.len));
         for (unique_sigs.items) |s| {
             try body.append(gpa, 0x60);
             try writeU32Leb(gpa, &body, @intCast(s.params.len));
@@ -89,20 +81,27 @@ pub fn build(gpa: Allocator, slots: []const Slot) Error![]u8 {
             try writeU32Leb(gpa, &body, @intCast(s.results.len));
             for (s.results) |r| try body.append(gpa, valTypeByte(r));
         }
-        try body.append(gpa, 0x60);
-        try body.append(gpa, 0x00);
-        try body.append(gpa, 0x00);
         try writeSection(gpa, &out, 0x01, body.items);
     }
 
-    const start_type_idx: u32 = @intCast(unique_sigs.items.len);
-
-    // import section: 1 table + N funcs
+    // import section: N funcs, then the table (matching wit-
+    // component's order so func indexspace is 0..N-1 for the
+    // imported adapter funcs).
     {
         var body = std.ArrayListUnmanaged(u8).empty;
         defer body.deinit(gpa);
         try writeU32Leb(gpa, &body, @intCast(slots.len + 1));
-        // table import: "" "$imports" funcref min/max=N
+
+        var name_buf: [16]u8 = undefined;
+        for (sig_idx_for_slot, 0..) |t, i| {
+            try writeU32Leb(gpa, &body, 0);
+            const name = std.fmt.bufPrint(&name_buf, "{d}", .{i}) catch unreachable;
+            try writeU32Leb(gpa, &body, @intCast(name.len));
+            try body.appendSlice(gpa, name);
+            try body.append(gpa, 0x00); // import desc: func
+            try writeU32Leb(gpa, &body, t);
+        }
+
         try writeU32Leb(gpa, &body, 0); // module ""
         const tbl_field = "$imports";
         try writeU32Leb(gpa, &body, @intCast(tbl_field.len));
@@ -113,74 +112,25 @@ pub fn build(gpa: Allocator, slots: []const Slot) Error![]u8 {
         try writeU32Leb(gpa, &body, @intCast(slots.len));
         try writeU32Leb(gpa, &body, @intCast(slots.len));
 
-        // func imports
-        var name_buf: [16]u8 = undefined;
-        for (sig_idx_for_slot, 0..) |t, i| {
-            try writeU32Leb(gpa, &body, 0);
-            const name = std.fmt.bufPrint(&name_buf, "{d}", .{i}) catch unreachable;
-            try writeU32Leb(gpa, &body, @intCast(name.len));
-            try body.appendSlice(gpa, name);
-            try body.append(gpa, 0x00); // import desc: func
-            try writeU32Leb(gpa, &body, t);
-        }
         try writeSection(gpa, &out, 0x02, body.items);
     }
 
-    // function section: 1 defined func (the start)
-    {
-        var body = std.ArrayListUnmanaged(u8).empty;
-        defer body.deinit(gpa);
-        try body.append(gpa, 0x01);
-        try writeU32Leb(gpa, &body, start_type_idx);
-        try writeSection(gpa, &out, 0x03, body.items);
-    }
-
-    // start section: idx of our start func (= N imported funcs)
-    {
-        var body = std.ArrayListUnmanaged(u8).empty;
-        defer body.deinit(gpa);
-        try writeU32Leb(gpa, &body, @intCast(slots.len));
-        try writeSection(gpa, &out, 0x08, body.items);
-    }
-
-    // element section: one declarative funcref segment listing every
-    // imported func — needed so `ref.func i` is a valid expression in
-    // the start body.
+    // element section: one active elem segment that initialises
+    // table 0 starting at offset 0 with funcs 0..N-1.
     if (slots.len > 0) {
         var body = std.ArrayListUnmanaged(u8).empty;
         defer body.deinit(gpa);
         try body.append(gpa, 0x01); // 1 segment
-        // flags = 3 (declarative + uses elem kind, i.e. funcref of
-        // funcidx). encoding: 0x03, elemkind=0x00 (funcref via
-        // funcidx), then count + funcidxs.
-        try body.append(gpa, 0x03);
+        // flags = 0: active, table 0, funcref via funcidx
         try body.append(gpa, 0x00);
+        // offset: i32.const 0; end
+        try body.append(gpa, 0x41);
+        try writeS32Leb(gpa, &body, 0);
+        try body.append(gpa, 0x0b);
+        // funcidx vector
         try writeU32Leb(gpa, &body, @intCast(slots.len));
         for (0..slots.len) |i| try writeU32Leb(gpa, &body, @intCast(i));
         try writeSection(gpa, &out, 0x09, body.items);
-    }
-
-    // code section: the start func body
-    {
-        var fn_body = std.ArrayListUnmanaged(u8).empty;
-        defer fn_body.deinit(gpa);
-        try fn_body.append(gpa, 0x00); // 0 local decls
-        for (0..slots.len) |i| {
-            try fn_body.append(gpa, 0x41); // i32.const
-            try writeS32Leb(gpa, &fn_body, @intCast(i));
-            try fn_body.append(gpa, 0xd2); // ref.func
-            try writeU32Leb(gpa, &fn_body, @intCast(i));
-            try fn_body.append(gpa, 0x26); // table.set
-            try writeU32Leb(gpa, &fn_body, 0); // tableidx 0
-        }
-        try fn_body.append(gpa, 0x0b); // end
-
-        var body = std.ArrayListUnmanaged(u8).empty;
-        defer body.deinit(gpa);
-        try writeU32Leb(gpa, &body, 1); // 1 func
-        try writeU32Leb(gpa, &body, @intCast(fn_body.items.len));
-        try body.appendSlice(gpa, fn_body.items);
-        try writeSection(gpa, &out, 0x0a, body.items);
     }
 
     return out.toOwnedSlice(gpa);
@@ -239,15 +189,14 @@ test "build: empty slot list still produces a valid module" {
     var module = try reader.readModule(testing.allocator, bytes);
     defer module.deinit();
 
-    // Just the table import + 1 defined start func.
+    // Only the table import (no funcs, no element segment).
     try testing.expectEqual(@as(usize, 1), module.imports.items.len);
     try testing.expectEqual(wtypes.ExternalKind.table, module.imports.items[0].kind);
     try testing.expectEqualStrings("$imports", module.imports.items[0].field_name);
-    try testing.expectEqual(@as(usize, 1), module.funcs.items.len);
-    try testing.expect(module.start_var != null);
+    try testing.expectEqual(@as(usize, 0), module.elem_segments.items.len);
 }
 
-test "build: one i32->i32 slot — imports table + 1 func, start defined" {
+test "build: one i32->i32 slot — N funcs + table imports + active elem" {
     const i32_p = [_]wtypes.ValType{.i32};
     const i32_r = [_]wtypes.ValType{.i32};
     const slots = [_]Slot{
@@ -259,16 +208,15 @@ test "build: one i32->i32 slot — imports table + 1 func, start defined" {
     var module = try reader.readModule(testing.allocator, bytes);
     defer module.deinit();
 
-    // Table + 1 func import + 1 defined start.
+    // N func imports + 1 table import.
     try testing.expectEqual(@as(usize, 2), module.imports.items.len);
-    try testing.expectEqual(wtypes.ExternalKind.table, module.imports.items[0].kind);
-    try testing.expectEqual(wtypes.ExternalKind.func, module.imports.items[1].kind);
-    try testing.expectEqualStrings("0", module.imports.items[1].field_name);
+    try testing.expectEqual(wtypes.ExternalKind.func, module.imports.items[0].kind);
+    try testing.expectEqualStrings("0", module.imports.items[0].field_name);
+    try testing.expectEqual(wtypes.ExternalKind.table, module.imports.items[1].kind);
+    try testing.expectEqualStrings("$imports", module.imports.items[1].field_name);
 
-    try testing.expectEqual(@as(usize, 2), module.funcs.items.len); // 1 imported + 1 defined
-    try testing.expect(module.start_var != null);
-    try testing.expectEqual(@as(u32, 1), module.start_var.?.index);
-
-    // 1 element segment (declarative).
+    try testing.expectEqual(@as(usize, 1), module.funcs.items.len); // imported only
     try testing.expectEqual(@as(usize, 1), module.elem_segments.items.len);
+    // No start function — the active elem runs at instantiation time.
+    try testing.expect(module.start_var == null);
 }

--- a/src/component/adapter/fixup.zig
+++ b/src/component/adapter/fixup.zig
@@ -1,0 +1,274 @@
+//! Synthesize the wasi-preview1 adapter splicer's "fixup" core
+//! module.
+//!
+//! The fixup is instantiated *last* inside the wrapping component
+//! (after main + adapter). Its job is to write the adapter's
+//! preview1 exports into the shim's funcref table so that calls
+//! through the shim trampolines reach real adapter funcs instead of
+//! trapping. Once the fixup's start function runs, the shim is
+//! "fully wired".
+//!
+//! Wire shape:
+//!
+//!   ┌─ fixup core module ─────────────────────────────────────────┐
+//!   │ types: one (func ...) per UNIQUE preview1-import signature  │
+//!   │   (matches the shim's type list, in the same order)         │
+//!   │ imports:                                                    │
+//!   │   "" "$imports" table funcref       (the shim's table)      │
+//!   │   "" "0" func sig0                  (adapter export 0)      │
+//!   │   "" "1" func sig1                  (adapter export 1)      │
+//!   │   …                                                         │
+//!   │ elem 0: declarative funcref, [func 0, func 1, …]            │
+//!   │   (declares every imported adapter func so ref.func is      │
+//!   │    legal)                                                   │
+//!   │ func N: the start function — body                           │
+//!   │   for each i in 0..N:                                       │
+//!   │     i32.const i                                             │
+//!   │     ref.func i                                              │
+//!   │     table.set 0                                             │
+//!   │ start: func N                                               │
+//!   └─────────────────────────────────────────────────────────────┘
+//!
+//! Slot order matches `shim.zig`'s slot order — same i'th index
+//! everywhere.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const wtypes = @import("../../types.zig");
+const leb = @import("../../leb128.zig");
+const Slot = @import("shim.zig").Slot;
+
+pub const Error = error{OutOfMemory};
+
+/// Build the fixup core wasm bytes.
+///
+/// The slots must match the shim's slots — same length, same order,
+/// same signatures — because the fixup's start function pairs up
+/// imported adapter func i with shim table slot i.
+pub fn build(gpa: Allocator, slots: []const Slot) Error![]u8 {
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(gpa);
+
+    try out.appendSlice(gpa, &.{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 });
+
+    // Deduplicate sigs (parallel to shim's logic; we just need the
+    // type table to match each imported func to a typeidx).
+    var sig_idx_for_slot = try gpa.alloc(u32, slots.len);
+    defer gpa.free(sig_idx_for_slot);
+
+    var unique_sigs = std.ArrayListUnmanaged(Slot).empty;
+    defer unique_sigs.deinit(gpa);
+
+    for (slots, 0..) |s, i| {
+        var found: ?u32 = null;
+        for (unique_sigs.items, 0..) |u, j| {
+            if (sigEql(u, s)) {
+                found = @intCast(j);
+                break;
+            }
+        }
+        if (found) |idx| {
+            sig_idx_for_slot[i] = idx;
+        } else {
+            sig_idx_for_slot[i] = @intCast(unique_sigs.items.len);
+            try unique_sigs.append(gpa, s);
+        }
+    }
+
+    // type section
+    {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        defer body.deinit(gpa);
+        // Plus the start func's () -> () type as the LAST entry.
+        try writeU32Leb(gpa, &body, @intCast(unique_sigs.items.len + 1));
+        for (unique_sigs.items) |s| {
+            try body.append(gpa, 0x60);
+            try writeU32Leb(gpa, &body, @intCast(s.params.len));
+            for (s.params) |p| try body.append(gpa, valTypeByte(p));
+            try writeU32Leb(gpa, &body, @intCast(s.results.len));
+            for (s.results) |r| try body.append(gpa, valTypeByte(r));
+        }
+        try body.append(gpa, 0x60);
+        try body.append(gpa, 0x00);
+        try body.append(gpa, 0x00);
+        try writeSection(gpa, &out, 0x01, body.items);
+    }
+
+    const start_type_idx: u32 = @intCast(unique_sigs.items.len);
+
+    // import section: 1 table + N funcs
+    {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        defer body.deinit(gpa);
+        try writeU32Leb(gpa, &body, @intCast(slots.len + 1));
+        // table import: "" "$imports" funcref min/max=N
+        try writeU32Leb(gpa, &body, 0); // module ""
+        const tbl_field = "$imports";
+        try writeU32Leb(gpa, &body, @intCast(tbl_field.len));
+        try body.appendSlice(gpa, tbl_field);
+        try body.append(gpa, 0x01); // import desc: table
+        try body.append(gpa, 0x70); // funcref
+        try body.append(gpa, 0x01); // min/max present
+        try writeU32Leb(gpa, &body, @intCast(slots.len));
+        try writeU32Leb(gpa, &body, @intCast(slots.len));
+
+        // func imports
+        var name_buf: [16]u8 = undefined;
+        for (sig_idx_for_slot, 0..) |t, i| {
+            try writeU32Leb(gpa, &body, 0);
+            const name = std.fmt.bufPrint(&name_buf, "{d}", .{i}) catch unreachable;
+            try writeU32Leb(gpa, &body, @intCast(name.len));
+            try body.appendSlice(gpa, name);
+            try body.append(gpa, 0x00); // import desc: func
+            try writeU32Leb(gpa, &body, t);
+        }
+        try writeSection(gpa, &out, 0x02, body.items);
+    }
+
+    // function section: 1 defined func (the start)
+    {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        defer body.deinit(gpa);
+        try body.append(gpa, 0x01);
+        try writeU32Leb(gpa, &body, start_type_idx);
+        try writeSection(gpa, &out, 0x03, body.items);
+    }
+
+    // start section: idx of our start func (= N imported funcs)
+    {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        defer body.deinit(gpa);
+        try writeU32Leb(gpa, &body, @intCast(slots.len));
+        try writeSection(gpa, &out, 0x08, body.items);
+    }
+
+    // element section: one declarative funcref segment listing every
+    // imported func — needed so `ref.func i` is a valid expression in
+    // the start body.
+    if (slots.len > 0) {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        defer body.deinit(gpa);
+        try body.append(gpa, 0x01); // 1 segment
+        // flags = 3 (declarative + uses elem kind, i.e. funcref of
+        // funcidx). encoding: 0x03, elemkind=0x00 (funcref via
+        // funcidx), then count + funcidxs.
+        try body.append(gpa, 0x03);
+        try body.append(gpa, 0x00);
+        try writeU32Leb(gpa, &body, @intCast(slots.len));
+        for (0..slots.len) |i| try writeU32Leb(gpa, &body, @intCast(i));
+        try writeSection(gpa, &out, 0x09, body.items);
+    }
+
+    // code section: the start func body
+    {
+        var fn_body = std.ArrayListUnmanaged(u8).empty;
+        defer fn_body.deinit(gpa);
+        try fn_body.append(gpa, 0x00); // 0 local decls
+        for (0..slots.len) |i| {
+            try fn_body.append(gpa, 0x41); // i32.const
+            try writeS32Leb(gpa, &fn_body, @intCast(i));
+            try fn_body.append(gpa, 0xd2); // ref.func
+            try writeU32Leb(gpa, &fn_body, @intCast(i));
+            try fn_body.append(gpa, 0x26); // table.set
+            try writeU32Leb(gpa, &fn_body, 0); // tableidx 0
+        }
+        try fn_body.append(gpa, 0x0b); // end
+
+        var body = std.ArrayListUnmanaged(u8).empty;
+        defer body.deinit(gpa);
+        try writeU32Leb(gpa, &body, 1); // 1 func
+        try writeU32Leb(gpa, &body, @intCast(fn_body.items.len));
+        try body.appendSlice(gpa, fn_body.items);
+        try writeSection(gpa, &out, 0x0a, body.items);
+    }
+
+    return out.toOwnedSlice(gpa);
+}
+
+// ── helpers (mirrored from shim.zig — kept private here to avoid
+// growing a shared util surface for two-call use) ──────────────────────────
+
+fn sigEql(a: Slot, b: Slot) bool {
+    return std.mem.eql(wtypes.ValType, a.params, b.params) and
+        std.mem.eql(wtypes.ValType, a.results, b.results);
+}
+
+fn valTypeByte(v: wtypes.ValType) u8 {
+    return switch (v) {
+        .i32 => 0x7f,
+        .i64 => 0x7e,
+        .f32 => 0x7d,
+        .f64 => 0x7c,
+        .v128 => 0x7b,
+        .funcref => 0x70,
+        .externref => 0x6f,
+        else => 0x7f,
+    };
+}
+
+fn writeU32Leb(gpa: Allocator, buf: *std.ArrayListUnmanaged(u8), v: u32) Error!void {
+    var tmp: [leb.max_u32_bytes]u8 = undefined;
+    const n = leb.writeU32Leb128(&tmp, v);
+    try buf.appendSlice(gpa, tmp[0..n]);
+}
+
+fn writeS32Leb(gpa: Allocator, buf: *std.ArrayListUnmanaged(u8), v: i32) Error!void {
+    var tmp: [leb.max_s32_bytes]u8 = undefined;
+    const n = leb.writeS32Leb128(&tmp, v);
+    try buf.appendSlice(gpa, tmp[0..n]);
+}
+
+fn writeSection(gpa: Allocator, out: *std.ArrayListUnmanaged(u8), id: u8, body: []const u8) Error!void {
+    try out.append(gpa, id);
+    var len_buf: [leb.max_u32_bytes]u8 = undefined;
+    const n = leb.writeU32Leb128(&len_buf, @intCast(body.len));
+    try out.appendSlice(gpa, len_buf[0..n]);
+    try out.appendSlice(gpa, body);
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+const reader = @import("../../binary/reader.zig");
+
+test "build: empty slot list still produces a valid module" {
+    const bytes = try build(testing.allocator, &.{});
+    defer testing.allocator.free(bytes);
+
+    var module = try reader.readModule(testing.allocator, bytes);
+    defer module.deinit();
+
+    // Just the table import + 1 defined start func.
+    try testing.expectEqual(@as(usize, 1), module.imports.items.len);
+    try testing.expectEqual(wtypes.ExternalKind.table, module.imports.items[0].kind);
+    try testing.expectEqualStrings("$imports", module.imports.items[0].field_name);
+    try testing.expectEqual(@as(usize, 1), module.funcs.items.len);
+    try testing.expect(module.start_var != null);
+}
+
+test "build: one i32->i32 slot — imports table + 1 func, start defined" {
+    const i32_p = [_]wtypes.ValType{.i32};
+    const i32_r = [_]wtypes.ValType{.i32};
+    const slots = [_]Slot{
+        .{ .params = &i32_p, .results = &i32_r },
+    };
+    const bytes = try build(testing.allocator, &slots);
+    defer testing.allocator.free(bytes);
+
+    var module = try reader.readModule(testing.allocator, bytes);
+    defer module.deinit();
+
+    // Table + 1 func import + 1 defined start.
+    try testing.expectEqual(@as(usize, 2), module.imports.items.len);
+    try testing.expectEqual(wtypes.ExternalKind.table, module.imports.items[0].kind);
+    try testing.expectEqual(wtypes.ExternalKind.func, module.imports.items[1].kind);
+    try testing.expectEqualStrings("0", module.imports.items[1].field_name);
+
+    try testing.expectEqual(@as(usize, 2), module.funcs.items.len); // 1 imported + 1 defined
+    try testing.expect(module.start_var != null);
+    try testing.expectEqual(@as(u32, 1), module.start_var.?.index);
+
+    // 1 element segment (declarative).
+    try testing.expectEqual(@as(usize, 1), module.elem_segments.items.len);
+}

--- a/src/component/adapter/shim.zig
+++ b/src/component/adapter/shim.zig
@@ -1,0 +1,280 @@
+//! Synthesize the wasi-preview1 adapter splicer's "shim" core module.
+//!
+//! The shim is a tiny core wasm module that gets instantiated *first*
+//! inside the wrapping component. It exposes one trapping trampoline
+//! per preview1 import the embed module declares, plus a funcref
+//! table named "$imports" that the trampolines call_indirect through.
+//!
+//! After the main embed module is instantiated (using these
+//! trampolines as its `wasi_snapshot_preview1.*` imports) and the
+//! adapter is instantiated (consuming main's exports + the lowered
+//! WASI 0.2.6 imports), the *fixup* module (see `fixup.zig`) is
+//! instantiated and its start function writes the adapter's preview1
+//! exports into the shim's table — patching every trampoline so
+//! subsequent calls reach the adapter instead of trapping.
+//!
+//! Wire shape:
+//!
+//!   ┌─ shim core module ─────────────────────────────────────────┐
+//!   │ types: one (func ...) per UNIQUE preview1-import signature │
+//!   │ table 0: funcref, min/max = N (one slot per import)         │
+//!   │ funcs: N trampolines, each with body                        │
+//!   │   local.get 0 … local.get k   (forward params)              │
+//!   │   i32.const i                  (slot index)                 │
+//!   │   call_indirect (type T) 0     (through table 0)            │
+//!   │ exports:                                                    │
+//!   │   "0" func 0, "1" func 1, …                                 │
+//!   │   "$imports" table 0                                        │
+//!   └─────────────────────────────────────────────────────────────┘
+//!
+//! Stable export naming ("0", "1", …) matches `wit-component`'s
+//! convention so the splicer can blindly alias the i'th shim export
+//! as `wasi_snapshot_preview1.<i'th preview1 import name>` from
+//! main's perspective.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const wtypes = @import("../../types.zig");
+const leb = @import("../../leb128.zig");
+
+pub const Error = error{OutOfMemory};
+
+/// One preview1 trampoline the shim should expose.
+pub const Slot = struct {
+    /// Param val types (i32 / i64 / f32 / f64). Reference types are
+    /// not currently supported — preview1 sigs only ever use ints.
+    params: []const wtypes.ValType,
+    /// Result val types. preview1 funcs always return either nothing
+    /// or a single i32 errno but we keep this open.
+    results: []const wtypes.ValType,
+};
+
+/// Build the shim core wasm bytes for the given slots. Slot order
+/// equals export-name order ("0", "1", …) and table-slot order.
+/// Caller frees the returned slice via `gpa`.
+pub fn build(gpa: Allocator, slots: []const Slot) Error![]u8 {
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(gpa);
+
+    // magic + version
+    try out.appendSlice(gpa, &.{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 });
+
+    // ── deduplicate signatures so the type section is compact ────────────
+    var sig_idx_for_slot = try gpa.alloc(u32, slots.len);
+    defer gpa.free(sig_idx_for_slot);
+
+    var unique_sigs = std.ArrayListUnmanaged(Slot).empty;
+    defer unique_sigs.deinit(gpa);
+
+    for (slots, 0..) |s, i| {
+        var found: ?u32 = null;
+        for (unique_sigs.items, 0..) |u, j| {
+            if (sigEql(u, s)) {
+                found = @intCast(j);
+                break;
+            }
+        }
+        if (found) |idx| {
+            sig_idx_for_slot[i] = idx;
+        } else {
+            sig_idx_for_slot[i] = @intCast(unique_sigs.items.len);
+            try unique_sigs.append(gpa, s);
+        }
+    }
+
+    // ── type section ─────────────────────────────────────────────────────
+    {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        defer body.deinit(gpa);
+        try writeU32Leb(gpa, &body, @intCast(unique_sigs.items.len));
+        for (unique_sigs.items) |s| {
+            try body.append(gpa, 0x60); // func type
+            try writeU32Leb(gpa, &body, @intCast(s.params.len));
+            for (s.params) |p| try body.append(gpa, valTypeByte(p));
+            try writeU32Leb(gpa, &body, @intCast(s.results.len));
+            for (s.results) |r| try body.append(gpa, valTypeByte(r));
+        }
+        try writeSection(gpa, &out, 0x01, body.items);
+    }
+
+    // ── function section: one defined func per slot ──────────────────────
+    {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        defer body.deinit(gpa);
+        try writeU32Leb(gpa, &body, @intCast(slots.len));
+        for (sig_idx_for_slot) |t| try writeU32Leb(gpa, &body, t);
+        try writeSection(gpa, &out, 0x03, body.items);
+    }
+
+    // ── table section: 1 funcref table sized to the slot count ─────────
+    {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        defer body.deinit(gpa);
+        try body.append(gpa, 0x01); // count
+        try body.append(gpa, 0x70); // funcref
+        try body.append(gpa, 0x01); // min/max present
+        try writeU32Leb(gpa, &body, @intCast(slots.len));
+        try writeU32Leb(gpa, &body, @intCast(slots.len));
+        try writeSection(gpa, &out, 0x04, body.items);
+    }
+
+    // ── export section: "<i>" funcs + "$imports" table ──────────────────
+    {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        defer body.deinit(gpa);
+        try writeU32Leb(gpa, &body, @intCast(slots.len + 1));
+        var name_buf: [16]u8 = undefined;
+        for (0..slots.len) |i| {
+            const name = std.fmt.bufPrint(&name_buf, "{d}", .{i}) catch unreachable;
+            try writeU32Leb(gpa, &body, @intCast(name.len));
+            try body.appendSlice(gpa, name);
+            try body.append(gpa, 0x00); // export desc: func
+            try writeU32Leb(gpa, &body, @intCast(i));
+        }
+        const tbl_name = "$imports";
+        try writeU32Leb(gpa, &body, @intCast(tbl_name.len));
+        try body.appendSlice(gpa, tbl_name);
+        try body.append(gpa, 0x01); // export desc: table
+        try body.append(gpa, 0x00); // table idx 0
+        try writeSection(gpa, &out, 0x07, body.items);
+    }
+
+    // ── code section: one trampoline body per slot ──────────────────────
+    {
+        var body = std.ArrayListUnmanaged(u8).empty;
+        defer body.deinit(gpa);
+        try writeU32Leb(gpa, &body, @intCast(slots.len));
+        for (slots, 0..) |s, i| {
+            var fn_body = std.ArrayListUnmanaged(u8).empty;
+            defer fn_body.deinit(gpa);
+            try fn_body.append(gpa, 0x00); // 0 local decls
+            // forward each param via local.get
+            for (0..s.params.len) |k| {
+                try fn_body.append(gpa, 0x20); // local.get
+                try writeU32Leb(gpa, &fn_body, @intCast(k));
+            }
+            // i32.const i  (signed LEB; small values fit in one byte)
+            try fn_body.append(gpa, 0x41);
+            try writeS32Leb(gpa, &fn_body, @intCast(i));
+            // call_indirect (type sig_idx_for_slot[i]) (table 0)
+            try fn_body.append(gpa, 0x11);
+            try writeU32Leb(gpa, &fn_body, sig_idx_for_slot[i]);
+            try writeU32Leb(gpa, &fn_body, 0);
+            // end
+            try fn_body.append(gpa, 0x0b);
+
+            try writeU32Leb(gpa, &body, @intCast(fn_body.items.len));
+            try body.appendSlice(gpa, fn_body.items);
+        }
+        try writeSection(gpa, &out, 0x0a, body.items);
+    }
+
+    return out.toOwnedSlice(gpa);
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+fn sigEql(a: Slot, b: Slot) bool {
+    return std.mem.eql(wtypes.ValType, a.params, b.params) and
+        std.mem.eql(wtypes.ValType, a.results, b.results);
+}
+
+fn valTypeByte(v: wtypes.ValType) u8 {
+    return switch (v) {
+        .i32 => 0x7f,
+        .i64 => 0x7e,
+        .f32 => 0x7d,
+        .f64 => 0x7c,
+        .v128 => 0x7b,
+        .funcref => 0x70,
+        .externref => 0x6f,
+        else => 0x7f, // not used for adapter sigs; default to i32
+    };
+}
+
+fn writeU32Leb(gpa: Allocator, buf: *std.ArrayListUnmanaged(u8), v: u32) Error!void {
+    var tmp: [leb.max_u32_bytes]u8 = undefined;
+    const n = leb.writeU32Leb128(&tmp, v);
+    try buf.appendSlice(gpa, tmp[0..n]);
+}
+
+fn writeS32Leb(gpa: Allocator, buf: *std.ArrayListUnmanaged(u8), v: i32) Error!void {
+    var tmp: [leb.max_s32_bytes]u8 = undefined;
+    const n = leb.writeS32Leb128(&tmp, v);
+    try buf.appendSlice(gpa, tmp[0..n]);
+}
+
+fn writeSection(gpa: Allocator, out: *std.ArrayListUnmanaged(u8), id: u8, body: []const u8) Error!void {
+    try out.append(gpa, id);
+    var len_buf: [leb.max_u32_bytes]u8 = undefined;
+    const n = leb.writeU32Leb128(&len_buf, @intCast(body.len));
+    try out.appendSlice(gpa, len_buf[0..n]);
+    try out.appendSlice(gpa, body);
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+const reader = @import("../../binary/reader.zig");
+
+test "build: empty slot list still produces a valid module" {
+    const bytes = try build(testing.allocator, &.{});
+    defer testing.allocator.free(bytes);
+
+    var module = try reader.readModule(testing.allocator, bytes);
+    defer module.deinit();
+
+    try testing.expectEqual(@as(usize, 0), module.funcs.items.len);
+    try testing.expectEqual(@as(usize, 1), module.tables.items.len);
+    try testing.expectEqual(@as(usize, 1), module.exports.items.len);
+    try testing.expectEqualStrings("$imports", module.exports.items[0].name);
+}
+
+test "build: one i32->i32 slot — exports '0' func + '$imports' table" {
+    const i32_p = [_]wtypes.ValType{.i32};
+    const i32_r = [_]wtypes.ValType{.i32};
+    const slots = [_]Slot{
+        .{ .params = &i32_p, .results = &i32_r },
+    };
+    const bytes = try build(testing.allocator, &slots);
+    defer testing.allocator.free(bytes);
+
+    var module = try reader.readModule(testing.allocator, bytes);
+    defer module.deinit();
+
+    try testing.expectEqual(@as(usize, 1), module.module_types.items.len);
+    try testing.expectEqual(@as(usize, 1), module.funcs.items.len);
+    try testing.expectEqual(@as(usize, 1), module.tables.items.len);
+    try testing.expectEqual(@as(u64, 1), module.tables.items[0].type.limits.initial);
+
+    try testing.expectEqual(@as(usize, 2), module.exports.items.len);
+    try testing.expectEqualStrings("0", module.exports.items[0].name);
+    try testing.expectEqual(wtypes.ExternalKind.func, module.exports.items[0].kind);
+    try testing.expectEqualStrings("$imports", module.exports.items[1].name);
+    try testing.expectEqual(wtypes.ExternalKind.table, module.exports.items[1].kind);
+}
+
+test "build: deduplicates signatures across multiple slots" {
+    const sig_a_p = [_]wtypes.ValType{ .i32, .i32 };
+    const sig_a_r = [_]wtypes.ValType{.i32};
+    const sig_b_p = [_]wtypes.ValType{.i32};
+    const sig_b_r = [_]wtypes.ValType{.i32};
+
+    const slots = [_]Slot{
+        .{ .params = &sig_a_p, .results = &sig_a_r },
+        .{ .params = &sig_b_p, .results = &sig_b_r },
+        .{ .params = &sig_a_p, .results = &sig_a_r }, // duplicate of slot 0
+    };
+    const bytes = try build(testing.allocator, &slots);
+    defer testing.allocator.free(bytes);
+
+    var module = try reader.readModule(testing.allocator, bytes);
+    defer module.deinit();
+
+    try testing.expectEqual(@as(usize, 2), module.module_types.items.len);
+    try testing.expectEqual(@as(usize, 3), module.funcs.items.len);
+    try testing.expectEqual(@as(u64, 3), module.tables.items[0].type.limits.initial);
+    // 3 stub exports + 1 table export
+    try testing.expectEqual(@as(usize, 4), module.exports.items.len);
+}

--- a/src/component/adapter/types_import.zig
+++ b/src/component/adapter/types_import.zig
@@ -1,0 +1,336 @@
+//! Hoist the adapter's encoded-world body into the wrapping
+//! component's top-level sections.
+//!
+//! The wasi-preview1 adapter ships its WASI 0.2.6 type tree and
+//! every import/export it consumes inside a self-contained
+//! `component-type:…:encoded world` payload (see
+//! `adapter/decode.zig`). For the splicer to emit a wrapping
+//! component that imports the right WASI instances and lifts
+//! `wasi:cli/run@<ver>`, every body decl needs to live at the
+//! wrapping component's top level.
+//!
+//! Crucially we *don't* renumber type indices. Inside an instance
+//! type body `(alias outer 1 X)` reads the type indexspace of the
+//! enclosing component. In the original adapter that enclosing
+//! component is the world body. Once we hoist the body decls to
+//! the top level of the wrapping component, the wrapping component
+//! IS the new enclosing component — and because we hoist it as the
+//! FIRST thing we emit, the type indexspace at the relevant depth
+//! stays positionally identical to what the body decls expect.
+//!
+//! Outer aliases inside instance type bodies thus remain valid
+//! verbatim; we just need to preserve the original *declaration
+//! order* between type defs / imports / alias-exports. That's
+//! exactly what `Component.section_order` is for — see
+//! `component/writer.zig`.
+//!
+//! What this module produces:
+//!
+//!   * Four parallel slices the splicer assigns directly to the
+//!     wrapping component (`types`, `imports`, `aliases`, `exports`
+//!     — the last is empty unless the adapter exports a
+//!     non-instance, which it never does).
+//!   * A `section_order` slice that interleaves them in the same
+//!     order as the original body decls.
+//!   * An `instance_slot_for_import` lookup so the splicer knows
+//!     which component-instance index each WASI namespace import
+//!     occupies (used when emitting `canon lower`).
+//!   * Each export's body type idx (used when emitting `canon
+//!     lift` for `wasi:cli/run@<ver>`).
+//!
+//! All slices are arena-allocated; the caller owns the arena.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const ctypes = @import("../types.zig");
+const decode = @import("decode.zig");
+
+pub const Error = error{ OutOfMemory, UnsupportedAdapterShape };
+
+pub const InstanceSlot = struct {
+    name: []const u8,
+    /// Slot in the wrapping component's component-instance
+    /// indexspace.
+    instance_idx: u32,
+    /// Type idx (in the wrapping component) of this import's
+    /// instance type — needed when later emitting an instance
+    /// import that references the same type.
+    type_idx: u32,
+};
+
+pub const ExportInfo = struct {
+    name: []const u8,
+    type_idx: u32,
+};
+
+pub const Hoisted = struct {
+    types: []const ctypes.TypeDef,
+    imports: []const ctypes.ImportDecl,
+    aliases: []const ctypes.Alias,
+    section_order: []const ctypes.SectionEntry,
+    instances: []const InstanceSlot,
+    exports: []const ExportInfo,
+    /// Total number of slots in the wrapping component's type
+    /// indexspace after hoisting (= the next free type idx). Useful
+    /// to the splicer when synthesising additional types after the
+    /// hoist (e.g. the canon-lift target).
+    type_count: u32,
+};
+
+/// Walk an adapter `AdapterWorld`'s body decls and emit four
+/// parallel slices + a section-order list mirroring the original
+/// declaration order.
+pub fn hoist(arena: Allocator, world: decode.AdapterWorld) Error!Hoisted {
+    var types = std.ArrayListUnmanaged(ctypes.TypeDef).empty;
+    var imports = std.ArrayListUnmanaged(ctypes.ImportDecl).empty;
+    var aliases = std.ArrayListUnmanaged(ctypes.Alias).empty;
+    var entries = std.ArrayListUnmanaged(ctypes.SectionEntry).empty;
+    var instances = std.ArrayListUnmanaged(InstanceSlot).empty;
+    var exports_out = std.ArrayListUnmanaged(ExportInfo).empty;
+
+    var type_idx: u32 = 0;
+    var inst_idx: u32 = 0;
+
+    // We coalesce contiguous runs of the same kind into a single
+    // SectionEntry — multiple same-kind entries are legal but
+    // bigger-than-needed.
+    var run_kind: ?ctypes.SectionKind = null;
+    var run_start: u32 = 0;
+    var run_count: u32 = 0;
+
+    const flush = struct {
+        fn doFlush(
+            ar: Allocator,
+            es: *std.ArrayListUnmanaged(ctypes.SectionEntry),
+            kind: *?ctypes.SectionKind,
+            start: u32,
+            count: u32,
+        ) Error!void {
+            if (kind.* == null or count == 0) return;
+            try es.append(ar, .{ .kind = kind.*.?, .start = start, .count = count });
+        }
+    }.doFlush;
+
+    for (world.body_decls) |d| {
+        const kind: ctypes.SectionKind = switch (d) {
+            .type, .core_type => .type,
+            .import => .import,
+            .alias => .alias,
+            .@"export" => .@"export",
+        };
+
+        // Open or extend a run.
+        if (run_kind) |rk| {
+            if (rk != kind) {
+                try flush(arena, &entries, &run_kind, run_start, run_count);
+                run_kind = kind;
+                run_start = currentStartFor(kind, &types, &imports, &aliases, &exports_out);
+                run_count = 0;
+            }
+        } else {
+            run_kind = kind;
+            run_start = currentStartFor(kind, &types, &imports, &aliases, &exports_out);
+            run_count = 0;
+        }
+
+        // Append the decl into the matching slice.
+        switch (d) {
+            .type => |td| {
+                try types.append(arena, td);
+                type_idx += 1;
+            },
+            .core_type => |ct| {
+                // We don't currently have a separate per-decl
+                // representation for core types vs component types
+                // at the wrapping level. The adapter's encoded
+                // world doesn't actually emit core types in the
+                // body (it's all component-level), so reject if we
+                // ever see one.
+                _ = ct;
+                return error.UnsupportedAdapterShape;
+            },
+            .import => |im| {
+                try imports.append(arena, im);
+                if (im.desc == .instance) {
+                    try instances.append(arena, .{
+                        .name = im.name,
+                        .instance_idx = inst_idx,
+                        .type_idx = im.desc.instance,
+                    });
+                }
+                inst_idx += 1;
+            },
+            .alias => |a| {
+                try aliases.append(arena, a);
+                const sort: ctypes.Sort = switch (a) {
+                    .instance_export => |ie| ie.sort,
+                    .outer => |o| o.sort,
+                };
+                if (sort == .type) type_idx += 1;
+            },
+            .@"export" => |e| {
+                if (e.desc == .instance) {
+                    try exports_out.append(arena, .{
+                        .name = e.name,
+                        .type_idx = e.desc.instance,
+                    });
+                }
+                // The body's `export` decls also create a slot in
+                // the wrapping component's exports[] but the splicer
+                // typically replaces them with its own export of
+                // the lifted instance, so we still emit them for
+                // shape parity. (For our supported adapters this is
+                // a single `wasi:cli/run@<ver>` entry.)
+            },
+        }
+        run_count += 1;
+    }
+
+    try flush(arena, &entries, &run_kind, run_start, run_count);
+
+    return .{
+        .types = try types.toOwnedSlice(arena),
+        .imports = try imports.toOwnedSlice(arena),
+        .aliases = try aliases.toOwnedSlice(arena),
+        .section_order = try entries.toOwnedSlice(arena),
+        .instances = try instances.toOwnedSlice(arena),
+        .exports = try exports_out.toOwnedSlice(arena),
+        .type_count = type_idx,
+    };
+}
+
+fn currentStartFor(
+    kind: ctypes.SectionKind,
+    types: *const std.ArrayListUnmanaged(ctypes.TypeDef),
+    imports: *const std.ArrayListUnmanaged(ctypes.ImportDecl),
+    aliases: *const std.ArrayListUnmanaged(ctypes.Alias),
+    exports_: *const std.ArrayListUnmanaged(ExportInfo),
+) u32 {
+    return switch (kind) {
+        .type => @intCast(types.items.len),
+        .import => @intCast(imports.items.len),
+        .alias => @intCast(aliases.items.len),
+        .@"export" => @intCast(exports_.items.len),
+        else => 0,
+    };
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+const loader = @import("../loader.zig");
+const writer = @import("../writer.zig");
+const metadata_encode = @import("../wit/metadata_encode.zig");
+
+fn buildMockEncodedWorld(allocator: Allocator) ![]u8 {
+    return metadata_encode.encodeWorldFromSource(allocator,
+        \\package mock:adapter@0.1.0;
+        \\
+        \\interface in1 { ping: func() -> u32; }
+        \\interface in2 { pong: func() -> u32; }
+        \\interface out { run: func() -> u32; }
+        \\
+        \\world adapter-mock {
+        \\    import in1;
+        \\    import in2;
+        \\    export out;
+        \\}
+    , "adapter-mock");
+}
+
+test "hoist: copies body decls and tracks instance slots" {
+    const ct = try buildMockEncodedWorld(testing.allocator);
+    defer testing.allocator.free(ct);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const world = try decode.parse(a, ct);
+    const h = try hoist(a, world);
+
+    // 3 instance type defs (in1, in2, out)
+    try testing.expectEqual(@as(usize, 3), h.types.len);
+    // 2 imports (in1, in2)
+    try testing.expectEqual(@as(usize, 2), h.imports.len);
+    // 1 export (out) — captured for the canon-lift step
+    try testing.expectEqual(@as(usize, 1), h.exports.len);
+    try testing.expectEqualStrings("mock:adapter/out@0.1.0", h.exports[0].name);
+
+    // 2 imported instance slots. They sit in the wrapping
+    // component's instance indexspace at 0 and 1.
+    try testing.expectEqual(@as(usize, 2), h.instances.len);
+    try testing.expectEqual(@as(u32, 0), h.instances[0].instance_idx);
+    try testing.expectEqual(@as(u32, 1), h.instances[1].instance_idx);
+    try testing.expectEqualStrings("mock:adapter/in1@0.1.0", h.instances[0].name);
+    try testing.expectEqualStrings("mock:adapter/in2@0.1.0", h.instances[1].name);
+
+    // 3 type defs in the wrapping component's type indexspace.
+    try testing.expectEqual(@as(u32, 3), h.type_count);
+
+    // Body order is interleaved per the wit-component encoder:
+    //   type, import, type, import, type, export
+    // → at minimum 4 alternating runs of (type, import) plus a
+    // trailing (type, export) — total 6 SectionEntries when fully
+    // run-coalesced. Our coalescer never merges different kinds, so
+    // expect exactly 6.
+    try testing.expectEqual(@as(usize, 6), h.section_order.len);
+    try testing.expectEqual(ctypes.SectionKind.type, h.section_order[0].kind);
+    try testing.expectEqual(ctypes.SectionKind.import, h.section_order[1].kind);
+    try testing.expectEqual(ctypes.SectionKind.type, h.section_order[2].kind);
+    try testing.expectEqual(ctypes.SectionKind.import, h.section_order[3].kind);
+    try testing.expectEqual(ctypes.SectionKind.type, h.section_order[4].kind);
+    try testing.expectEqual(ctypes.SectionKind.@"export", h.section_order[5].kind);
+}
+
+test "hoist: roundtrip — emit the hoisted slices and reload" {
+    // Verify the hoisted body forms a structurally valid component
+    // when handed to the writer with section_order set. This is the
+    // closest hermetic check we have to "the splicer's first phase
+    // produces a valid component".
+    const ct = try buildMockEncodedWorld(testing.allocator);
+    defer testing.allocator.free(ct);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const world = try decode.parse(a, ct);
+    const h = try hoist(a, world);
+
+    // Build the wrapping component using ONLY the hoisted body. The
+    // export decls in `h.exports` are kept by the splicer for
+    // tracking but not emitted at the top level here — they live
+    // inside the world-body encoding only. We don't include them in
+    // the round-trip component.
+    //
+    // Strip the .export entries from section_order before encoding.
+    var trimmed = std.ArrayListUnmanaged(ctypes.SectionEntry).empty;
+    for (h.section_order) |se| {
+        if (se.kind != .@"export") try trimmed.append(a, se);
+    }
+
+    const c = ctypes.Component{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = h.aliases,
+        .types = h.types,
+        .canons = &.{},
+        .imports = h.imports,
+        .exports = &.{},
+        .section_order = trimmed.items,
+    };
+
+    const bytes = try writer.encode(testing.allocator, &c);
+    defer testing.allocator.free(bytes);
+
+    var arena2 = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena2.deinit();
+    const decoded = try loader.load(bytes, arena2.allocator());
+    try testing.expectEqual(@as(usize, 3), decoded.types.len);
+    try testing.expectEqual(@as(usize, 2), decoded.imports.len);
+}

--- a/src/component/types.zig
+++ b/src/component/types.zig
@@ -433,6 +433,40 @@ pub const CustomSection = struct {
     payload: []const u8,
 };
 
+/// Physical section kind. Used by `Component.section_order` to drive
+/// interleaved emission when conventional section order would re-order
+/// type-indexspace contributors and break references between them.
+pub const SectionKind = enum {
+    custom,
+    core_module,
+    core_instance,
+    core_type,
+    component,
+    instance,
+    alias,
+    type,
+    canon,
+    start,
+    import,
+    @"export",
+};
+
+/// One physical section emission. `start..start+count` indexes into
+/// the corresponding per-section field on `Component` (e.g. for
+/// `.type`, into `component.types[]`; for `.alias`, into
+/// `component.aliases[]`). For `.start`, both fields are ignored (the
+/// field is a singleton). For `.custom`, indexes into
+/// `component.custom_sections[]`.
+///
+/// Multiple entries with the same `kind` produce multiple physical
+/// sections — legal and routinely necessary when the encoded shape
+/// requires types and imports to interleave.
+pub const SectionEntry = struct {
+    kind: SectionKind,
+    start: u32 = 0,
+    count: u32 = 0,
+};
+
 // ── Top-level Component ─────────────────────────────────────────────────────
 
 /// A parsed WebAssembly Component.
@@ -503,6 +537,14 @@ pub const Component = struct {
     /// only way to faithfully preserve a component's original
     /// section interleaving (which the AST flattens away).
     raw_bytes: ?[]const u8 = null,
+    /// Optional explicit section emission order. When non-null, the
+    /// writer emits one physical section per entry, in order, drawing
+    /// items from the corresponding per-section field. When null, the
+    /// writer falls back to the conventional "types, imports, core
+    /// modules, …" ordering. Required for components whose type
+    /// indexspace interleaves type defs, imports, and aliases — the
+    /// shape `wasm-tools component new --adapt` produces.
+    section_order: ?[]const SectionEntry = null,
 };
 
 /// A single contributor to the core-func index space.

--- a/src/component/writer.zig
+++ b/src/component/writer.zig
@@ -56,6 +56,11 @@ pub fn encode(allocator: Allocator, component: *const ctypes.Component) EncodeEr
     try w.writeU32LE(wasm_magic);
     try w.writeU32LE(component_version);
 
+    if (component.section_order) |order| {
+        try writeOrdered(&w, component, order);
+        return w.buf.toOwnedSlice(allocator);
+    }
+
     // Custom sections are emitted up-front — the wit-component
     // encoding marker section needs to appear before the type section
     // for downstream tooling that scans for it positionally.
@@ -88,6 +93,36 @@ pub fn encode(allocator: Allocator, component: *const ctypes.Component) EncodeEr
     if (component.exports.len > 0) try writeExportSection(&w, component.exports);
 
     return w.buf.toOwnedSlice(allocator);
+}
+
+/// Drive section emission from `component.section_order`. Each entry
+/// produces exactly one physical section containing
+/// `component.<field>[start .. start+count]`.
+fn writeOrdered(
+    w: *Writer,
+    component: *const ctypes.Component,
+    order: []const ctypes.SectionEntry,
+) EncodeError!void {
+    for (order) |entry| {
+        const s = entry.start;
+        const n = entry.count;
+        switch (entry.kind) {
+            .custom => for (component.custom_sections[s .. s + n]) |cs| {
+                try writeCustomSection(w, cs);
+            },
+            .core_module => try writeCoreModuleSection(w, component.core_modules[s .. s + n]),
+            .core_instance => try writeCoreInstanceSection(w, component.core_instances[s .. s + n]),
+            .core_type => try writeCoreTypeSection(w, component.core_types[s .. s + n]),
+            .component => try writeNestedComponentSection(w, component.components[s .. s + n]),
+            .instance => try writeInstanceSection(w, component.instances[s .. s + n]),
+            .alias => try writeAliasSection(w, component.aliases[s .. s + n]),
+            .type => try writeTypeSection(w, component.types[s .. s + n]),
+            .canon => try writeCanonSection(w, component.canons[s .. s + n]),
+            .start => if (component.start) |st| try writeStartSection(w, st),
+            .import => try writeImportSection(w, component.imports[s .. s + n]),
+            .@"export" => try writeExportSection(w, component.exports[s .. s + n]),
+        }
+    }
 }
 
 // ── Internal writer ─────────────────────────────────────────────────────────
@@ -932,4 +967,117 @@ test "encode: import+export round-trip" {
     try std.testing.expectEqual(@as(usize, 1), decoded.exports.len);
     try std.testing.expectEqualStrings("do-thing", decoded.exports[0].name);
     try std.testing.expect(decoded.exports[0].desc == .func);
+}
+
+test "encode: section_order interleaves type+import+alias for resource sharing" {
+    // Mimic the shape `wasm-tools component new --adapt` produces:
+    //
+    //   type 0 = instance { (sub resource) "error" }
+    //   import "wasi:io/error"   instance(type 0)        -> instance idx 0
+    //   alias  export 0 "error"  type                    -> type idx 1
+    //   type 2 = instance { (alias outer 1 1) (eq 1) "error" }
+    //   import "wasi:io/streams" instance(type 2)        -> instance idx 1
+    //
+    // The conventional order ("all types first, then imports, then
+    // aliases") would put alias output at type idx 28 instead of 1,
+    // breaking the `(alias outer 1 1)` ref inside the io/streams
+    // instance type body. `section_order` preserves the interleaving
+    // and keeps the references valid.
+    const allocator = std.testing.allocator;
+
+    const error_decls = [_]ctypes.Decl{
+        .{ .@"export" = .{
+            .name = "error",
+            .desc = .{ .type = .sub_resource },
+        } },
+    };
+    const streams_decls = [_]ctypes.Decl{
+        .{ .alias = .{ .outer = .{
+            .sort = .type,
+            .outer_count = 1,
+            .idx = 1,
+        } } },
+        .{ .@"export" = .{
+            .name = "error",
+            .desc = .{ .type = .{ .eq = 1 } },
+        } },
+    };
+    const types = [_]ctypes.TypeDef{
+        .{ .instance = .{ .decls = &error_decls } },
+        .{ .instance = .{ .decls = &streams_decls } },
+    };
+    const imports = [_]ctypes.ImportDecl{
+        .{ .name = "wasi:io/error@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:io/streams@0.2.6", .desc = .{ .instance = 1 } },
+    };
+    const aliases = [_]ctypes.Alias{
+        .{ .instance_export = .{
+            .sort = .type,
+            .instance_idx = 0,
+            .name = "error",
+        } },
+    };
+
+    const order = [_]ctypes.SectionEntry{
+        .{ .kind = .type, .start = 0, .count = 1 },
+        .{ .kind = .import, .start = 0, .count = 1 },
+        .{ .kind = .alias, .start = 0, .count = 1 },
+        .{ .kind = .type, .start = 1, .count = 1 },
+        .{ .kind = .import, .start = 1, .count = 1 },
+    };
+
+    const c = ctypes.Component{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &aliases,
+        .types = &types,
+        .canons = &.{},
+        .imports = &imports,
+        .exports = &.{},
+        .section_order = &order,
+    };
+
+    const bytes = try encode(allocator, &c);
+    defer allocator.free(bytes);
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const decoded = try loader.load(bytes, arena.allocator());
+
+    try std.testing.expectEqual(@as(usize, 2), decoded.types.len);
+    try std.testing.expectEqual(@as(usize, 2), decoded.imports.len);
+    try std.testing.expectEqual(@as(usize, 1), decoded.aliases.len);
+    try std.testing.expectEqualStrings("wasi:io/error@0.2.6", decoded.imports[0].name);
+    try std.testing.expectEqualStrings("wasi:io/streams@0.2.6", decoded.imports[1].name);
+    // Alias placed between the imports — its output is type idx 1, so
+    // the streams instance's `(alias outer 1 1)` resolves correctly.
+    try std.testing.expect(decoded.aliases[0] == .instance_export);
+    try std.testing.expectEqualStrings("error", decoded.aliases[0].instance_export.name);
+}
+
+test "encode: section_order with no entries emits empty body after preamble" {
+    const allocator = std.testing.allocator;
+
+    const c = ctypes.Component{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &.{},
+        .imports = &.{},
+        .exports = &.{},
+        .section_order = &.{},
+    };
+
+    const bytes = try encode(allocator, &c);
+    defer allocator.free(bytes);
+
+    try std.testing.expectEqual(@as(usize, 8), bytes.len);
+    try std.testing.expectEqualSlices(u8, &.{ 0x00, 0x61, 0x73, 0x6d, 0x0d, 0x00, 0x01, 0x00 }, bytes);
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -46,6 +46,8 @@ pub const component = struct {
     pub const adapter = struct {
         pub const decode = @import("component/adapter/decode.zig");
         pub const core_imports = @import("component/adapter/core_imports.zig");
+        pub const shim = @import("component/adapter/shim.zig");
+        pub const fixup = @import("component/adapter/fixup.zig");
     };
 };
 
@@ -69,6 +71,8 @@ test {
     _ = @import("component/wit/metadata_decode.zig");
     _ = @import("component/adapter/decode.zig");
     _ = @import("component/adapter/core_imports.zig");
+    _ = @import("component/adapter/shim.zig");
+    _ = @import("component/adapter/fixup.zig");
     _ = @import("integration_tests.zig");
     _ = @import("spec_tests.zig");
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -49,6 +49,7 @@ pub const component = struct {
         pub const shim = @import("component/adapter/shim.zig");
         pub const fixup = @import("component/adapter/fixup.zig");
         pub const types_import = @import("component/adapter/types_import.zig");
+        pub const abi = @import("component/adapter/abi.zig");
     };
 };
 
@@ -75,6 +76,7 @@ test {
     _ = @import("component/adapter/shim.zig");
     _ = @import("component/adapter/fixup.zig");
     _ = @import("component/adapter/types_import.zig");
+    _ = @import("component/adapter/abi.zig");
     _ = @import("integration_tests.zig");
     _ = @import("spec_tests.zig");
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -43,6 +43,9 @@ pub const component = struct {
         pub const metadata_encode = @import("component/wit/metadata_encode.zig");
         pub const metadata_decode = @import("component/wit/metadata_decode.zig");
     };
+    pub const adapter = struct {
+        pub const decode = @import("component/adapter/decode.zig");
+    };
 };
 
 /// Maximum input file size (256 MiB). Prevents OOM from oversized or malicious input.
@@ -63,6 +66,7 @@ test {
     _ = @import("component/wit/resolver.zig");
     _ = @import("component/wit/metadata_encode.zig");
     _ = @import("component/wit/metadata_decode.zig");
+    _ = @import("component/adapter/decode.zig");
     _ = @import("integration_tests.zig");
     _ = @import("spec_tests.zig");
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -45,6 +45,7 @@ pub const component = struct {
     };
     pub const adapter = struct {
         pub const decode = @import("component/adapter/decode.zig");
+        pub const core_imports = @import("component/adapter/core_imports.zig");
     };
 };
 
@@ -67,6 +68,7 @@ test {
     _ = @import("component/wit/metadata_encode.zig");
     _ = @import("component/wit/metadata_decode.zig");
     _ = @import("component/adapter/decode.zig");
+    _ = @import("component/adapter/core_imports.zig");
     _ = @import("integration_tests.zig");
     _ = @import("spec_tests.zig");
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -50,6 +50,7 @@ pub const component = struct {
         pub const fixup = @import("component/adapter/fixup.zig");
         pub const types_import = @import("component/adapter/types_import.zig");
         pub const abi = @import("component/adapter/abi.zig");
+        pub const adapter = @import("component/adapter/adapter.zig");
     };
 };
 
@@ -77,6 +78,7 @@ test {
     _ = @import("component/adapter/fixup.zig");
     _ = @import("component/adapter/types_import.zig");
     _ = @import("component/adapter/abi.zig");
+    _ = @import("component/adapter/adapter.zig");
     _ = @import("integration_tests.zig");
     _ = @import("spec_tests.zig");
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -48,6 +48,7 @@ pub const component = struct {
         pub const core_imports = @import("component/adapter/core_imports.zig");
         pub const shim = @import("component/adapter/shim.zig");
         pub const fixup = @import("component/adapter/fixup.zig");
+        pub const types_import = @import("component/adapter/types_import.zig");
     };
 };
 
@@ -73,6 +74,7 @@ test {
     _ = @import("component/adapter/core_imports.zig");
     _ = @import("component/adapter/shim.zig");
     _ = @import("component/adapter/fixup.zig");
+    _ = @import("component/adapter/types_import.zig");
     _ = @import("integration_tests.zig");
     _ = @import("spec_tests.zig");
 }

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -4,27 +4,32 @@
 //! Drop-in subset of `wasm-tools component new` for the wamr build
 //! pipeline:
 //!
-//!   wabt component new [-o <out>] [--skip-validation] <input.wasm>
+//!   wabt component new [-o <out>] [--skip-validation]
+//!                      [--adapt <name>=<adapter.wasm>] <input.wasm>
 //!
 //! The input core wasm must already have a `component-type:<world>`
 //! custom section produced by `wabt component embed` (or
 //! `wasm-tools component embed`).
 //!
-//! For each export interface declared by the world, this builds:
+//! Two paths:
 //!
-//!   * a core-instance alias for the matching `<iface>#<func>` core
-//!     export,
-//!   * a component-level func type matching the interface's signature,
-//!   * a `(canon lift)` wrapping the core export at the component
-//!     type,
-//!   * a component-level instance bundling the lifted func(s),
-//!   * a top-level export of that instance under the qualified name.
+//! 1. **Plain wrap** (no `--adapt`): for each export interface in the
+//!    world, build a core-instance alias for the matching
+//!    `<iface>#<func>` export, a component-level func type matching
+//!    the interface's signature, a `(canon lift)`, an instance
+//!    bundling the lifted funcs, and a top-level export under the
+//!    qualified interface name. Suitable for plain reactor-style
+//!    cores like the wamr `zig-adder` fixture.
 //!
-//! Exports without param/return types and any *imports* declared by
-//! the world are deferred to the next iteration (`--adapt` /
-//! WASI-preview1 splicing). This is enough to handle the wamr
-//! `zig-adder` fixture end-to-end (one export interface, one func,
-//! u32×2 → u32) and serves as the substrate for the import path.
+//! 2. **Adapter splice** (`--adapt wasi_snapshot_preview1=<a.wasm>`):
+//!    delegate to `wabt.component.adapter.adapter.splice`, which
+//!    composes the embed core with the given preview1→component
+//!    adapter into a four- or five-core-module component (shim,
+//!    embed, adapter, fixup, optional `__main_module__` fallback)
+//!    and lifts `wasi:cli/run` for top-level export. Mirrors
+//!    `wasm-tools component new --adapt …` and unblocks the
+//!    `zig-hello`, `zig-calculator-cmd`, and `mixed-zig-rust-calc`
+//!    wamr command-component fixtures.
 
 const std = @import("std");
 const wabt = @import("wabt");

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -46,7 +46,8 @@ pub const usage =
     \\Options:
     \\  -o, --output <file>     Output file (default: <input>.component.wasm)
     \\      --skip-validation   Skip post-encoding component validation
-    \\      --adapt <n>=<file>  (Reserved — adapter splicing TBD)
+    \\      --adapt <n>=<file>  Splice in a wasi-preview1 adapter (e.g.
+    \\                          --adapt wasi_snapshot_preview1=path/to/adapter.wasm)
     \\  -h, --help              Show this help
     \\
 ;
@@ -57,6 +58,8 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var output_file: ?[]const u8 = null;
     var skip_validation: bool = false;
     var input_path: ?[]const u8 = null;
+    var adapt_name: ?[]const u8 = null;
+    var adapt_file: ?[]const u8 = null;
 
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
@@ -74,8 +77,22 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
         } else if (std.mem.eql(u8, arg, "--skip-validation")) {
             skip_validation = true;
         } else if (std.mem.eql(u8, arg, "--adapt")) {
-            std.debug.print("error: --adapt is not yet implemented in wabt\n", .{});
-            std.process.exit(1);
+            i += 1;
+            if (i >= sub_args.len) {
+                std.debug.print("error: --adapt requires an argument of the form <name>=<file>\n", .{});
+                std.process.exit(1);
+            }
+            const spec = sub_args[i];
+            const eq = std.mem.indexOfScalar(u8, spec, '=') orelse {
+                std.debug.print("error: --adapt expects <name>=<file>, got '{s}'\n", .{spec});
+                std.process.exit(1);
+            };
+            if (adapt_name != null) {
+                std.debug.print("error: only one --adapt is supported\n", .{});
+                std.process.exit(1);
+            }
+            adapt_name = spec[0..eq];
+            adapt_file = spec[eq + 1 ..];
         } else if (std.mem.startsWith(u8, arg, "-")) {
             std.debug.print("error: unknown option '{s}'. Use `wabt help component`.\n", .{arg});
             std.process.exit(1);
@@ -112,9 +129,28 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
         break :blk std.fmt.allocPrint(alloc, "{s}.component.wasm", .{in_path}) catch in_path;
     };
 
-    const out_bytes = buildComponent(alloc, core_bytes) catch |err| {
-        std.debug.print("error: building component: {s}\n", .{@errorName(err)});
-        std.process.exit(1);
+    const out_bytes = blk: {
+        if (adapt_name) |aname| {
+            const adp_path = adapt_file.?;
+            const adp_bytes = std.Io.Dir.cwd().readFileAlloc(
+                init.io,
+                adp_path,
+                alloc,
+                std.Io.Limit.limited(wabt.max_input_file_size),
+            ) catch |err| {
+                std.debug.print("error: cannot read adapter '{s}': {any}\n", .{ adp_path, err });
+                std.process.exit(1);
+            };
+            defer alloc.free(adp_bytes);
+            break :blk wabt.component.adapter.adapter.splice(alloc, core_bytes, adp_bytes, aname) catch |err| {
+                std.debug.print("error: splicing adapter '{s}': {s}\n", .{ aname, @errorName(err) });
+                std.process.exit(1);
+            };
+        }
+        break :blk buildComponent(alloc, core_bytes) catch |err| {
+            std.debug.print("error: building component: {s}\n", .{@errorName(err)});
+            std.process.exit(1);
+        };
     };
     defer alloc.free(out_bytes);
 


### PR DESCRIPTION
## Summary

Closes #111. Implements `wabt component new --adapt
wasi_snapshot_preview1=<adapter.wasm>` so the wamr command-component
fixtures (`zig-hello`, `zig-calculator-cmd`, `mixed-zig-rust-calc`)
build end-to-end through wabt instead of `wasm-tools component new`.

The previous `--adapt` stub at `src/tools/component_new.zig:77`
exited with "not yet implemented"; this PR replaces it with a full
splicing pipeline that mirrors `wasm-tools component new --adapt …`.

## What ships

A new `src/component/adapter/` module hierarchy:

- **`adapter.zig`** — orchestrator. `splice(gpa, embed_bytes,
  adapter_bytes, adapter_name) ![]u8` is the single entrypoint.
  Walks the adapter's encoded world, classifies each WASI import
  via canon-ABI (direct vs indirect), bundles per namespace,
  synthesizes shim/fixup/main-fallback core modules, hoists the
  adapter's type tree, and emits a 4- or 5-core-module wrapping
  component.
- **`abi.zig`** — canon-ABI classifier + per-slot flattener.
- **`decode.zig`** — extracts the adapter's `component-type:…:encoded
  world` custom section and surfaces imports/exports/run-export.
  Also accepts the bare `component-type` name produced by
  `wasm-tools component embed` so we can recover original FuncType
  param names from the embed's component-type section.
- **`core_imports.zig`** — parses adapter/embed core wasm to recover
  `(module, name, sig)` triples.
- **`shim.zig` / `fixup.zig`** — synthesize the shim core module
  (trampoline funcs that index into a `$imports` table) and the
  fixup core module (active element segment that patches the table
  at start time with the real adapter funcs).
- **`types_import.zig`** — hoists the adapter's encoded-world body
  decls verbatim into the wrapping component using the new
  `Component.section_order` mechanism so type/import/alias decls
  stay interleaved (required for resource-aware
  `(alias outer 1 X)` references).

Component-side plumbing:

- **`Component.section_order`** + writer support — when set, the
  writer emits sections in the listed order rather than the
  conventional one. Zero behavior change for existing callers
  (defaults to null).

CLI:

- **`component_new.zig`** — parses `--adapt <name>=<file>` and
  dispatches to `adapter.splice` when present; falls back to the
  existing `buildComponent` plain-wrap path when absent.

## Verification

- `zig build test`: **340/340** pass (was 336 before this PR;
  +4 new tests covering orchestrator helpers + the existing adapter
  submodule tests). Pre-existing `wast_runner UndefinedElement`
  failure is unrelated.
- `wasm-tools validate` accepts every output produced by the splicer.
- `wasm-tools component wit` extracts a structurally equivalent
  world to the `wasm-tools` reference output (just larger because
  we don't GC).
- All three wamr command-component fixtures
  (`zig-hello`, `zig-calculator-cmd`, `mixed-zig-rust-calc`) build
  end-to-end through wabt + wasm-tools compose (where applicable)
  + wamr and produce the expected stdout/stderr.

## Notable design decisions

- **Type-tree provenance**: the WASI 0.2.6 type tree is extracted
  from the adapter binary's own `component-type:…:encoded world`
  custom section rather than hand-vendored. Tracks whatever WASI
  version the adapter declares; shrinks LOC dramatically.
- **`__main_module__` fallback**: the v36.0.9 adapter imports
  `__main_module__.cabi_realloc`, which none of the wamr fixtures
  export. Rather than reject, we synthesize a fifth core module
  whose body is `unreachable; end` for each missing
  `__main_module__.<name>`. This is fine for these fixtures because
  the adapter doesn't actually call back into `cabi_realloc` at
  runtime; if any future embed does, the runtime gets a clean trap
  instead of an unbounded fault.
- **Non-WASI embed imports**: the calculator/mixed fixtures' embeds
  declare a `docs:adder/add@0.1.0` import. The orchestrator lifts
  these to top-level component-level instance imports (preserving
  param names from the embed's `component-type` section when
  present) and bundles canon-lowered core funcs back into an
  inline-export instance for the embed.

## Out of scope (filed as follow-ups)

- Adapter GC / dead-func trimming (mirror of
  `wit-component/src/gc.rs`). Output components validate and run
  but are larger than `wasm-tools` output.
- Multi-`--adapt` (more than one `--adapt` per invocation). The
  fixtures only use one preview1 adapter; we currently reject the
  second `--adapt`. `wasm-tools` supports it.
- Reactor / library components.
- WASI 0.2.7+.
- Synthetic mock-adapter end-to-end test (full `splice()`
  round-trip on hand-built fixtures). Per-module helpers + the
  orchestrator's standalone helpers are unit-tested; the full path
  is exercised by the wamr fixtures out-of-tree.

## Commits

The diff is split into 12 reviewer-friendly commits:

1. `component: add Component.section_order for interleaved emission`
2. `component/adapter: decode wasi adapter encoded-world metadata`
3. `component/adapter: extract core wasm import/export tables`
4. `component/adapter: synthesize shim and fixup core modules`
5. `component/adapter: hoist adapter encoded-world body into wrapping component`
6. `component/adapter: switch fixup to active element segment`
7. `component/adapter: classify wasi imports via canon-ABI flattening`
8. `component/adapter/abi: produce per-slot canon-ABI flat types`
9. `component/adapter/decode: also accept bare \`component-type\` custom name`
10. `component/adapter: orchestrator for adapter splicing`
11. `component new: wire \`--adapt\` flag to adapter splicer`
12. `component/adapter: tests + refresh \`component new\` doc comment`
