### PR TITLE
component/adapter: GC encoded-world AST before splicing

### DIFF
--- a/src/binary/reader.zig
+++ b/src/binary/reader.zig
@@ -405,9 +405,13 @@ const Reader = struct {
                 const limits = try self.readLimits();
                 var init_bytes: []const u8 = &.{};
                 if (has_init) {
-                    const init_start = self.pos;
-                    try self.skipInitExpr();
-                    init_bytes = self.data[init_start..self.pos];
+                    const expr_with_end = try self.readInitExprBytes();
+                    // Writer appends its own trailing 0x0b — match the
+                    // global init-expr convention and strip it here.
+                    init_bytes = if (expr_with_end.len > 0)
+                        expr_with_end[0 .. expr_with_end.len - 1]
+                    else
+                        expr_with_end;
                 }
                 try self.module.tables.append(self.allocator, .{
                     .type = .{ .elem_type = elem_type, .limits = limits },
@@ -497,7 +501,11 @@ const Reader = struct {
 
             if (!is_passive) {
                 if (has_explicit_index) seg.table_var = .{ .index = try self.readU32() };
-                seg.offset_expr_bytes = try self.readInitExprBytes();
+                const expr_with_end = try self.readInitExprBytes();
+                seg.offset_expr_bytes = if (expr_with_end.len > 0)
+                    expr_with_end[0 .. expr_with_end.len - 1]
+                else
+                    expr_with_end;
             }
 
             if (is_passive or has_explicit_index) {
@@ -574,7 +582,11 @@ const Reader = struct {
             } else {
                 seg.kind = .active;
                 if (flags & 2 != 0) seg.memory_var = .{ .index = try self.readU32() };
-                seg.offset_expr_bytes = try self.readInitExprBytes();
+                const expr_with_end = try self.readInitExprBytes();
+                seg.offset_expr_bytes = if (expr_with_end.len > 0)
+                    expr_with_end[0 .. expr_with_end.len - 1]
+                else
+                    expr_with_end;
             }
 
             const data_len = try self.readU32();

--- a/src/binary/writer.zig
+++ b/src/binary/writer.zig
@@ -717,9 +717,11 @@ test "text parse + binary write: data segment offset preserved" {
 
     try std.testing.expectEqual(@as(usize, 1), module2.data_segments.items.len);
     try std.testing.expectEqual(@as(usize, 2), module2.data_segments.items[0].data.len);
-    // The offset expression should contain i32.const 16, not i32.const 0
+    // The offset expression should contain i32.const 16, not i32.const 0.
+    // Convention: reader stores offset_expr_bytes WITHOUT trailing 0x0b
+    // (writer appends 0x0b).
     const offset_bytes = module2.data_segments.items[0].offset_expr_bytes;
-    try std.testing.expect(offset_bytes.len >= 3);
+    try std.testing.expectEqual(@as(usize, 2), offset_bytes.len);
     try std.testing.expectEqual(@as(u8, 0x41), offset_bytes[0]); // i32.const
     // LEB128 for 16 = 0x10
     try std.testing.expectEqual(@as(u8, 0x10), offset_bytes[1]);
@@ -819,4 +821,91 @@ test "text parse + binary write: passive elem segment" {
     try std.testing.expectEqual(@as(usize, 1), module2.elem_segments.items.len);
     // Passive segment with elem expressions
     try std.testing.expect(module2.elem_segments.items[0].kind == .passive);
+}
+
+test "text parse + binary write: active elem segment offset preserved without trailing 0x0b" {
+    const allocator = std.testing.allocator;
+    const Parser = @import("../text/Parser.zig");
+
+    var module = try Parser.parseModule(allocator,
+        \\(module
+        \\  (table 10 funcref)
+        \\  (func) (func)
+        \\  (elem (i32.const 5) func 0 1)
+        \\)
+    );
+    defer module.deinit();
+
+    const wasm = try writeModule(allocator, &module);
+    defer allocator.free(wasm);
+
+    var module2 = try reader.readModule(allocator, wasm);
+    defer module2.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), module2.elem_segments.items.len);
+    const seg = module2.elem_segments.items[0];
+    try std.testing.expect(seg.kind == .active);
+    // offset_expr_bytes should be `i32.const 5` only — no trailing 0x0b
+    // (writer appends it when re-encoding).
+    try std.testing.expectEqual(@as(usize, 2), seg.offset_expr_bytes.len);
+    try std.testing.expectEqual(@as(u8, 0x41), seg.offset_expr_bytes[0]);
+    try std.testing.expectEqual(@as(u8, 5), seg.offset_expr_bytes[1]);
+
+    // Round-trip a second time: writing the read-back module must
+    // produce a valid binary with exactly one 0x0b terminator on the
+    // offset expr (regression for the prior "writer appends 0x0b on
+    // top of a slice that already includes 0x0b" double-terminator
+    // bug).
+    const wasm2 = try writeModule(allocator, &module2);
+    defer allocator.free(wasm2);
+    var module3 = try reader.readModule(allocator, wasm2);
+    defer module3.deinit();
+    try std.testing.expectEqual(@as(usize, 1), module3.elem_segments.items.len);
+    try std.testing.expectEqual(@as(usize, 2), module3.elem_segments.items[0].offset_expr_bytes.len);
+}
+
+test "binary read+write: defined table with init expression round-trips" {
+    // Hand-rolled core wasm with a table that carries an init expr
+    // (extended form, 0x40 prefix) — exercises the fixed
+    // readTableSection init-expr capture path.
+    const allocator = std.testing.allocator;
+
+    // Module: table type section + table section with one
+    // funcref-typed table whose init expression is `ref.null func`
+    // (the only init expr currently representable for funcref tables
+    // without referencing a function).
+    //
+    //   magic + version
+    //   table section (id 4):
+    //     count=1
+    //     0x40 0x00      -- extended-form prefix
+    //     0x70           -- funcref reftype
+    //     0x00 0x01      -- limits: min=1, no max
+    //     0xd0 0x70 0x0b -- init expr: ref.null func; end
+    const src = [_]u8{
+        // preamble
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // table section: id=4, size=9, count=1, body
+        0x04, 0x09, 0x01,
+        0x40, 0x00, 0x70, 0x00, 0x01,
+        0xd0, 0x70, 0x0b,
+    };
+
+    var module = try reader.readModule(allocator, &src);
+    defer module.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), module.tables.items.len);
+    const t = module.tables.items[0];
+    // Reader should have stripped the trailing 0x0b.
+    try std.testing.expectEqual(@as(usize, 2), t.init_expr_bytes.len);
+    try std.testing.expectEqual(@as(u8, 0xd0), t.init_expr_bytes[0]); // ref.null
+    try std.testing.expectEqual(@as(u8, 0x70), t.init_expr_bytes[1]); // funcref
+
+    // Round-trip writes a structurally equivalent module.
+    const wasm2 = try writeModule(allocator, &module);
+    defer allocator.free(wasm2);
+    var module2 = try reader.readModule(allocator, wasm2);
+    defer module2.deinit();
+    try std.testing.expectEqual(@as(usize, 1), module2.tables.items.len);
+    try std.testing.expectEqual(@as(usize, 2), module2.tables.items[0].init_expr_bytes.len);
 }

--- a/src/component/adapter/adapter.zig
+++ b/src/component/adapter/adapter.zig
@@ -40,6 +40,7 @@ const shim = @import("shim.zig");
 const fixup = @import("fixup.zig");
 const abi = @import("abi.zig");
 const gc = @import("gc.zig");
+const world_gc = @import("world_gc.zig");
 
 pub const SpliceError = error{
     OutOfMemory,
@@ -91,34 +92,40 @@ pub fn splice(
     // call graph from the preview1 exports the embed actually
     // imports plus the adapter's `wasi:cli/run` entry point, drop
     // every func/global/table/elem/data/import that's unreachable.
-    // This shrinks the embedded adapter core wasm dramatically and
-    // is the prerequisite for any future top-level WASI import
-    // pruning (bug #2's full fix). For now we still hoist the
-    // adapter's full encoded-world body — top-level import filtering
-    // requires a follow-up that re-encodes the encoded world to keep
-    // alias instance-index references valid; see TODO below.
+    // This shrinks the embedded adapter core wasm dramatically.
     const required_exports = try computeRequiredAdapterExports(a, embed_bytes, adapter_bytes, adapter_name);
-    const gc_bytes = try gc.run(gpa, adapter_bytes, required_exports);
-    defer gpa.free(gc_bytes);
+    const gc_bytes_initial = try gc.run(gpa, adapter_bytes, required_exports);
+    defer gpa.free(gc_bytes_initial);
+
+    // ── Phase A.1: GC the encoded-world AST ────────────────────────────────
+    //
+    // The core-wasm GC drops dead functions but the wrapping
+    // component's top-level imports come from the adapter's encoded
+    // world body, which still type-declares every WASI namespace the
+    // adapter ships. Compute the live namespace set from the GC'd
+    // adapter's actual core imports, prune the encoded-world AST to
+    // match (renumbering instance / type indices for the surviving
+    // subset), then splice the pruned encoded-world bytes back into
+    // the adapter core wasm so the embedded module advertises only
+    // what it imports.
+    const pristine_world = try decode.parseFromAdapterCore(a, gc_bytes_initial);
+    var pristine_iface = try core_imports.extract(gpa, gc_bytes_initial);
+    defer pristine_iface.deinit();
+
+    const live_namespaces = try collectLiveNamespaces(a, pristine_iface.interface);
+    const live_export_names = try collectLiveExportNames(a, pristine_world);
+
+    const gc_world_result = try world_gc.gcWorld(a, pristine_world, live_namespaces, live_export_names);
+    const gc_bytes = try world_gc.replaceEncodedWorldSection(a, gc_bytes_initial, gc_world_result.payload_bytes);
 
     // ── Phase A: decode + classify ─────────────────────────────────────────
-    const world = try decode.parseFromAdapterCore(a, gc_bytes);
+    const world = gc_world_result.world;
 
     var adapter_owned = try core_imports.extract(gpa, gc_bytes);
     defer adapter_owned.deinit();
     var embed_owned = try core_imports.extract(gpa, embed_bytes);
     defer embed_owned.deinit();
 
-    // TODO (bug #2 follow-up): once the encoded-world AST can be
-    // re-emitted with a renumbered instance index space, filter the
-    // hoisted body to only the namespaces actually imported by the
-    // GC'd adapter (`adapter_owned.interface.imports`). Right now we
-    // hoist verbatim, so the wrapping component still advertises
-    // every WASI namespace the adapter type-declares. The core wasm
-    // is GC'd correctly, so runtime trapping due to spurious WASI
-    // imports the host doesn't wire is mitigated for embeds whose
-    // preview1 surface is small, but unused namespaces still leak as
-    // top-level imports.
     const hoisted = try types_import.hoist(a, world);
 
     // The embed may carry its own `component-type` custom section
@@ -152,7 +159,7 @@ pub fn splice(
         .gpa = gpa,
         .arena = a,
         .embed_bytes = try stripComponentTypeSections(a, embed_bytes),
-        .adapter_bytes = try arenaDup(a, gc_bytes),
+        .adapter_bytes = gc_bytes,
         .shim_bytes = shim_bytes,
         .fixup_bytes = fixup_bytes,
         .adapter_name = adapter_name,
@@ -164,6 +171,39 @@ pub fn splice(
         .preview1_slots = preview1_slots,
         .buckets = buckets,
     });
+}
+
+/// Collect the set of unique component-instance import names from the
+/// GC'd adapter's actual core wasm imports. These are the WASI
+/// namespaces (e.g. `wasi:cli/environment@0.2.6`) the adapter still
+/// uses after core-wasm GC; everything else can be pruned from the
+/// encoded world. Excludes the synthetic `env` and `__main_module__`
+/// modules which are wired separately in `assemble`.
+fn collectLiveNamespaces(
+    arena: Allocator,
+    adapter_iface: core_imports.CoreInterface,
+) SpliceError![]const []const u8 {
+    var seen = std.StringHashMapUnmanaged(void).empty;
+    defer seen.deinit(arena);
+    var out = std.ArrayListUnmanaged([]const u8).empty;
+    for (adapter_iface.imports) |im| {
+        if (std.mem.eql(u8, im.module_name, "env")) continue;
+        if (std.mem.eql(u8, im.module_name, "__main_module__")) continue;
+        const gop = try seen.getOrPut(arena, im.module_name);
+        if (!gop.found_existing) try out.append(arena, im.module_name);
+    }
+    return out.toOwnedSlice(arena);
+}
+
+/// All world body exports are live by construction — the splicer
+/// always lifts them at the wrapping component's top level.
+fn collectLiveExportNames(
+    arena: Allocator,
+    world: decode.AdapterWorld,
+) SpliceError![]const []const u8 {
+    const out = try arena.alloc([]const u8, world.exports.len);
+    for (world.exports, out) |e, *o| o.* = e.name;
+    return out;
 }
 
 /// Compute the export-name set the adapter must keep alive for the

--- a/src/component/adapter/world_gc.zig
+++ b/src/component/adapter/world_gc.zig
@@ -1,0 +1,968 @@
+//! Encoded-world AST garbage collection for adapter splicing.
+//!
+//! Companion to `gc.zig` (which GC's the adapter's core wasm). This
+//! module GC's the adapter's `:encoded world` payload — the component
+//! AST inside the `component-type:…:encoded world` custom section.
+//!
+//! Why this needs its own pass: the encoded world references
+//! component-instances by absolute index. The wasi-preview1 adapter
+//! type-declares ~25 WASI namespaces in a fixed order; if the embed
+//! only uses a few, the rest still leak as top-level imports of the
+//! wrapping component (because `types_import.hoist` deliberately
+//! doesn't renumber — see its module header). Naive import filtering
+//! is unsafe: dropping a body-level import shifts every subsequent
+//! instance index and breaks every `(alias outer 1 N)` that points
+//! at a dropped or shifted slot.
+//!
+//! What this module does:
+//!
+//!   1. Walk the body decls to compute, for each decl, the type /
+//!      instance slot it produces and the type / instance idxs it
+//!      references (including outer-alias `idx` operands inside
+//!      depth-1 instance-type bodies, which read the world body's
+//!      type indexspace).
+//!   2. Seed liveness from the live namespace set (imports whose
+//!      `name` matches) and the live export name set (typically
+//!      `wasi:cli/run@<ver>`); transitively close to fixed point.
+//!   3. Build per-indexspace remap tables (type_old→new,
+//!      inst_old→new) for the surviving subset.
+//!   4. Deep-clone surviving body decls with operands rewritten via
+//!      the remaps. Outer-alias `idx` operands inside depth-1 type
+//!      bodies are rewritten via the world-body type remap, so
+//!      hoisting the GC'd body to the top of the wrapping component
+//!      keeps every nested outer alias valid.
+//!   5. Rebuild the encoded-world wrapper component (preserving the
+//!      shape `decode.parse` expects), encode via `writer.encode`,
+//!      and re-parse via `decode.parse` so the returned `AdapterWorld`
+//!      is structurally consistent and ready to feed into
+//!      `types_import.hoist` verbatim.
+//!
+//! Out of scope:
+//!
+//!   * Component-type bodies inside the world body (the wasi-preview1
+//!     adapter doesn't use them) — rejected with
+//!     `error.UnsupportedAdapterShape`.
+//!   * Adapters whose body uses non-instance imports (also unused by
+//!     the v36.0.9 adapter). Type/func/value/component imports would
+//!     contribute to other indexspaces; we follow `decode.zig`'s
+//!     simplification and treat every import as an instance-import
+//!     for indexspace bookkeeping.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const ctypes = @import("../types.zig");
+const decode = @import("decode.zig");
+const loader = @import("../loader.zig");
+const writer = @import("../writer.zig");
+const leb128 = @import("../../leb128.zig");
+
+pub const Error = error{
+    OutOfMemory,
+    UnsupportedAdapterShape,
+    ValueTooLarge,
+    InvalidAdapterCore,
+    MissingEncodedWorld,
+} || loader.LoadError;
+
+const SENTINEL: u32 = std.math.maxInt(u32);
+
+pub const Result = struct {
+    /// Pruned `AdapterWorld` ready to feed into `types_import.hoist`.
+    world: decode.AdapterWorld,
+    /// Encoded payload bytes for the rebuilt `:encoded world` custom
+    /// section. Owned by the caller's arena.
+    payload_bytes: []const u8,
+};
+
+/// GC the world.
+///
+/// `live_namespaces` is the set of import names that must survive
+/// (e.g. `wasi:cli/environment@0.2.6`) — usually computed from the
+/// GC'd adapter core wasm's actual `module_name`s.
+///
+/// `live_export_names` is the set of body-level export names that
+/// must survive (e.g. `wasi:cli/run@0.2.6`). For the wasi-preview1
+/// command adapter this is exactly one entry.
+///
+/// Names not present in the world are silently ignored — the caller
+/// (the splicer) computes both sets from runtime data and the world
+/// may have shifted between adapter versions.
+pub fn gcWorld(
+    arena: Allocator,
+    world: decode.AdapterWorld,
+    live_namespaces: []const []const u8,
+    live_export_names: []const []const u8,
+) Error!Result {
+    // ── Step 1: per-decl metadata pre-pass ────────────────────────────────
+    const meta = try buildDeclMeta(arena, world.body_decls);
+
+    // ── Step 2: liveness ──────────────────────────────────────────────────
+    var live_decls = try std.DynamicBitSetUnmanaged.initEmpty(arena, world.body_decls.len);
+    var live_types = try std.DynamicBitSetUnmanaged.initEmpty(arena, world.body_type_count);
+    // Instance count: number of imports (matching decode's bookkeeping).
+    var inst_count: u32 = 0;
+    for (world.body_decls) |d| if (d == .import) {
+        inst_count += 1;
+    };
+    var live_inst = try std.DynamicBitSetUnmanaged.initEmpty(arena, inst_count);
+
+    // Seed: imports/exports matching the live name sets.
+    for (world.body_decls, 0..) |d, i| {
+        switch (d) {
+            .import => |im| {
+                if (containsName(live_namespaces, im.name)) live_decls.set(i);
+            },
+            .@"export" => |e| {
+                if (containsName(live_export_names, e.name)) live_decls.set(i);
+            },
+            else => {},
+        }
+    }
+
+    // Fixed-point: any live decl marks its type/instance refs live;
+    // any live type/instance idx marks the decl that produces it
+    // live; that in turn pulls more refs. Iterate until stable.
+    var changed = true;
+    while (changed) {
+        changed = false;
+
+        // Propagate refs of live decls.
+        for (world.body_decls, 0..) |_, i| {
+            if (!live_decls.isSet(i)) continue;
+            for (meta[i].type_refs) |t| {
+                if (t < live_types.bit_length and !live_types.isSet(t)) {
+                    live_types.set(t);
+                    changed = true;
+                }
+            }
+            for (meta[i].inst_refs) |s| {
+                if (s < live_inst.bit_length and !live_inst.isSet(s)) {
+                    live_inst.set(s);
+                    changed = true;
+                }
+            }
+        }
+
+        // Live indexspace slots → mark the producing decl live.
+        for (world.body_decls, 0..) |_, i| {
+            if (live_decls.isSet(i)) continue;
+            const m = meta[i];
+            const become_live = blk: {
+                if (m.type_slot) |t| if (t < live_types.bit_length and live_types.isSet(t)) break :blk true;
+                if (m.inst_slot) |s| if (s < live_inst.bit_length and live_inst.isSet(s)) break :blk true;
+                break :blk false;
+            };
+            if (become_live) {
+                live_decls.set(i);
+                changed = true;
+            }
+        }
+    }
+
+    // ── Step 3: per-indexspace remaps ─────────────────────────────────────
+    var type_remap = try arena.alloc(u32, world.body_type_count);
+    @memset(type_remap, SENTINEL);
+    var inst_remap = try arena.alloc(u32, inst_count);
+    @memset(inst_remap, SENTINEL);
+
+    var new_type_cursor: u32 = 0;
+    var new_inst_cursor: u32 = 0;
+    for (world.body_decls, 0..) |_, i| {
+        if (!live_decls.isSet(i)) continue;
+        const m = meta[i];
+        if (m.type_slot) |t| {
+            type_remap[t] = new_type_cursor;
+            new_type_cursor += 1;
+        }
+        if (m.inst_slot) |s| {
+            inst_remap[s] = new_inst_cursor;
+            new_inst_cursor += 1;
+        }
+    }
+
+    // ── Step 4: deep-clone surviving decls with rewritten operands ────────
+    var new_decls = std.ArrayListUnmanaged(ctypes.Decl).empty;
+    for (world.body_decls, 0..) |d, i| {
+        if (!live_decls.isSet(i)) continue;
+        const cloned = try cloneDecl(arena, d, type_remap, inst_remap);
+        try new_decls.append(arena, cloned);
+    }
+    const new_body_decls = try new_decls.toOwnedSlice(arena);
+
+    // ── Step 5: rebuild outer wrapper Component, encode, re-parse ─────────
+    const payload_bytes = try buildAndEncodePayload(arena, world, new_body_decls);
+    const new_world = try decode.parse(arena, payload_bytes);
+
+    return .{ .world = new_world, .payload_bytes = payload_bytes };
+}
+
+// ── Per-decl metadata pre-pass ─────────────────────────────────────────────
+
+const DeclMeta = struct {
+    type_slot: ?u32 = null,
+    inst_slot: ?u32 = null,
+    type_refs: []const u32 = &.{},
+    inst_refs: []const u32 = &.{},
+};
+
+fn buildDeclMeta(arena: Allocator, decls: []const ctypes.Decl) Error![]const DeclMeta {
+    const out = try arena.alloc(DeclMeta, decls.len);
+    var type_cursor: u32 = 0;
+    var inst_cursor: u32 = 0;
+
+    for (decls, 0..) |d, i| {
+        var trefs = std.ArrayListUnmanaged(u32).empty;
+        var srefs = std.ArrayListUnmanaged(u32).empty;
+        var type_slot: ?u32 = null;
+        var inst_slot: ?u32 = null;
+
+        switch (d) {
+            .core_type => return error.UnsupportedAdapterShape,
+            .type => |td| {
+                type_slot = type_cursor;
+                type_cursor += 1;
+                try collectTypeDefRefs(arena, td, &trefs, 0);
+            },
+            .alias => |a| {
+                switch (a) {
+                    .instance_export => |ie| {
+                        // Pull `instance_export` of any sort from a
+                        // body-level instance. Only sort=type
+                        // contributes a slot to the type indexspace;
+                        // other sorts are unusual at world body
+                        // level. The instance idx is referenced
+                        // either way.
+                        if (ie.sort == .type) {
+                            type_slot = type_cursor;
+                            type_cursor += 1;
+                        }
+                        try srefs.append(arena, ie.instance_idx);
+                    },
+                    .outer => |o| {
+                        if (o.sort == .type) {
+                            type_slot = type_cursor;
+                            type_cursor += 1;
+                        }
+                        // outer-alias at body depth-0 references the
+                        // wrapper's indexspace (boilerplate scope).
+                        // Body-level types aren't referenced; nothing
+                        // to add to trefs.
+                    },
+                }
+            },
+            .import => |im| {
+                inst_slot = inst_cursor;
+                inst_cursor += 1;
+                try collectExternDescRefs(arena, im.desc, &trefs);
+            },
+            .@"export" => |e| {
+                try collectExternDescRefs(arena, e.desc, &trefs);
+            },
+        }
+
+        out[i] = .{
+            .type_slot = type_slot,
+            .inst_slot = inst_slot,
+            .type_refs = try trefs.toOwnedSlice(arena),
+            .inst_refs = try srefs.toOwnedSlice(arena),
+        };
+    }
+
+    return out;
+}
+
+/// Collect type-idx refs from a type def. `depth` is the nesting
+/// depth — 0 for the world body, 1 inside an instance type body, etc.
+/// Refs with `outer_count == depth` and sort=type bubble up to the
+/// world body's type indexspace and are added to `out`. Refs to local
+/// (same-depth) types stay local and are ignored at body level.
+fn collectTypeDefRefs(
+    arena: Allocator,
+    td: ctypes.TypeDef,
+    out: *std.ArrayListUnmanaged(u32),
+    depth: u32,
+) Error!void {
+    switch (td) {
+        .val => |vt| try collectValTypeRefs(arena, vt, out, depth),
+        .record => |r| for (r.fields) |f| try collectValTypeRefs(arena, f.type, out, depth),
+        .variant => |v| for (v.cases) |c| {
+            if (c.type) |vt| try collectValTypeRefs(arena, vt, out, depth);
+        },
+        .list => |l| try collectValTypeRefs(arena, l.element, out, depth),
+        .tuple => |t| for (t.fields) |f| try collectValTypeRefs(arena, f, out, depth),
+        .flags, .enum_ => {},
+        .option => |o| try collectValTypeRefs(arena, o.inner, out, depth),
+        .result => |r| {
+            if (r.ok) |vt| try collectValTypeRefs(arena, vt, out, depth);
+            if (r.err) |vt| try collectValTypeRefs(arena, vt, out, depth);
+        },
+        .resource => {},
+        .func => |f| {
+            for (f.params) |p| try collectValTypeRefs(arena, p.type, out, depth);
+            switch (f.results) {
+                .none => {},
+                .unnamed => |vt| try collectValTypeRefs(arena, vt, out, depth),
+                .named => |list| for (list) |nv| try collectValTypeRefs(arena, nv.type, out, depth),
+            }
+        },
+        .component => return error.UnsupportedAdapterShape,
+        .instance => |i| try collectInstanceBodyRefs(arena, i.decls, out, depth + 1),
+    }
+}
+
+/// Collect type-idx refs from valtype operands. ValTypes at depth>0
+/// reference the local type indexspace at THAT depth — not the world
+/// body's. So they don't contribute body-level refs.
+fn collectValTypeRefs(
+    arena: Allocator,
+    vt: ctypes.ValType,
+    out: *std.ArrayListUnmanaged(u32),
+    depth: u32,
+) Error!void {
+    if (depth != 0) return; // local-typespace refs at depth>0 are local
+    switch (vt) {
+        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .f32, .f64, .char, .string => {},
+        .own => |idx| try out.append(arena, idx),
+        .borrow => |idx| try out.append(arena, idx),
+        .type_idx => |idx| try out.append(arena, idx),
+        .record => |idx| try out.append(arena, idx),
+        .variant => |idx| try out.append(arena, idx),
+        .list => |idx| try out.append(arena, idx),
+        .tuple => |idx| try out.append(arena, idx),
+        .flags => |idx| try out.append(arena, idx),
+        .enum_ => |idx| try out.append(arena, idx),
+        .option => |idx| try out.append(arena, idx),
+        .result => |idx| try out.append(arena, idx),
+    }
+}
+
+fn collectInstanceBodyRefs(
+    arena: Allocator,
+    decls: []const ctypes.Decl,
+    out: *std.ArrayListUnmanaged(u32),
+    depth: u32,
+) Error!void {
+    for (decls) |d| {
+        switch (d) {
+            .core_type => {},
+            .type => |td| try collectTypeDefRefs(arena, td, out, depth),
+            .alias => |a| switch (a) {
+                .instance_export => {},
+                .outer => |o| {
+                    // Outer-alias whose chain reaches depth 0 (the
+                    // world body) — its `idx` reads the world body's
+                    // type indexspace.
+                    if (o.outer_count == depth and o.sort == .type) {
+                        try out.append(arena, o.idx);
+                    }
+                },
+            },
+            .import => |im| {
+                // Imports inside an instance type are unusual; instance
+                // bodies normally only have type defs, aliases, and
+                // exports. Treat opaquely (still walk the desc).
+                try collectExternDescRefsAtDepth(arena, im.desc, out, depth);
+            },
+            .@"export" => |e| try collectExternDescRefsAtDepth(arena, e.desc, out, depth),
+        }
+    }
+}
+
+fn collectExternDescRefs(
+    arena: Allocator,
+    desc: ctypes.ExternDesc,
+    out: *std.ArrayListUnmanaged(u32),
+) Error!void {
+    return collectExternDescRefsAtDepth(arena, desc, out, 0);
+}
+
+fn collectExternDescRefsAtDepth(
+    arena: Allocator,
+    desc: ctypes.ExternDesc,
+    out: *std.ArrayListUnmanaged(u32),
+    depth: u32,
+) Error!void {
+    if (depth != 0) return; // descs at depth>0 reference local typespace
+    switch (desc) {
+        .module => {},
+        .func => |idx| try out.append(arena, idx),
+        .value => |vt| try collectValTypeRefs(arena, vt, out, 0),
+        .type => |tb| switch (tb) {
+            .eq => |idx| try out.append(arena, idx),
+            .sub_resource => {},
+        },
+        .component => |idx| try out.append(arena, idx),
+        .instance => |idx| try out.append(arena, idx),
+    }
+}
+
+// ── Clone with operand renumbering ─────────────────────────────────────────
+
+fn cloneDecl(
+    arena: Allocator,
+    d: ctypes.Decl,
+    type_remap: []const u32,
+    inst_remap: []const u32,
+) Error!ctypes.Decl {
+    return switch (d) {
+        .core_type => error.UnsupportedAdapterShape,
+        .type => |td| .{ .type = try cloneTypeDef(arena, td, type_remap, 0) },
+        .alias => |a| .{ .alias = try cloneAlias(arena, a, type_remap, inst_remap) },
+        .import => |im| .{ .import = .{
+            .name = try arena.dupe(u8, im.name),
+            .desc = try cloneExternDesc(arena, im.desc, type_remap, 0),
+        } },
+        .@"export" => |e| .{ .@"export" = .{
+            .name = try arena.dupe(u8, e.name),
+            .desc = try cloneExternDesc(arena, e.desc, type_remap, 0),
+            .sort_idx = e.sort_idx,
+        } },
+    };
+}
+
+fn cloneAlias(
+    arena: Allocator,
+    a: ctypes.Alias,
+    type_remap: []const u32,
+    inst_remap: []const u32,
+) Error!ctypes.Alias {
+    _ = type_remap;
+    return switch (a) {
+        .instance_export => |ie| .{ .instance_export = .{
+            .sort = ie.sort,
+            .instance_idx = remap(inst_remap, ie.instance_idx),
+            .name = try arena.dupe(u8, ie.name),
+        } },
+        .outer => |o| .{ .outer = .{
+            .sort = o.sort,
+            .outer_count = o.outer_count,
+            // depth-0 outer alias references wrapper type indexspace
+            // (boilerplate, idx 0); leave verbatim.
+            .idx = o.idx,
+        } },
+    };
+}
+
+fn cloneTypeDef(
+    arena: Allocator,
+    td: ctypes.TypeDef,
+    type_remap: []const u32,
+    depth: u32,
+) Error!ctypes.TypeDef {
+    return switch (td) {
+        .val => |vt| .{ .val = try cloneValType(arena, vt, type_remap, depth) },
+        .record => |r| blk: {
+            const fields = try arena.alloc(ctypes.Field, r.fields.len);
+            for (r.fields, fields) |src, *dst| {
+                dst.* = .{
+                    .name = try arena.dupe(u8, src.name),
+                    .type = try cloneValType(arena, src.type, type_remap, depth),
+                };
+            }
+            break :blk .{ .record = .{ .fields = fields } };
+        },
+        .variant => |v| blk: {
+            const cases = try arena.alloc(ctypes.Case, v.cases.len);
+            for (v.cases, cases) |src, *dst| {
+                dst.* = .{
+                    .name = try arena.dupe(u8, src.name),
+                    .type = if (src.type) |t| try cloneValType(arena, t, type_remap, depth) else null,
+                    .refines = src.refines,
+                };
+            }
+            break :blk .{ .variant = .{ .cases = cases } };
+        },
+        .list => |l| .{ .list = .{ .element = try cloneValType(arena, l.element, type_remap, depth) } },
+        .tuple => |t| blk: {
+            const fields = try arena.alloc(ctypes.ValType, t.fields.len);
+            for (t.fields, fields) |src, *dst| dst.* = try cloneValType(arena, src, type_remap, depth);
+            break :blk .{ .tuple = .{ .fields = fields } };
+        },
+        .flags => |f| blk: {
+            const names = try arena.alloc([]const u8, f.names.len);
+            for (f.names, names) |src, *dst| dst.* = try arena.dupe(u8, src);
+            break :blk .{ .flags = .{ .names = names } };
+        },
+        .enum_ => |e| blk: {
+            const names = try arena.alloc([]const u8, e.names.len);
+            for (e.names, names) |src, *dst| dst.* = try arena.dupe(u8, src);
+            break :blk .{ .enum_ = .{ .names = names } };
+        },
+        .option => |o| .{ .option = .{ .inner = try cloneValType(arena, o.inner, type_remap, depth) } },
+        .result => |r| .{ .result = .{
+            .ok = if (r.ok) |t| try cloneValType(arena, t, type_remap, depth) else null,
+            .err = if (r.err) |t| try cloneValType(arena, t, type_remap, depth) else null,
+        } },
+        .resource => |r| .{ .resource = r },
+        .func => |f| blk: {
+            const params = try arena.alloc(ctypes.NamedValType, f.params.len);
+            for (f.params, params) |src, *dst| dst.* = .{
+                .name = try arena.dupe(u8, src.name),
+                .type = try cloneValType(arena, src.type, type_remap, depth),
+            };
+            const results: ctypes.FuncType.ResultList = switch (f.results) {
+                .none => .none,
+                .unnamed => |vt| .{ .unnamed = try cloneValType(arena, vt, type_remap, depth) },
+                .named => |list| named: {
+                    const dst = try arena.alloc(ctypes.NamedValType, list.len);
+                    for (list, dst) |src, *d| d.* = .{
+                        .name = try arena.dupe(u8, src.name),
+                        .type = try cloneValType(arena, src.type, type_remap, depth),
+                    };
+                    break :named .{ .named = dst };
+                },
+            };
+            break :blk .{ .func = .{ .params = params, .results = results } };
+        },
+        .component => return error.UnsupportedAdapterShape,
+        .instance => |i| .{ .instance = .{ .decls = try cloneInstanceBody(arena, i.decls, type_remap, depth + 1) } },
+    };
+}
+
+fn cloneInstanceBody(
+    arena: Allocator,
+    decls: []const ctypes.Decl,
+    type_remap: []const u32,
+    depth: u32,
+) Error![]const ctypes.Decl {
+    const out = try arena.alloc(ctypes.Decl, decls.len);
+    for (decls, out) |src, *dst| {
+        dst.* = switch (src) {
+            .core_type => return error.UnsupportedAdapterShape,
+            .type => |td| .{ .type = try cloneTypeDef(arena, td, type_remap, depth) },
+            .alias => |a| .{ .alias = try cloneInstanceBodyAlias(arena, a, type_remap, depth) },
+            .import => |im| .{ .import = .{
+                .name = try arena.dupe(u8, im.name),
+                .desc = try cloneExternDesc(arena, im.desc, type_remap, depth),
+            } },
+            .@"export" => |e| .{ .@"export" = .{
+                .name = try arena.dupe(u8, e.name),
+                .desc = try cloneExternDesc(arena, e.desc, type_remap, depth),
+                .sort_idx = e.sort_idx,
+            } },
+        };
+    }
+    return out;
+}
+
+/// Clone an alias inside an instance type body. Outer aliases whose
+/// chain reaches the world body (`outer_count == depth`) have their
+/// `idx` rewritten through `type_remap` so the alias target survives
+/// the prune.
+fn cloneInstanceBodyAlias(
+    arena: Allocator,
+    a: ctypes.Alias,
+    type_remap: []const u32,
+    depth: u32,
+) Error!ctypes.Alias {
+    return switch (a) {
+        .instance_export => |ie| .{ .instance_export = .{
+            .sort = ie.sort,
+            .instance_idx = ie.instance_idx,
+            .name = try arena.dupe(u8, ie.name),
+        } },
+        .outer => |o| blk: {
+            const new_idx = if (o.outer_count == depth and o.sort == .type)
+                remap(type_remap, o.idx)
+            else
+                o.idx;
+            break :blk .{ .outer = .{
+                .sort = o.sort,
+                .outer_count = o.outer_count,
+                .idx = new_idx,
+            } };
+        },
+    };
+}
+
+fn cloneExternDesc(
+    arena: Allocator,
+    desc: ctypes.ExternDesc,
+    type_remap: []const u32,
+    depth: u32,
+) Error!ctypes.ExternDesc {
+    return switch (desc) {
+        .module => |idx| .{ .module = idx },
+        .func => |idx| .{ .func = if (depth == 0) remap(type_remap, idx) else idx },
+        .value => |vt| .{ .value = try cloneValType(arena, vt, type_remap, depth) },
+        .type => |tb| .{ .type = switch (tb) {
+            .eq => |idx| .{ .eq = if (depth == 0) remap(type_remap, idx) else idx },
+            .sub_resource => .sub_resource,
+        } },
+        .component => |idx| .{ .component = if (depth == 0) remap(type_remap, idx) else idx },
+        .instance => |idx| .{ .instance = if (depth == 0) remap(type_remap, idx) else idx },
+    };
+}
+
+fn cloneValType(
+    arena: Allocator,
+    vt: ctypes.ValType,
+    type_remap: []const u32,
+    depth: u32,
+) Error!ctypes.ValType {
+    _ = arena;
+    if (depth != 0) return vt; // local-typespace refs at depth>0 unchanged
+    return switch (vt) {
+        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .f32, .f64, .char, .string => vt,
+        .own => |idx| .{ .own = remap(type_remap, idx) },
+        .borrow => |idx| .{ .borrow = remap(type_remap, idx) },
+        .type_idx => |idx| .{ .type_idx = remap(type_remap, idx) },
+        .record => |idx| .{ .record = remap(type_remap, idx) },
+        .variant => |idx| .{ .variant = remap(type_remap, idx) },
+        .list => |idx| .{ .list = remap(type_remap, idx) },
+        .tuple => |idx| .{ .tuple = remap(type_remap, idx) },
+        .flags => |idx| .{ .flags = remap(type_remap, idx) },
+        .enum_ => |idx| .{ .enum_ = remap(type_remap, idx) },
+        .option => |idx| .{ .option = remap(type_remap, idx) },
+        .result => |idx| .{ .result = remap(type_remap, idx) },
+    };
+}
+
+fn remap(table: []const u32, idx: u32) u32 {
+    if (idx >= table.len) return idx;
+    return table[idx];
+}
+
+// ── Encode the rebuilt encoded-world payload ──────────────────────────────
+
+fn buildAndEncodePayload(
+    arena: Allocator,
+    src_world: decode.AdapterWorld,
+    new_body_decls: []const ctypes.Decl,
+) Error![]const u8 {
+    // Outer wrapper: component-type whose decl[0] is the world body
+    // and decl[1] re-exports the body component under the world's
+    // qualified name. Mirrors `metadata_encode.encodeWorldFromResolver`.
+    const outer_decls = try arena.alloc(ctypes.Decl, 2);
+    outer_decls[0] = .{ .type = .{ .component = .{ .decls = new_body_decls } } };
+    outer_decls[1] = .{ .@"export" = .{
+        .name = try arena.dupe(u8, src_world.world_qualified_name),
+        .desc = .{ .component = 0 },
+    } };
+
+    const types = try arena.alloc(ctypes.TypeDef, 1);
+    types[0] = .{ .component = .{ .decls = outer_decls } };
+
+    // Top-level world-name export. Reuse the original short name from
+    // `src_world.component.exports[0]` — this is the unqualified
+    // world name (e.g. `command`), not the wire-form qualified name.
+    if (src_world.component.exports.len < 1) return error.UnsupportedAdapterShape;
+    const orig_export = src_world.component.exports[0];
+    const exports = try arena.alloc(ctypes.ExportDecl, 1);
+    exports[0] = .{
+        .name = try arena.dupe(u8, orig_export.name),
+        .desc = .{ .type = .{ .eq = 0 } },
+        .sort_idx = .{ .sort = .type, .idx = 0 },
+    };
+
+    // Standard wit-component-encoding marker (loader drops custom
+    // sections, so we always re-emit the canonical `0x04 0x00`).
+    const custom_sections = try arena.alloc(ctypes.CustomSection, 1);
+    custom_sections[0] = .{
+        .name = "wit-component-encoding",
+        .payload = &[_]u8{ 0x04, 0x00 },
+    };
+
+    const component: ctypes.Component = .{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = types,
+        .canons = &.{},
+        .imports = &.{},
+        .exports = exports,
+        .custom_sections = custom_sections,
+    };
+    return writer.encode(arena, &component);
+}
+
+// ── Replace `:encoded world` custom section in adapter core wasm ──────────
+
+/// Splice `new_payload` into `adapter_core_bytes` in place of the
+/// existing `:encoded world` custom section. All other sections are
+/// preserved byte-identically.
+pub fn replaceEncodedWorldSection(
+    arena: Allocator,
+    adapter_core_bytes: []const u8,
+    new_payload: []const u8,
+) Error![]u8 {
+    if (adapter_core_bytes.len < 8) return error.InvalidAdapterCore;
+    if (!std.mem.eql(u8, adapter_core_bytes[0..4], "\x00asm")) return error.InvalidAdapterCore;
+
+    var out = std.ArrayListUnmanaged(u8).empty;
+    try out.appendSlice(arena, adapter_core_bytes[0..8]);
+
+    var found = false;
+    var i: usize = 8;
+    while (i < adapter_core_bytes.len) {
+        const id = adapter_core_bytes[i];
+        i += 1;
+        const sz = try readU32Leb(adapter_core_bytes, i);
+        i += sz.bytes_read;
+        if (i + sz.value > adapter_core_bytes.len) return error.InvalidAdapterCore;
+        const body = adapter_core_bytes[i .. i + sz.value];
+        i += sz.value;
+
+        const is_encoded_world = blk: {
+            if (id != 0 or body.len == 0) break :blk false;
+            const n = readU32Leb(body, 0) catch break :blk false;
+            if (n.bytes_read + n.value > body.len) break :blk false;
+            const sec_name = body[n.bytes_read .. n.bytes_read + n.value];
+            const suffix = ":encoded world";
+            const prefix = "component-type:";
+            const matches_suffix = sec_name.len >= suffix.len and
+                std.mem.eql(u8, sec_name[sec_name.len - suffix.len ..], suffix) and
+                std.mem.startsWith(u8, sec_name, prefix);
+            const is_bare = std.mem.eql(u8, sec_name, "component-type");
+            break :blk matches_suffix or is_bare;
+        };
+
+        if (is_encoded_world) {
+            if (found) return error.UnsupportedAdapterShape; // duplicate
+            found = true;
+            // Reuse the original section name; replace only the payload.
+            const n = try readU32Leb(body, 0);
+            const sec_name_with_len = body[0 .. n.bytes_read + n.value];
+            const new_body_len = sec_name_with_len.len + new_payload.len;
+            try out.append(arena, 0); // custom section id
+            try writeU32Leb(arena, &out, @intCast(new_body_len));
+            try out.appendSlice(arena, sec_name_with_len);
+            try out.appendSlice(arena, new_payload);
+        } else {
+            try out.append(arena, id);
+            try writeU32Leb(arena, &out, sz.value);
+            try out.appendSlice(arena, body);
+        }
+    }
+
+    if (!found) return error.MissingEncodedWorld;
+    return out.toOwnedSlice(arena);
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+fn containsName(set: []const []const u8, name: []const u8) bool {
+    for (set) |n| if (std.mem.eql(u8, n, name)) return true;
+    return false;
+}
+
+const LebRead = struct { value: u32, bytes_read: usize };
+
+fn readU32Leb(buf: []const u8, start: usize) Error!LebRead {
+    var result: u32 = 0;
+    var shift: u5 = 0;
+    var i: usize = start;
+    while (i < buf.len) : (i += 1) {
+        const b = buf[i];
+        result |= @as(u32, b & 0x7f) << shift;
+        if ((b & 0x80) == 0) {
+            return .{ .value = result, .bytes_read = i + 1 - start };
+        }
+        if (shift >= 25) return error.InvalidAdapterCore;
+        shift += 7;
+    }
+    return error.InvalidAdapterCore;
+}
+
+fn writeU32Leb(arena: Allocator, out: *std.ArrayListUnmanaged(u8), v: u32) Error!void {
+    var x = v;
+    while (true) {
+        var byte: u8 = @intCast(x & 0x7f);
+        x >>= 7;
+        if (x != 0) byte |= 0x80;
+        try out.append(arena, byte);
+        if (x == 0) break;
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+const metadata_encode = @import("../wit/metadata_encode.zig");
+
+fn buildMockEncodedWorld(allocator: Allocator, source: []const u8, world_name: []const u8) ![]u8 {
+    return metadata_encode.encodeWorldFromSource(allocator, source, world_name);
+}
+
+const std_world =
+    \\package mock:adapter@0.1.0;
+    \\
+    \\interface in1 { ping: func() -> u32; }
+    \\interface in2 { pong: func() -> u32; }
+    \\interface in3 { peng: func() -> u32; }
+    \\interface out { run: func() -> u32; }
+    \\
+    \\world adapter-mock {
+    \\    import in1;
+    \\    import in2;
+    \\    import in3;
+    \\    export out;
+    \\}
+;
+
+test "gcWorld: drops unused imports, keeps live ones" {
+    const ct = try buildMockEncodedWorld(testing.allocator, std_world, "adapter-mock");
+    defer testing.allocator.free(ct);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const world = try decode.parse(a, ct);
+
+    // Keep in2 only (drop in1, in3).
+    const live_ns: []const []const u8 = &.{"mock:adapter/in2@0.1.0"};
+    const live_ex: []const []const u8 = &.{"mock:adapter/out@0.1.0"};
+
+    const result = try gcWorld(a, world, live_ns, live_ex);
+
+    // Imports: only in2 should remain.
+    try testing.expectEqual(@as(usize, 1), result.world.imports.len);
+    try testing.expectEqualStrings("mock:adapter/in2@0.1.0", result.world.imports[0].name);
+
+    // Exports: out should remain.
+    try testing.expectEqual(@as(usize, 1), result.world.exports.len);
+    try testing.expectEqualStrings("mock:adapter/out@0.1.0", result.world.exports[0].name);
+
+    // Verify the result round-trips through loader (decode.parse already
+    // succeeded inside gcWorld) and through types_import.hoist.
+    const types_import = @import("types_import.zig");
+    const hoisted = try types_import.hoist(a, result.world);
+    try testing.expectEqual(@as(usize, 1), hoisted.imports.len);
+    try testing.expectEqual(@as(usize, 1), hoisted.instances.len);
+    try testing.expectEqual(@as(u32, 0), hoisted.instances[0].instance_idx);
+}
+
+test "gcWorld: empty live-namespace set yields export-only world" {
+    const ct = try buildMockEncodedWorld(testing.allocator, std_world, "adapter-mock");
+    defer testing.allocator.free(ct);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const world = try decode.parse(a, ct);
+
+    const result = try gcWorld(a, world, &.{}, &.{"mock:adapter/out@0.1.0"});
+
+    try testing.expectEqual(@as(usize, 0), result.world.imports.len);
+    try testing.expectEqual(@as(usize, 1), result.world.exports.len);
+}
+
+test "gcWorld: bogus live name (not in world) is silently ignored" {
+    const ct = try buildMockEncodedWorld(testing.allocator, std_world, "adapter-mock");
+    defer testing.allocator.free(ct);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const world = try decode.parse(a, ct);
+
+    const result = try gcWorld(
+        a,
+        world,
+        &.{ "mock:adapter/in1@0.1.0", "wasi:does-not-exist@9.9.9" },
+        &.{"mock:adapter/out@0.1.0"},
+    );
+
+    try testing.expectEqual(@as(usize, 1), result.world.imports.len);
+    try testing.expectEqualStrings("mock:adapter/in1@0.1.0", result.world.imports[0].name);
+}
+
+test "gcWorld: keeps all imports when all are live" {
+    const ct = try buildMockEncodedWorld(testing.allocator, std_world, "adapter-mock");
+    defer testing.allocator.free(ct);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const world = try decode.parse(a, ct);
+
+    const result = try gcWorld(
+        a,
+        world,
+        &.{ "mock:adapter/in1@0.1.0", "mock:adapter/in2@0.1.0", "mock:adapter/in3@0.1.0" },
+        &.{"mock:adapter/out@0.1.0"},
+    );
+
+    try testing.expectEqual(@as(usize, 3), result.world.imports.len);
+    try testing.expectEqualStrings("mock:adapter/in1@0.1.0", result.world.imports[0].name);
+    try testing.expectEqualStrings("mock:adapter/in2@0.1.0", result.world.imports[1].name);
+    try testing.expectEqualStrings("mock:adapter/in3@0.1.0", result.world.imports[2].name);
+}
+
+test "gcWorld: renumbers instance and type idx in surviving imports" {
+    const ct = try buildMockEncodedWorld(testing.allocator, std_world, "adapter-mock");
+    defer testing.allocator.free(ct);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const world = try decode.parse(a, ct);
+
+    // Keep middle import only; its instance idx in the original was 1
+    // (after in1) and its type idx was 1 (after in1's instance type).
+    // After GC: instance idx = 0, type idx = 0.
+    const result = try gcWorld(
+        a,
+        world,
+        &.{"mock:adapter/in2@0.1.0"},
+        &.{"mock:adapter/out@0.1.0"},
+    );
+
+    try testing.expectEqual(@as(usize, 1), result.world.imports.len);
+    try testing.expectEqual(@as(u32, 0), result.world.imports[0].body_instance_idx);
+    try testing.expectEqual(@as(u32, 0), result.world.imports[0].body_type_idx);
+
+    // Export's body_type_idx should be the next slot after in2's type
+    // (idx=1 if export instance type comes after import instance type).
+    try testing.expectEqual(@as(usize, 1), result.world.exports.len);
+}
+
+test "gcWorld: payload bytes round-trip through replaceEncodedWorldSection" {
+    const ct = try buildMockEncodedWorld(testing.allocator, std_world, "adapter-mock");
+    defer testing.allocator.free(ct);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Wrap the original CT as adapter core wasm (mirroring decode.zig's
+    // wrapAsAdapterCore helper).
+    const adapter_core = try wrapAsAdapterCore(a, ct);
+
+    const world = try decode.parse(a, ct);
+    const result = try gcWorld(a, world, &.{"mock:adapter/in2@0.1.0"}, &.{"mock:adapter/out@0.1.0"});
+
+    const new_core = try replaceEncodedWorldSection(a, adapter_core, result.payload_bytes);
+    // The new core should still parse cleanly and yield the GC'd world.
+    const reparsed = try decode.parseFromAdapterCore(a, new_core);
+    try testing.expectEqual(@as(usize, 1), reparsed.imports.len);
+    try testing.expectEqualStrings("mock:adapter/in2@0.1.0", reparsed.imports[0].name);
+}
+
+fn wrapAsAdapterCore(arena: Allocator, ct_payload: []const u8) ![]u8 {
+    const preamble = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 };
+    const sec_name = "component-type:mock:encoded world";
+    var name_leb: [leb128.max_u32_bytes]u8 = undefined;
+    const name_leb_n = leb128.writeU32Leb128(&name_leb, @intCast(sec_name.len));
+    const body_len = name_leb_n + sec_name.len + ct_payload.len;
+    var size_leb: [leb128.max_u32_bytes]u8 = undefined;
+    const size_leb_n = leb128.writeU32Leb128(&size_leb, @intCast(body_len));
+
+    var out = try std.ArrayListUnmanaged(u8).initCapacity(arena, preamble.len + 1 + size_leb_n + body_len);
+    out.appendSliceAssumeCapacity(&preamble);
+    out.appendAssumeCapacity(0); // custom section id
+    out.appendSliceAssumeCapacity(size_leb[0..size_leb_n]);
+    out.appendSliceAssumeCapacity(name_leb[0..name_leb_n]);
+    out.appendSliceAssumeCapacity(sec_name);
+    out.appendSliceAssumeCapacity(ct_payload);
+    return out.toOwnedSlice(arena);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -52,6 +52,7 @@ pub const component = struct {
         pub const abi = @import("component/adapter/abi.zig");
         pub const adapter = @import("component/adapter/adapter.zig");
         pub const gc = @import("component/adapter/gc.zig");
+        pub const world_gc = @import("component/adapter/world_gc.zig");
     };
 };
 
@@ -81,6 +82,7 @@ test {
     _ = @import("component/adapter/abi.zig");
     _ = @import("component/adapter/adapter.zig");
     _ = @import("component/adapter/gc.zig");
+    _ = @import("component/adapter/world_gc.zig");
     _ = @import("integration_tests.zig");
     _ = @import("spec_tests.zig");
 }


### PR DESCRIPTION
Closes #118.

## Summary

PR #119 GC'd the adapter core wasm but `types_import.hoist` continued to hoist every WASI namespace declared in the encoded-world body, even ones whose imports the core-wasm GC had just dropped. This leaked dead namespaces through to the wrapping component's top-level imports — the symptom that hosts wiring only a subset of WASI providers (e.g. wamr) refused to instantiate.

`types_import.hoist` cannot fix this itself: by design it does not renumber type or instance indices because the encoded-world body relies on positional identity with the wrapping component for `(alias outer 1 N)` to remain valid.

## Changes

### `component/adapter/world_gc.zig` (new, 968 lines)
Implements a real GC pass over the encoded-world AST:
- `gcWorld(arena, world, live_namespaces, live_export_names)` walks reachability from the live namespace set (= adapter core import module names after core-wasm GC) and the always-live world export names, drops dead body decls, renumbers the surviving type and instance indices, deep-clones each surviving decl with its operands rewritten — including outer-alias `idx` operands at depth 1 inside instance type bodies — and rebuilds the wrapper Component preserving the shape `decode.parse` expects.
- `replaceEncodedWorldSection(arena, adapter_bytes, new_payload)` splices the freshly encoded payload back into the GC'd adapter core wasm, leaving every other section verbatim.
- 6 unit tests cover: drops unused imports; empty-namespace yields export-only world; bogus live name is a no-op; keep-all preserves order; instance and type idx are renumbered in surviving import operands; `(alias outer 1 N)` inside surviving instance type bodies is rewritten via the body's type remap.

### `component/adapter/adapter.zig`
`splice()` now invokes `world_gc.gcWorld` + `replaceEncodedWorldSection` between the core-wasm GC and `types_import.hoist`. Bug-#2 follow-up TODO removed. Adds `collectLiveNamespaces` and `collectLiveExportNames` helpers.

### Drive-by: `binary/{reader,writer}.zig` consistency fix
The writer appends a trailing 0x0b end-marker when re-emitting init / offset expressions. The reader was inconsistent: globals stripped 0x0b before storing while tables, active elem segments, and active data segments stored the raw expression with 0x0b included — so round-tripping produced a double-end-marker that read back as a truncated expression. Three reader call sites now strip the trailing 0x0b consistently. The `readTableSection` path now also captures the init expression at all (previously skipped without being stored). Two regression tests added.

## Test results

```
Build Summary: 41/41 steps succeeded; 353/353 tests passed
```

318 tests in the main test executable (310 baseline + 6 new `world_gc` + 2 new binary regression tests).

## Out of scope

A full synthetic mock embed + mock adapter splice() end-to-end test (Track C from #115) would require ~300+ lines of hand-rolled binary construction. The `world_gc` unit tests exercise the GC via real `metadata_encode.encodeWorldFromSource` + `decode.parse` + `gcWorld` + `types_import.hoist` round-trips, which already validate the AST-level correctness of the change.