### PR TITLE
component compose: topo-sort + transitive-close types[] (#121)

### DIFF
--- a/src/component/adapter/world_gc.zig
+++ b/src/component/adapter/world_gc.zig
@@ -56,6 +56,7 @@ const decode = @import("decode.zig");
 const loader = @import("../loader.zig");
 const writer = @import("../writer.zig");
 const leb128 = @import("../../leb128.zig");
+const type_walk = @import("../type_walk.zig");
 
 pub const Error = error{
     OutOfMemory,
@@ -236,7 +237,7 @@ pub fn gcWorld(
     var new_decls = std.ArrayListUnmanaged(ctypes.Decl).empty;
     for (pruned_body_decls, 0..) |d, i| {
         if (!live_decls.isSet(i)) continue;
-        const cloned = try cloneDecl(arena, d, type_remap, inst_remap);
+        const cloned = try type_walk.cloneDecl(arena, d, type_remap, inst_remap);
         try new_decls.append(arena, cloned);
     }
     const new_body_decls = try new_decls.toOwnedSlice(arena);
@@ -273,7 +274,7 @@ fn buildDeclMeta(arena: Allocator, decls: []const ctypes.Decl) Error![]const Dec
             .type => |td| {
                 type_slot = type_cursor;
                 type_cursor += 1;
-                try collectTypeDefRefs(arena, td, &trefs, 0);
+                try type_walk.collectTypeDefRefs(arena, td, &trefs, 0);
             },
             .alias => |a| {
                 switch (a) {
@@ -305,10 +306,10 @@ fn buildDeclMeta(arena: Allocator, decls: []const ctypes.Decl) Error![]const Dec
             .import => |im| {
                 inst_slot = inst_cursor;
                 inst_cursor += 1;
-                try collectExternDescRefs(arena, im.desc, &trefs);
+                try type_walk.collectExternDescRefs(arena, im.desc, &trefs);
             },
             .@"export" => |e| {
-                try collectExternDescRefs(arena, e.desc, &trefs);
+                try type_walk.collectExternDescRefs(arena, e.desc, &trefs);
             },
         }
 
@@ -541,7 +542,7 @@ fn gcInstanceBody(
                 // the call site. Treating the body as view-depth-0
                 // makes its own typespace the "world body" in this
                 // helper's eyes.
-                try collectTypeDefRefs(arena, td, &refs, 0);
+                try type_walk.collectTypeDefRefs(arena, td, &refs, 0);
             },
             .alias => |a| switch (a) {
                 .instance_export => |ie| {
@@ -579,7 +580,7 @@ fn gcInstanceBody(
                 },
                 else => {
                     kind = .method;
-                    try collectExternDescRefsAtDepth(arena, e.desc, &refs, 0);
+                    try type_walk.collectExternDescRefsAtDepth(arena, e.desc, &refs, 0);
                 },
             },
         }
@@ -670,368 +671,17 @@ fn cloneInstBodyDeclLocal(
 ) Error!ctypes.Decl {
     return switch (d) {
         .core_type => error.UnsupportedAdapterShape,
-        .type => |td| .{ .type = try cloneTypeDef(arena, td, local_remap, 0) },
-        .alias => |a| .{ .alias = try cloneInstanceBodyAlias(arena, a, local_remap, 0) },
+        .type => |td| .{ .type = try type_walk.cloneTypeDef(arena, td, local_remap, 0) },
+        .alias => |a| .{ .alias = try type_walk.cloneInstanceBodyAlias(arena, a, local_remap, 0) },
         .import => error.UnsupportedAdapterShape,
         .@"export" => |e| .{ .@"export" = .{
             .name = try arena.dupe(u8, e.name),
-            .desc = try cloneExternDesc(arena, e.desc, local_remap, 0),
+            .desc = try type_walk.cloneExternDesc(arena, e.desc, local_remap, 0),
             .sort_idx = e.sort_idx,
         } },
     };
 }
 
-/// Collect type-idx refs from a type def. `depth` is the nesting
-/// depth — 0 for the world body, 1 inside an instance type body, etc.
-/// Refs with `outer_count == depth` and sort=type bubble up to the
-/// world body's type indexspace and are added to `out`. Refs to local
-/// (same-depth) types stay local and are ignored at body level.
-fn collectTypeDefRefs(
-    arena: Allocator,
-    td: ctypes.TypeDef,
-    out: *std.ArrayListUnmanaged(u32),
-    depth: u32,
-) Error!void {
-    switch (td) {
-        .val => |vt| try collectValTypeRefs(arena, vt, out, depth),
-        .record => |r| for (r.fields) |f| try collectValTypeRefs(arena, f.type, out, depth),
-        .variant => |v| for (v.cases) |c| {
-            if (c.type) |vt| try collectValTypeRefs(arena, vt, out, depth);
-        },
-        .list => |l| try collectValTypeRefs(arena, l.element, out, depth),
-        .tuple => |t| for (t.fields) |f| try collectValTypeRefs(arena, f, out, depth),
-        .flags, .enum_ => {},
-        .option => |o| try collectValTypeRefs(arena, o.inner, out, depth),
-        .result => |r| {
-            if (r.ok) |vt| try collectValTypeRefs(arena, vt, out, depth);
-            if (r.err) |vt| try collectValTypeRefs(arena, vt, out, depth);
-        },
-        .resource => {},
-        .func => |f| {
-            for (f.params) |p| try collectValTypeRefs(arena, p.type, out, depth);
-            switch (f.results) {
-                .none => {},
-                .unnamed => |vt| try collectValTypeRefs(arena, vt, out, depth),
-                .named => |list| for (list) |nv| try collectValTypeRefs(arena, nv.type, out, depth),
-            }
-        },
-        .component => return error.UnsupportedAdapterShape,
-        .instance => |i| try collectInstanceBodyRefs(arena, i.decls, out, depth + 1),
-    }
-}
-
-/// Collect type-idx refs from valtype operands. ValTypes at depth>0
-/// reference the local type indexspace at THAT depth — not the world
-/// body's. So they don't contribute body-level refs.
-fn collectValTypeRefs(
-    arena: Allocator,
-    vt: ctypes.ValType,
-    out: *std.ArrayListUnmanaged(u32),
-    depth: u32,
-) Error!void {
-    if (depth != 0) return; // local-typespace refs at depth>0 are local
-    switch (vt) {
-        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .f32, .f64, .char, .string => {},
-        .own => |idx| try out.append(arena, idx),
-        .borrow => |idx| try out.append(arena, idx),
-        .type_idx => |idx| try out.append(arena, idx),
-        .record => |idx| try out.append(arena, idx),
-        .variant => |idx| try out.append(arena, idx),
-        .list => |idx| try out.append(arena, idx),
-        .tuple => |idx| try out.append(arena, idx),
-        .flags => |idx| try out.append(arena, idx),
-        .enum_ => |idx| try out.append(arena, idx),
-        .option => |idx| try out.append(arena, idx),
-        .result => |idx| try out.append(arena, idx),
-    }
-}
-
-fn collectInstanceBodyRefs(
-    arena: Allocator,
-    decls: []const ctypes.Decl,
-    out: *std.ArrayListUnmanaged(u32),
-    depth: u32,
-) Error!void {
-    for (decls) |d| {
-        switch (d) {
-            .core_type => {},
-            .type => |td| try collectTypeDefRefs(arena, td, out, depth),
-            .alias => |a| switch (a) {
-                .instance_export => {},
-                .outer => |o| {
-                    // Outer-alias whose chain reaches depth 0 (the
-                    // world body) — its `idx` reads the world body's
-                    // type indexspace.
-                    if (o.outer_count == depth and o.sort == .type) {
-                        try out.append(arena, o.idx);
-                    }
-                },
-            },
-            .import => |im| {
-                // Imports inside an instance type are unusual; instance
-                // bodies normally only have type defs, aliases, and
-                // exports. Treat opaquely (still walk the desc).
-                try collectExternDescRefsAtDepth(arena, im.desc, out, depth);
-            },
-            .@"export" => |e| try collectExternDescRefsAtDepth(arena, e.desc, out, depth),
-        }
-    }
-}
-
-fn collectExternDescRefs(
-    arena: Allocator,
-    desc: ctypes.ExternDesc,
-    out: *std.ArrayListUnmanaged(u32),
-) Error!void {
-    return collectExternDescRefsAtDepth(arena, desc, out, 0);
-}
-
-fn collectExternDescRefsAtDepth(
-    arena: Allocator,
-    desc: ctypes.ExternDesc,
-    out: *std.ArrayListUnmanaged(u32),
-    depth: u32,
-) Error!void {
-    if (depth != 0) return; // descs at depth>0 reference local typespace
-    switch (desc) {
-        .module => {},
-        .func => |idx| try out.append(arena, idx),
-        .value => |vt| try collectValTypeRefs(arena, vt, out, 0),
-        .type => |tb| switch (tb) {
-            .eq => |idx| try out.append(arena, idx),
-            .sub_resource => {},
-        },
-        .component => |idx| try out.append(arena, idx),
-        .instance => |idx| try out.append(arena, idx),
-    }
-}
-
-// ── Clone with operand renumbering ─────────────────────────────────────────
-
-fn cloneDecl(
-    arena: Allocator,
-    d: ctypes.Decl,
-    type_remap: []const u32,
-    inst_remap: []const u32,
-) Error!ctypes.Decl {
-    return switch (d) {
-        .core_type => error.UnsupportedAdapterShape,
-        .type => |td| .{ .type = try cloneTypeDef(arena, td, type_remap, 0) },
-        .alias => |a| .{ .alias = try cloneAlias(arena, a, type_remap, inst_remap) },
-        .import => |im| .{ .import = .{
-            .name = try arena.dupe(u8, im.name),
-            .desc = try cloneExternDesc(arena, im.desc, type_remap, 0),
-        } },
-        .@"export" => |e| .{ .@"export" = .{
-            .name = try arena.dupe(u8, e.name),
-            .desc = try cloneExternDesc(arena, e.desc, type_remap, 0),
-            .sort_idx = e.sort_idx,
-        } },
-    };
-}
-
-fn cloneAlias(
-    arena: Allocator,
-    a: ctypes.Alias,
-    type_remap: []const u32,
-    inst_remap: []const u32,
-) Error!ctypes.Alias {
-    _ = type_remap;
-    return switch (a) {
-        .instance_export => |ie| .{ .instance_export = .{
-            .sort = ie.sort,
-            .instance_idx = remap(inst_remap, ie.instance_idx),
-            .name = try arena.dupe(u8, ie.name),
-        } },
-        .outer => |o| .{ .outer = .{
-            .sort = o.sort,
-            .outer_count = o.outer_count,
-            // depth-0 outer alias references wrapper type indexspace
-            // (boilerplate, idx 0); leave verbatim.
-            .idx = o.idx,
-        } },
-    };
-}
-
-fn cloneTypeDef(
-    arena: Allocator,
-    td: ctypes.TypeDef,
-    type_remap: []const u32,
-    depth: u32,
-) Error!ctypes.TypeDef {
-    return switch (td) {
-        .val => |vt| .{ .val = try cloneValType(arena, vt, type_remap, depth) },
-        .record => |r| blk: {
-            const fields = try arena.alloc(ctypes.Field, r.fields.len);
-            for (r.fields, fields) |src, *dst| {
-                dst.* = .{
-                    .name = try arena.dupe(u8, src.name),
-                    .type = try cloneValType(arena, src.type, type_remap, depth),
-                };
-            }
-            break :blk .{ .record = .{ .fields = fields } };
-        },
-        .variant => |v| blk: {
-            const cases = try arena.alloc(ctypes.Case, v.cases.len);
-            for (v.cases, cases) |src, *dst| {
-                dst.* = .{
-                    .name = try arena.dupe(u8, src.name),
-                    .type = if (src.type) |t| try cloneValType(arena, t, type_remap, depth) else null,
-                    .refines = src.refines,
-                };
-            }
-            break :blk .{ .variant = .{ .cases = cases } };
-        },
-        .list => |l| .{ .list = .{ .element = try cloneValType(arena, l.element, type_remap, depth) } },
-        .tuple => |t| blk: {
-            const fields = try arena.alloc(ctypes.ValType, t.fields.len);
-            for (t.fields, fields) |src, *dst| dst.* = try cloneValType(arena, src, type_remap, depth);
-            break :blk .{ .tuple = .{ .fields = fields } };
-        },
-        .flags => |f| blk: {
-            const names = try arena.alloc([]const u8, f.names.len);
-            for (f.names, names) |src, *dst| dst.* = try arena.dupe(u8, src);
-            break :blk .{ .flags = .{ .names = names } };
-        },
-        .enum_ => |e| blk: {
-            const names = try arena.alloc([]const u8, e.names.len);
-            for (e.names, names) |src, *dst| dst.* = try arena.dupe(u8, src);
-            break :blk .{ .enum_ = .{ .names = names } };
-        },
-        .option => |o| .{ .option = .{ .inner = try cloneValType(arena, o.inner, type_remap, depth) } },
-        .result => |r| .{ .result = .{
-            .ok = if (r.ok) |t| try cloneValType(arena, t, type_remap, depth) else null,
-            .err = if (r.err) |t| try cloneValType(arena, t, type_remap, depth) else null,
-        } },
-        .resource => |r| .{ .resource = r },
-        .func => |f| blk: {
-            const params = try arena.alloc(ctypes.NamedValType, f.params.len);
-            for (f.params, params) |src, *dst| dst.* = .{
-                .name = try arena.dupe(u8, src.name),
-                .type = try cloneValType(arena, src.type, type_remap, depth),
-            };
-            const results: ctypes.FuncType.ResultList = switch (f.results) {
-                .none => .none,
-                .unnamed => |vt| .{ .unnamed = try cloneValType(arena, vt, type_remap, depth) },
-                .named => |list| named: {
-                    const dst = try arena.alloc(ctypes.NamedValType, list.len);
-                    for (list, dst) |src, *d| d.* = .{
-                        .name = try arena.dupe(u8, src.name),
-                        .type = try cloneValType(arena, src.type, type_remap, depth),
-                    };
-                    break :named .{ .named = dst };
-                },
-            };
-            break :blk .{ .func = .{ .params = params, .results = results } };
-        },
-        .component => return error.UnsupportedAdapterShape,
-        .instance => |i| .{ .instance = .{ .decls = try cloneInstanceBody(arena, i.decls, type_remap, depth + 1) } },
-    };
-}
-
-fn cloneInstanceBody(
-    arena: Allocator,
-    decls: []const ctypes.Decl,
-    type_remap: []const u32,
-    depth: u32,
-) Error![]const ctypes.Decl {
-    const out = try arena.alloc(ctypes.Decl, decls.len);
-    for (decls, out) |src, *dst| {
-        dst.* = switch (src) {
-            .core_type => return error.UnsupportedAdapterShape,
-            .type => |td| .{ .type = try cloneTypeDef(arena, td, type_remap, depth) },
-            .alias => |a| .{ .alias = try cloneInstanceBodyAlias(arena, a, type_remap, depth) },
-            .import => |im| .{ .import = .{
-                .name = try arena.dupe(u8, im.name),
-                .desc = try cloneExternDesc(arena, im.desc, type_remap, depth),
-            } },
-            .@"export" => |e| .{ .@"export" = .{
-                .name = try arena.dupe(u8, e.name),
-                .desc = try cloneExternDesc(arena, e.desc, type_remap, depth),
-                .sort_idx = e.sort_idx,
-            } },
-        };
-    }
-    return out;
-}
-
-/// Clone an alias inside an instance type body. Outer aliases whose
-/// chain reaches the world body (`outer_count == depth`) have their
-/// `idx` rewritten through `type_remap` so the alias target survives
-/// the prune.
-fn cloneInstanceBodyAlias(
-    arena: Allocator,
-    a: ctypes.Alias,
-    type_remap: []const u32,
-    depth: u32,
-) Error!ctypes.Alias {
-    return switch (a) {
-        .instance_export => |ie| .{ .instance_export = .{
-            .sort = ie.sort,
-            .instance_idx = ie.instance_idx,
-            .name = try arena.dupe(u8, ie.name),
-        } },
-        .outer => |o| blk: {
-            const new_idx = if (o.outer_count == depth and o.sort == .type)
-                remap(type_remap, o.idx)
-            else
-                o.idx;
-            break :blk .{ .outer = .{
-                .sort = o.sort,
-                .outer_count = o.outer_count,
-                .idx = new_idx,
-            } };
-        },
-    };
-}
-
-fn cloneExternDesc(
-    arena: Allocator,
-    desc: ctypes.ExternDesc,
-    type_remap: []const u32,
-    depth: u32,
-) Error!ctypes.ExternDesc {
-    return switch (desc) {
-        .module => |idx| .{ .module = idx },
-        .func => |idx| .{ .func = if (depth == 0) remap(type_remap, idx) else idx },
-        .value => |vt| .{ .value = try cloneValType(arena, vt, type_remap, depth) },
-        .type => |tb| .{ .type = switch (tb) {
-            .eq => |idx| .{ .eq = if (depth == 0) remap(type_remap, idx) else idx },
-            .sub_resource => .sub_resource,
-        } },
-        .component => |idx| .{ .component = if (depth == 0) remap(type_remap, idx) else idx },
-        .instance => |idx| .{ .instance = if (depth == 0) remap(type_remap, idx) else idx },
-    };
-}
-
-fn cloneValType(
-    arena: Allocator,
-    vt: ctypes.ValType,
-    type_remap: []const u32,
-    depth: u32,
-) Error!ctypes.ValType {
-    _ = arena;
-    if (depth != 0) return vt; // local-typespace refs at depth>0 unchanged
-    return switch (vt) {
-        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .f32, .f64, .char, .string => vt,
-        .own => |idx| .{ .own = remap(type_remap, idx) },
-        .borrow => |idx| .{ .borrow = remap(type_remap, idx) },
-        .type_idx => |idx| .{ .type_idx = remap(type_remap, idx) },
-        .record => |idx| .{ .record = remap(type_remap, idx) },
-        .variant => |idx| .{ .variant = remap(type_remap, idx) },
-        .list => |idx| .{ .list = remap(type_remap, idx) },
-        .tuple => |idx| .{ .tuple = remap(type_remap, idx) },
-        .flags => |idx| .{ .flags = remap(type_remap, idx) },
-        .enum_ => |idx| .{ .enum_ = remap(type_remap, idx) },
-        .option => |idx| .{ .option = remap(type_remap, idx) },
-        .result => |idx| .{ .result = remap(type_remap, idx) },
-    };
-}
-
-fn remap(table: []const u32, idx: u32) u32 {
-    if (idx >= table.len) return idx;
-    return table[idx];
-}
 
 // ── Encode the rebuilt encoded-world payload ──────────────────────────────
 

--- a/src/component/type_walk.zig
+++ b/src/component/type_walk.zig
@@ -1,0 +1,412 @@
+//! Depth-aware traversal helpers for component-level type trees.
+//!
+//! Two reusable passes:
+//!
+//!   * `collect…` — walk a `TypeDef` / `Decl` / `ExternDesc` and emit
+//!     the set of type-indexspace operands that read the *enclosing*
+//!     (depth-0) component's type indexspace. Operands at `depth>0`
+//!     reference a local-to-the-nested-scope indexspace and are
+//!     ignored — except for outer aliases whose `outer_count` reaches
+//!     all the way back to depth 0, which DO contribute a depth-0
+//!     ref.
+//!
+//!   * `clone…` — deep-copy a `TypeDef` / `Decl` / `ExternDesc` while
+//!     rewriting every depth-0 operand through a `type_remap` table.
+//!     Operands at `depth>0` are copied verbatim. Outer aliases whose
+//!     chain reaches depth 0 (`outer_count == depth` and `sort ==
+//!     .type`) are remapped — keeping the alias valid after the
+//!     enclosing component's type indexspace has been rewritten.
+//!
+//! Originally extracted from `src/component/adapter/world_gc.zig`,
+//! which still owns the per-decl-metadata pre-pass and liveness
+//! solver. This module just provides the shared walk primitives so
+//! `wabt component compose` can reuse them when topologically
+//! emitting consumer types into a wrapping component.
+//!
+//! Limitations (deliberate, mirrored from `world_gc`):
+//!
+//!   * `.component` TypeDefs at any depth → `error.UnsupportedAdapterShape`.
+//!     Real component-type bodies inside top-level types are rare in
+//!     wasm-tools output and the wasi-preview1 adapter never uses
+//!     them. Relax in a follow-up if real inputs hit it.
+//!   * `core_type` decls inside an instance body →
+//!     `error.UnsupportedAdapterShape`. Same rationale.
+//!
+//! All slices are arena-allocated; the caller owns the arena.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const ctypes = @import("types.zig");
+
+// `UnsupportedAdapterShape` is preserved as a name for compatibility
+// with the adapter splicer's existing error sets (see
+// `src/component/adapter/world_gc.zig::Error`). Conceptually it means
+// "the type tree contains a construct this walk doesn't model" — it
+// is not adapter-specific.
+pub const Error = error{ OutOfMemory, UnsupportedAdapterShape };
+
+// ── Collect: type-indexspace refs at depth 0 ───────────────────────────────
+
+/// Collect type-idx refs from a type def. `depth` is the nesting
+/// depth — 0 for the enclosing component's body, 1 inside an
+/// instance type body, etc. Refs at `depth>0` reference a
+/// local-to-nested-scope indexspace and are *not* emitted; outer
+/// aliases whose `outer_count == depth` bubble up to depth 0 and ARE
+/// emitted (handled in `collectInstanceBodyRefs`).
+pub fn collectTypeDefRefs(
+    arena: Allocator,
+    td: ctypes.TypeDef,
+    out: *std.ArrayListUnmanaged(u32),
+    depth: u32,
+) Error!void {
+    switch (td) {
+        .val => |vt| try collectValTypeRefs(arena, vt, out, depth),
+        .record => |r| for (r.fields) |f| try collectValTypeRefs(arena, f.type, out, depth),
+        .variant => |v| for (v.cases) |c| {
+            if (c.type) |vt| try collectValTypeRefs(arena, vt, out, depth);
+        },
+        .list => |l| try collectValTypeRefs(arena, l.element, out, depth),
+        .tuple => |t| for (t.fields) |f| try collectValTypeRefs(arena, f, out, depth),
+        .flags, .enum_ => {},
+        .option => |o| try collectValTypeRefs(arena, o.inner, out, depth),
+        .result => |r| {
+            if (r.ok) |vt| try collectValTypeRefs(arena, vt, out, depth);
+            if (r.err) |vt| try collectValTypeRefs(arena, vt, out, depth);
+        },
+        .resource => {},
+        .func => |f| {
+            for (f.params) |p| try collectValTypeRefs(arena, p.type, out, depth);
+            switch (f.results) {
+                .none => {},
+                .unnamed => |vt| try collectValTypeRefs(arena, vt, out, depth),
+                .named => |list| for (list) |nv| try collectValTypeRefs(arena, nv.type, out, depth),
+            }
+        },
+        .component => return error.UnsupportedAdapterShape,
+        .instance => |i| try collectInstanceBodyRefs(arena, i.decls, out, depth + 1),
+    }
+}
+
+/// Collect type-idx refs from valtype operands. ValTypes at `depth>0`
+/// reference the local type indexspace at THAT depth — not the
+/// enclosing component's. So they don't contribute body-level refs.
+pub fn collectValTypeRefs(
+    arena: Allocator,
+    vt: ctypes.ValType,
+    out: *std.ArrayListUnmanaged(u32),
+    depth: u32,
+) Error!void {
+    if (depth != 0) return;
+    switch (vt) {
+        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .f32, .f64, .char, .string => {},
+        .own => |idx| try out.append(arena, idx),
+        .borrow => |idx| try out.append(arena, idx),
+        .type_idx => |idx| try out.append(arena, idx),
+        .record => |idx| try out.append(arena, idx),
+        .variant => |idx| try out.append(arena, idx),
+        .list => |idx| try out.append(arena, idx),
+        .tuple => |idx| try out.append(arena, idx),
+        .flags => |idx| try out.append(arena, idx),
+        .enum_ => |idx| try out.append(arena, idx),
+        .option => |idx| try out.append(arena, idx),
+        .result => |idx| try out.append(arena, idx),
+    }
+}
+
+pub fn collectInstanceBodyRefs(
+    arena: Allocator,
+    decls: []const ctypes.Decl,
+    out: *std.ArrayListUnmanaged(u32),
+    depth: u32,
+) Error!void {
+    for (decls) |d| {
+        switch (d) {
+            .core_type => {},
+            .type => |td| try collectTypeDefRefs(arena, td, out, depth),
+            .alias => |a| switch (a) {
+                .instance_export => {},
+                .outer => |o| {
+                    // Outer-alias whose chain reaches depth 0 (the
+                    // enclosing component) — its `idx` reads that
+                    // component's type indexspace.
+                    if (o.outer_count == depth and o.sort == .type) {
+                        try out.append(arena, o.idx);
+                    }
+                },
+            },
+            .import => |im| {
+                // Imports inside an instance type are unusual; instance
+                // bodies normally only have type defs, aliases, and
+                // exports. Treat opaquely (still walk the desc).
+                try collectExternDescRefsAtDepth(arena, im.desc, out, depth);
+            },
+            .@"export" => |e| try collectExternDescRefsAtDepth(arena, e.desc, out, depth),
+        }
+    }
+}
+
+pub fn collectExternDescRefs(
+    arena: Allocator,
+    desc: ctypes.ExternDesc,
+    out: *std.ArrayListUnmanaged(u32),
+) Error!void {
+    return collectExternDescRefsAtDepth(arena, desc, out, 0);
+}
+
+pub fn collectExternDescRefsAtDepth(
+    arena: Allocator,
+    desc: ctypes.ExternDesc,
+    out: *std.ArrayListUnmanaged(u32),
+    depth: u32,
+) Error!void {
+    if (depth != 0) return;
+    switch (desc) {
+        .module => {},
+        .func => |idx| try out.append(arena, idx),
+        .value => |vt| try collectValTypeRefs(arena, vt, out, 0),
+        .type => |tb| switch (tb) {
+            .eq => |idx| try out.append(arena, idx),
+            .sub_resource => {},
+        },
+        .component => |idx| try out.append(arena, idx),
+        .instance => |idx| try out.append(arena, idx),
+    }
+}
+
+// ── Clone with operand renumbering ─────────────────────────────────────────
+
+pub fn cloneDecl(
+    arena: Allocator,
+    d: ctypes.Decl,
+    type_remap: []const u32,
+    inst_remap: []const u32,
+) Error!ctypes.Decl {
+    return switch (d) {
+        .core_type => error.UnsupportedAdapterShape,
+        .type => |td| .{ .type = try cloneTypeDef(arena, td, type_remap, 0) },
+        .alias => |a| .{ .alias = try cloneAlias(arena, a, type_remap, inst_remap) },
+        .import => |im| .{ .import = .{
+            .name = try arena.dupe(u8, im.name),
+            .desc = try cloneExternDesc(arena, im.desc, type_remap, 0),
+        } },
+        .@"export" => |e| .{ .@"export" = .{
+            .name = try arena.dupe(u8, e.name),
+            .desc = try cloneExternDesc(arena, e.desc, type_remap, 0),
+            .sort_idx = e.sort_idx,
+        } },
+    };
+}
+
+pub fn cloneAlias(
+    arena: Allocator,
+    a: ctypes.Alias,
+    type_remap: []const u32,
+    inst_remap: []const u32,
+) Error!ctypes.Alias {
+    _ = type_remap;
+    return switch (a) {
+        .instance_export => |ie| .{ .instance_export = .{
+            .sort = ie.sort,
+            .instance_idx = remap(inst_remap, ie.instance_idx),
+            .name = try arena.dupe(u8, ie.name),
+        } },
+        .outer => |o| .{ .outer = .{
+            .sort = o.sort,
+            .outer_count = o.outer_count,
+            // depth-0 outer alias references the enclosing
+            // component's indexspace; world_gc's caller has always
+            // emitted this for boilerplate (idx 0) and left it
+            // verbatim. Compose's caller likewise emits this only
+            // for top-level body alias decls, where the enclosing
+            // scope is the wrapping component and the idx is fresh
+            // in the wrapper's space — leave verbatim here too.
+            .idx = o.idx,
+        } },
+    };
+}
+
+pub fn cloneTypeDef(
+    arena: Allocator,
+    td: ctypes.TypeDef,
+    type_remap: []const u32,
+    depth: u32,
+) Error!ctypes.TypeDef {
+    return switch (td) {
+        .val => |vt| .{ .val = try cloneValType(arena, vt, type_remap, depth) },
+        .record => |r| blk: {
+            const fields = try arena.alloc(ctypes.Field, r.fields.len);
+            for (r.fields, fields) |src, *dst| {
+                dst.* = .{
+                    .name = try arena.dupe(u8, src.name),
+                    .type = try cloneValType(arena, src.type, type_remap, depth),
+                };
+            }
+            break :blk .{ .record = .{ .fields = fields } };
+        },
+        .variant => |v| blk: {
+            const cases = try arena.alloc(ctypes.Case, v.cases.len);
+            for (v.cases, cases) |src, *dst| {
+                dst.* = .{
+                    .name = try arena.dupe(u8, src.name),
+                    .type = if (src.type) |t| try cloneValType(arena, t, type_remap, depth) else null,
+                    .refines = src.refines,
+                };
+            }
+            break :blk .{ .variant = .{ .cases = cases } };
+        },
+        .list => |l| .{ .list = .{ .element = try cloneValType(arena, l.element, type_remap, depth) } },
+        .tuple => |t| blk: {
+            const fields = try arena.alloc(ctypes.ValType, t.fields.len);
+            for (t.fields, fields) |src, *dst| dst.* = try cloneValType(arena, src, type_remap, depth);
+            break :blk .{ .tuple = .{ .fields = fields } };
+        },
+        .flags => |f| blk: {
+            const names = try arena.alloc([]const u8, f.names.len);
+            for (f.names, names) |src, *dst| dst.* = try arena.dupe(u8, src);
+            break :blk .{ .flags = .{ .names = names } };
+        },
+        .enum_ => |e| blk: {
+            const names = try arena.alloc([]const u8, e.names.len);
+            for (e.names, names) |src, *dst| dst.* = try arena.dupe(u8, src);
+            break :blk .{ .enum_ = .{ .names = names } };
+        },
+        .option => |o| .{ .option = .{ .inner = try cloneValType(arena, o.inner, type_remap, depth) } },
+        .result => |r| .{ .result = .{
+            .ok = if (r.ok) |t| try cloneValType(arena, t, type_remap, depth) else null,
+            .err = if (r.err) |t| try cloneValType(arena, t, type_remap, depth) else null,
+        } },
+        .resource => |r| .{ .resource = r },
+        .func => |f| blk: {
+            const params = try arena.alloc(ctypes.NamedValType, f.params.len);
+            for (f.params, params) |src, *dst| dst.* = .{
+                .name = try arena.dupe(u8, src.name),
+                .type = try cloneValType(arena, src.type, type_remap, depth),
+            };
+            const results: ctypes.FuncType.ResultList = switch (f.results) {
+                .none => .none,
+                .unnamed => |vt| .{ .unnamed = try cloneValType(arena, vt, type_remap, depth) },
+                .named => |list| named: {
+                    const dst = try arena.alloc(ctypes.NamedValType, list.len);
+                    for (list, dst) |src, *d| d.* = .{
+                        .name = try arena.dupe(u8, src.name),
+                        .type = try cloneValType(arena, src.type, type_remap, depth),
+                    };
+                    break :named .{ .named = dst };
+                },
+            };
+            break :blk .{ .func = .{ .params = params, .results = results } };
+        },
+        .component => return error.UnsupportedAdapterShape,
+        .instance => |i| .{ .instance = .{ .decls = try cloneInstanceBody(arena, i.decls, type_remap, depth + 1) } },
+    };
+}
+
+pub fn cloneInstanceBody(
+    arena: Allocator,
+    decls: []const ctypes.Decl,
+    type_remap: []const u32,
+    depth: u32,
+) Error![]const ctypes.Decl {
+    const out = try arena.alloc(ctypes.Decl, decls.len);
+    for (decls, out) |src, *dst| {
+        dst.* = switch (src) {
+            .core_type => return error.UnsupportedAdapterShape,
+            .type => |td| .{ .type = try cloneTypeDef(arena, td, type_remap, depth) },
+            .alias => |a| .{ .alias = try cloneInstanceBodyAlias(arena, a, type_remap, depth) },
+            .import => |im| .{ .import = .{
+                .name = try arena.dupe(u8, im.name),
+                .desc = try cloneExternDesc(arena, im.desc, type_remap, depth),
+            } },
+            .@"export" => |e| .{ .@"export" = .{
+                .name = try arena.dupe(u8, e.name),
+                .desc = try cloneExternDesc(arena, e.desc, type_remap, depth),
+                .sort_idx = e.sort_idx,
+            } },
+        };
+    }
+    return out;
+}
+
+/// Clone an alias inside an instance type body. Outer aliases whose
+/// chain reaches depth 0 (`outer_count == depth`) have their `idx`
+/// rewritten through `type_remap`, so the alias target survives a
+/// rewrite of the depth-0 type indexspace.
+pub fn cloneInstanceBodyAlias(
+    arena: Allocator,
+    a: ctypes.Alias,
+    type_remap: []const u32,
+    depth: u32,
+) Error!ctypes.Alias {
+    return switch (a) {
+        .instance_export => |ie| .{ .instance_export = .{
+            .sort = ie.sort,
+            .instance_idx = ie.instance_idx,
+            .name = try arena.dupe(u8, ie.name),
+        } },
+        .outer => |o| blk: {
+            const new_idx = if (o.outer_count == depth and o.sort == .type)
+                remap(type_remap, o.idx)
+            else
+                o.idx;
+            break :blk .{ .outer = .{
+                .sort = o.sort,
+                .outer_count = o.outer_count,
+                .idx = new_idx,
+            } };
+        },
+    };
+}
+
+pub fn cloneExternDesc(
+    arena: Allocator,
+    desc: ctypes.ExternDesc,
+    type_remap: []const u32,
+    depth: u32,
+) Error!ctypes.ExternDesc {
+    return switch (desc) {
+        .module => |idx| .{ .module = idx },
+        .func => |idx| .{ .func = if (depth == 0) remap(type_remap, idx) else idx },
+        .value => |vt| .{ .value = try cloneValType(arena, vt, type_remap, depth) },
+        .type => |tb| .{ .type = switch (tb) {
+            .eq => |idx| .{ .eq = if (depth == 0) remap(type_remap, idx) else idx },
+            .sub_resource => .sub_resource,
+        } },
+        .component => |idx| .{ .component = if (depth == 0) remap(type_remap, idx) else idx },
+        .instance => |idx| .{ .instance = if (depth == 0) remap(type_remap, idx) else idx },
+    };
+}
+
+pub fn cloneValType(
+    arena: Allocator,
+    vt: ctypes.ValType,
+    type_remap: []const u32,
+    depth: u32,
+) Error!ctypes.ValType {
+    _ = arena;
+    if (depth != 0) return vt;
+    return switch (vt) {
+        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .f32, .f64, .char, .string => vt,
+        .own => |idx| .{ .own = remap(type_remap, idx) },
+        .borrow => |idx| .{ .borrow = remap(type_remap, idx) },
+        .type_idx => |idx| .{ .type_idx = remap(type_remap, idx) },
+        .record => |idx| .{ .record = remap(type_remap, idx) },
+        .variant => |idx| .{ .variant = remap(type_remap, idx) },
+        .list => |idx| .{ .list = remap(type_remap, idx) },
+        .tuple => |idx| .{ .tuple = remap(type_remap, idx) },
+        .flags => |idx| .{ .flags = remap(type_remap, idx) },
+        .enum_ => |idx| .{ .enum_ = remap(type_remap, idx) },
+        .option => |idx| .{ .option = remap(type_remap, idx) },
+        .result => |idx| .{ .result = remap(type_remap, idx) },
+    };
+}
+
+/// Rewrite `idx` through `table`. Values past the end of `table` are
+/// returned verbatim — sentinel for "this idx is outside the remap'd
+/// indexspace and should be passed through" (e.g. depth>0 local
+/// types when `cloneValType` is called at depth==0 by mistake won't
+/// crash, but should never happen in practice).
+pub fn remap(table: []const u32, idx: u32) u32 {
+    if (idx >= table.len) return idx;
+    return table[idx];
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -35,6 +35,7 @@ pub const component = struct {
     pub const loader = @import("component/loader.zig");
     pub const writer = @import("component/writer.zig");
     pub const compose = @import("component/compose.zig");
+    pub const type_walk = @import("component/type_walk.zig");
     pub const wit = struct {
         pub const lexer = @import("component/wit/lexer.zig");
         pub const ast = @import("component/wit/ast.zig");
@@ -68,6 +69,7 @@ test {
     _ = @import("component/loader.zig");
     _ = @import("component/writer.zig");
     _ = @import("component/compose.zig");
+    _ = @import("component/type_walk.zig");
     _ = @import("component/wit/lexer.zig");
     _ = @import("component/wit/ast.zig");
     _ = @import("component/wit/parser.zig");

--- a/src/tools/component_compose.zig
+++ b/src/tools/component_compose.zig
@@ -30,6 +30,7 @@ const ctypes = wabt.component.types;
 const writer = wabt.component.writer;
 const loader = wabt.component.loader;
 const compose = wabt.component.compose;
+const type_walk = wabt.component.type_walk;
 
 pub const usage =
     \\Usage: wabt component compose [options] <consumer.wasm>
@@ -195,46 +196,44 @@ pub fn composeBinaries(
     const num_bindings: u32 = @intCast(link.bindings.len);
 
     // ── Wrapper types: copy each unresolved import's referenced type
-    //    from the consumer into our local types[] so the bubbled-up
-    //    import can reference it by a wrapper-local idx.
+    //    (and its transitive deps) from the consumer into our local
+    //    types[] so the bubbled-up imports + every nested outer-alias
+    //    inside their bodies still resolves to a wrapper-local idx.
     //
-    //    Pre-fix bug: the wrapper used to emit an `import` section
-    //    with `desc.instance(N)` referencing the *consumer's* type
-    //    idx N — but the wrapper had no types[] section at all,
-    //    producing a malformed component (id 0x0a precedes id 0x07
-    //    on every emission). Building a `types[]` here, plus the
-    //    explicit `section_order` below, ensures the writer emits
-    //    type-before-import. ──
-    var types_list = std.ArrayListUnmanaged(ctypes.TypeDef).empty;
-    var type_remap = std.AutoHashMapUnmanaged(u32, u32).empty;
-    for (link.unresolved) |u_idx| {
-        const imp = consumer.imports[u_idx];
-        if (imp.desc != .instance) continue;
-        const old_t_idx = imp.desc.instance;
-        const gop = try type_remap.getOrPut(ar, old_t_idx);
-        if (gop.found_existing) continue;
-        gop.value_ptr.* = @intCast(types_list.items.len);
-        if (lookupConsumerType(&consumer, old_t_idx)) |td| {
-            try types_list.append(ar, td);
-        } else {
-            // Hand-built fixtures occasionally declare imports that
-            // reference type indices not materialized in `types[]`
-            // (e.g. tests with `types: &.{}`). Fall back to an empty
-            // instance type — keeps the wrapper structurally valid;
-            // real compose inputs always supply the type.
-            try types_list.append(ar, .{ .instance = .{ .decls = &.{} } });
-        }
-    }
+    //    Pre-fix bug 1 (#115/#118, fixed in #119): the wrapper used
+    //    to emit an `import` section with `desc.instance(N)`
+    //    referencing the *consumer's* type idx N — but the wrapper
+    //    had no types[] section at all, producing a malformed
+    //    component (id 0x0a precedes id 0x07 on every emission).
+    //
+    //    Pre-fix bug 2 (#121): the wrapper copied only the import's
+    //    immediately-referenced TypeDef, leaving its body's outer
+    //    aliases (`(alias outer 1 X)`) and depth-0 valtype refs
+    //    pointing at consumer-typespace idxs that were never
+    //    materialised in the wrapper. wasm-tools rejected the result
+    //    with "type index out of bounds".
+    //
+    //    Fix: BFS the transitive consumer-typespace-idx closure from
+    //    each unresolved import's desc, topologically sort it so each
+    //    emitted type's body only references strictly smaller
+    //    wrapper indices, then deep-clone every TypeDef through a
+    //    consumer→wrapper remap so all depth-0 operands (including
+    //    body-level outer aliases inside instance types) hit the
+    //    wrapper's renumbered indexspace. ──
+    const wrapper_types = try buildWrapperTypes(ar, &consumer, link.unresolved);
+    const types_list_items = wrapper_types.types;
+    const type_remap_table = wrapper_types.remap;
 
-    // ── Wrapper imports: rewrite each bubbled-up desc.instance to
-    //    point at our wrapper-local type idx. Names are preserved so
-    //    downstream callers see the same import set the consumer had. ──
+    // ── Wrapper imports: rewrite each bubbled-up desc to point at
+    //    wrapper-local type idxs via the same remap table. Names are
+    //    preserved so downstream callers see the same import set the
+    //    consumer had. ──
     const imports_arr = try ar.alloc(ctypes.ImportDecl, num_unresolved);
     for (link.unresolved, 0..) |u_idx, i| {
         const imp = consumer.imports[u_idx];
         imports_arr[i] = .{
             .name = imp.name,
-            .desc = remapImportDesc(imp.desc, &type_remap),
+            .desc = try type_walk.cloneExternDesc(ar, imp.desc, type_remap_table, 0),
         };
     }
 
@@ -325,7 +324,7 @@ pub fn composeBinaries(
     var instance_counter: u32 = consumer_inst_idx + 1;
     var func_counter: u32 = 0;
     var component_counter: u32 = 0;
-    var type_counter: u32 = @intCast(types_list.items.len);
+    var type_counter: u32 = @intCast(types_list_items.len);
     var value_counter: u32 = 0;
     var core_func_counter: u32 = 0;
     var core_module_counter: u32 = 0;
@@ -394,10 +393,10 @@ pub fn composeBinaries(
     //   The component-instance indexspace fills forward-only — each
     //   section only references slots produced by earlier sections. ──
     var section_order = std.ArrayListUnmanaged(ctypes.SectionEntry).empty;
-    if (types_list.items.len > 0) try section_order.append(ar, .{
+    if (types_list_items.len > 0) try section_order.append(ar, .{
         .kind = .type,
         .start = 0,
-        .count = @intCast(types_list.items.len),
+        .count = @intCast(types_list_items.len),
     });
     if (imports_arr.len > 0) try section_order.append(ar, .{
         .kind = .import,
@@ -442,7 +441,7 @@ pub fn composeBinaries(
         .components = components_arr,
         .instances = instances_list.items,
         .aliases = aliases_list.items,
-        .types = types_list.items,
+        .types = types_list_items,
         .canons = &.{},
         .imports = imports_arr,
         .exports = exports_list.items,
@@ -488,18 +487,159 @@ fn passthroughComponent(bytes: []const u8) ctypes.Component {
     };
 }
 
-/// Rewrite a bubbled-up consumer import's desc so any type-idx
-/// references point at the wrapper-local types[] slot instead of the
-/// consumer-local one. Only `.instance` carries a type idx that needs
-/// remapping in practice; other descs are passed through unchanged.
-fn remapImportDesc(
-    desc: ctypes.ExternDesc,
-    m: *const std.AutoHashMapUnmanaged(u32, u32),
-) ctypes.ExternDesc {
-    return switch (desc) {
-        .instance => |idx| .{ .instance = m.get(idx) orelse 0 },
-        else => desc,
-    };
+/// Result of building the wrapping component's `types[]` section
+/// from the unresolved imports' transitive type-dependency closure.
+const WrapperTypes = struct {
+    /// Topologically-ordered TypeDefs ready to assign to
+    /// `Component.types`. Each TypeDef's body has been deep-cloned
+    /// with all depth-0 operands renumbered through `remap`.
+    types: []const ctypes.TypeDef,
+    /// Mapping `consumer.type_indexspace[X]` → wrapper-types[]-idx.
+    /// Slots not in the closure remain `SENTINEL` (max u32). The
+    /// table is sized to fit any legal idx the cloner might encounter
+    /// (max of consumer.type_indexspace.len and consumer.types.len).
+    remap: []const u32,
+};
+
+const SENTINEL_TYPE_IDX: u32 = std.math.maxInt(u32);
+
+/// Build the wrapping component's `types[]` from the closure of
+/// consumer-typespace idxs reachable from `unresolved`'s imports.
+///
+/// Algorithm:
+///
+///   1. **Seed.** For every unresolved import, collect every type-idx
+///      operand its `ExternDesc` carries (via `type_walk`).
+///   2. **BFS expand.** For each idx in the queue, resolve to its
+///      consumer TypeDef (`lookupConsumerType`), walk it at depth 0
+///      to gather every type-idx the body references at depth 0,
+///      enqueue any new ones.
+///   3. **Topo sort.** DFS post-order over the closure: emit a node
+///      after all its in-closure deps are emitted. Cycles cannot
+///      occur in well-formed components but we detect and bail with
+///      a stable order if one slips through (tolerant — the
+///      validator will catch it downstream anyway).
+///   4. **Clone + remap.** For each closure idx in topo order, build
+///      the consumer→wrapper remap entry, then clone its TypeDef
+///      via `type_walk.cloneTypeDef(td, remap, depth=0)`. Slots
+///      whose `lookupConsumerType` returns null fall back to an
+///      empty instance type — same behaviour the pre-fix code had,
+///      kept so hand-built fixtures with `types: &.{}` still round-
+///      trip.
+fn buildWrapperTypes(
+    arena: std.mem.Allocator,
+    consumer: *const ctypes.Component,
+    unresolved: []const u32,
+) !WrapperTypes {
+    // ── Step 1+2: BFS the closure of consumer-typespace idxs ───────
+    var queue = std.ArrayListUnmanaged(u32).empty;
+    var in_closure = std.AutoHashMapUnmanaged(u32, void).empty;
+    var max_idx: u32 = 0;
+
+    for (unresolved) |u_idx| {
+        const imp = consumer.imports[u_idx];
+        var seeds = std.ArrayListUnmanaged(u32).empty;
+        try type_walk.collectExternDescRefs(arena, imp.desc, &seeds);
+        for (seeds.items) |s| {
+            if ((try in_closure.fetchPut(arena, s, {})) == null) {
+                try queue.append(arena, s);
+                if (s > max_idx) max_idx = s;
+            }
+        }
+    }
+
+    var head: usize = 0;
+    while (head < queue.items.len) : (head += 1) {
+        const cur = queue.items[head];
+        const td = lookupConsumerType(consumer, cur) orelse continue;
+        var refs = std.ArrayListUnmanaged(u32).empty;
+        try type_walk.collectTypeDefRefs(arena, td, &refs, 0);
+        for (refs.items) |r| {
+            if ((try in_closure.fetchPut(arena, r, {})) == null) {
+                try queue.append(arena, r);
+                if (r > max_idx) max_idx = r;
+            }
+        }
+    }
+
+    // remap covers every consumer-typespace idx that could be
+    // operand to a depth-0 ref in any cloned body. Size it to
+    // accommodate the consumer's indexspace, its types[], and the
+    // highest BFS-encountered idx (which may sit *past* the
+    // indexspace for hand-built fixtures with `types: &.{}` whose
+    // imports still cite a numeric type idx).
+    var remap_len: usize = consumer.type_indexspace.len;
+    if (consumer.types.len > remap_len) remap_len = consumer.types.len;
+    if (in_closure.count() > 0 and @as(usize, max_idx) + 1 > remap_len) {
+        remap_len = @as(usize, max_idx) + 1;
+    }
+    const remap = try arena.alloc(u32, remap_len);
+    @memset(remap, SENTINEL_TYPE_IDX);
+
+    // ── Step 3: DFS post-order topo sort ──────────────────────────
+    const order = try arena.alloc(u32, queue.items.len);
+    var order_len: usize = 0;
+    var visiting = std.AutoHashMapUnmanaged(u32, void).empty;
+    var visited = std.AutoHashMapUnmanaged(u32, void).empty;
+
+    for (queue.items) |seed| {
+        try topoVisit(arena, consumer, seed, &visiting, &visited, order, &order_len);
+    }
+
+    // ── Step 4: clone + remap in topo order ───────────────────────
+    const types = try arena.alloc(ctypes.TypeDef, order_len);
+    // First pass: assign wrapper-idxs so refs from later types
+    // resolve. (DFS post-order already guarantees deps come first,
+    // so we can also fill remap in a single pass — done up-front
+    // here for symmetry with the cycle-tolerance bail-out path.)
+    for (order[0..order_len], 0..) |consumer_idx, wrapper_idx| {
+        if (consumer_idx < remap.len) remap[consumer_idx] = @intCast(wrapper_idx);
+    }
+    // Second pass: clone bodies through the now-complete remap.
+    for (order[0..order_len], 0..) |consumer_idx, wrapper_idx| {
+        const td = lookupConsumerType(consumer, consumer_idx) orelse blk: {
+            // Hand-built fixtures (e.g. tests with `types: &.{}`)
+            // declare imports referencing slots not materialised in
+            // `types[]`. Substitute an empty instance type — keeps
+            // the wrapper structurally valid; real compose inputs
+            // always supply the type.
+            break :blk ctypes.TypeDef{ .instance = .{ .decls = &.{} } };
+        };
+        types[wrapper_idx] = try type_walk.cloneTypeDef(arena, td, remap, 0);
+    }
+
+    return .{ .types = types, .remap = remap };
+}
+
+/// DFS post-order visit. Skips already-visited nodes and tolerates
+/// cycles by bailing on back-edges (the cyclic node is dropped from
+/// the order; downstream validators will catch any resulting
+/// invalidity).
+fn topoVisit(
+    arena: std.mem.Allocator,
+    consumer: *const ctypes.Component,
+    node: u32,
+    visiting: *std.AutoHashMapUnmanaged(u32, void),
+    visited: *std.AutoHashMapUnmanaged(u32, void),
+    order: []u32,
+    order_len: *usize,
+) !void {
+    if (visited.contains(node)) return;
+    if (visiting.contains(node)) return; // back-edge — break the cycle
+    try visiting.put(arena, node, {});
+
+    if (lookupConsumerType(consumer, node)) |td| {
+        var refs = std.ArrayListUnmanaged(u32).empty;
+        try type_walk.collectTypeDefRefs(arena, td, &refs, 0);
+        for (refs.items) |r| {
+            try topoVisit(arena, consumer, r, visiting, visited, order, order_len);
+        }
+    }
+
+    _ = visiting.remove(node);
+    try visited.put(arena, node, {});
+    order[order_len.*] = node;
+    order_len.* += 1;
 }
 
 fn synthSortFromExport(exp: ctypes.ExportDecl) ctypes.SortIdx {
@@ -713,4 +853,168 @@ test "composeBinaries: multi-package consumer + provider end-to-end" {
     try testing.expectEqual(@as(usize, 2), loaded.components.len);
     try testing.expectEqual(@as(usize, 2), loaded.instances.len);
     try testing.expectEqual(@as(usize, 1), loaded.aliases.len);
+}
+
+test "composeBinaries: copies transitive type deps when bubbling up instance import" {
+    // Consumer with two top-level types:
+    //   types[0] = func(x: u32) -> u32         (the underlying "add")
+    //   types[1] = instance {
+    //                (alias outer 1 0)         ; pull func from outer
+    //                (export "add" (func (type 0)))
+    //              }
+    // imports[0].desc = .instance(1)
+    //
+    // Pre-fix bug (#121): only types[1] would be copied into the
+    // wrapper, leaving its body's outer-alias-1-0 pointing at a
+    // wrapper-type-0 that didn't exist. Post-fix: BFS pulls in
+    // types[0] too, topo-sort puts it first, and the body's outer
+    // alias is remapped to the wrapper's renumbered idx.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    const params = [_]ctypes.NamedValType{.{ .name = "x", .type = .u32 }};
+    const func_type = ctypes.TypeDef{ .func = .{
+        .params = &params,
+        .results = .{ .unnamed = .u32 },
+    } };
+
+    const inst_decls = [_]ctypes.Decl{
+        .{ .alias = .{ .outer = .{
+            .sort = .type,
+            .outer_count = 1,
+            .idx = 0,
+        } } },
+        .{ .@"export" = .{
+            .name = "add",
+            .desc = .{ .func = 0 },
+        } },
+    };
+    const inst_type = ctypes.TypeDef{ .instance = .{ .decls = &inst_decls } };
+
+    const types = [_]ctypes.TypeDef{ func_type, inst_type };
+    const imports = [_]ctypes.ImportDecl{
+        .{ .name = "ns:pkg/iface@0.1.0", .desc = .{ .instance = 1 } },
+    };
+    const consumer: ctypes.Component = .{
+        .core_modules = &.{}, .core_instances = &.{}, .core_types = &.{},
+        .components = &.{}, .instances = &.{}, .aliases = &.{},
+        .types = &types, .canons = &.{},
+        .imports = &imports, .exports = &.{},
+    };
+    const consumer_bytes = try writer.encode(ar, &consumer);
+
+    const empty_providers: []const []u8 = &.{};
+    const composed = try composeBinaries(testing.allocator, consumer_bytes, empty_providers);
+    defer testing.allocator.free(composed);
+
+    var arena2 = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena2.deinit();
+    const loaded = try loader.load(composed, arena2.allocator());
+
+    // Both types must be present in the wrapper (transitive closure).
+    try testing.expect(loaded.types.len >= 2);
+
+    // The bubbled-up import must reference an instance type slot
+    // that exists in the wrapper.
+    try testing.expectEqual(@as(usize, 1), loaded.imports.len);
+    try testing.expect(loaded.imports[0].desc == .instance);
+    const inst_idx = loaded.imports[0].desc.instance;
+    try testing.expect(inst_idx < loaded.types.len);
+
+    // The instance's body must contain an outer-alias whose `idx` is
+    // strictly less than `inst_idx` — so the alias resolves to a
+    // wrapper type already declared at that point (the spec's
+    // forward-only-references rule).
+    try testing.expect(loaded.types[inst_idx] == .instance);
+    const body = loaded.types[inst_idx].instance.decls;
+    var found_outer_alias = false;
+    for (body) |d| {
+        if (d != .alias) continue;
+        if (d.alias != .outer) continue;
+        if (d.alias.outer.sort != .type) continue;
+        if (d.alias.outer.outer_count != 1) continue;
+        try testing.expect(d.alias.outer.idx < inst_idx);
+        found_outer_alias = true;
+    }
+    try testing.expect(found_outer_alias);
+}
+
+test "composeBinaries: emits types in topological order" {
+    // Same shape as the previous test but consumer declares the
+    // instance type FIRST (idx 0) and the func dep SECOND (idx 1).
+    // The wrapper must topologically reorder them so each emitted
+    // type's body only references strictly smaller wrapper indices.
+    // The bubbled-up import's desc must follow the renumbering.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    const params = [_]ctypes.NamedValType{.{ .name = "x", .type = .u32 }};
+    const func_type = ctypes.TypeDef{ .func = .{
+        .params = &params,
+        .results = .{ .unnamed = .u32 },
+    } };
+
+    // Body refs outer-1-1 → consumer-typespace-1 (the func, declared
+    // *after* the instance in source order).
+    const inst_decls = [_]ctypes.Decl{
+        .{ .alias = .{ .outer = .{
+            .sort = .type,
+            .outer_count = 1,
+            .idx = 1,
+        } } },
+        .{ .@"export" = .{
+            .name = "add",
+            .desc = .{ .func = 0 },
+        } },
+    };
+    const inst_type = ctypes.TypeDef{ .instance = .{ .decls = &inst_decls } };
+
+    // Instance at idx 0, func at idx 1 — reverse of dep order.
+    const types = [_]ctypes.TypeDef{ inst_type, func_type };
+    const imports = [_]ctypes.ImportDecl{
+        .{ .name = "ns:pkg/iface@0.1.0", .desc = .{ .instance = 0 } },
+    };
+    const consumer: ctypes.Component = .{
+        .core_modules = &.{}, .core_instances = &.{}, .core_types = &.{},
+        .components = &.{}, .instances = &.{}, .aliases = &.{},
+        .types = &types, .canons = &.{},
+        .imports = &imports, .exports = &.{},
+    };
+    const consumer_bytes = try writer.encode(ar, &consumer);
+
+    const empty_providers: []const []u8 = &.{};
+    const composed = try composeBinaries(testing.allocator, consumer_bytes, empty_providers);
+    defer testing.allocator.free(composed);
+
+    var arena2 = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena2.deinit();
+    const loaded = try loader.load(composed, arena2.allocator());
+
+    try testing.expectEqual(@as(usize, 2), loaded.types.len);
+    // Topo sort must hoist the func dep ahead of the instance so the
+    // instance's outer alias resolves to a strictly smaller idx.
+    try testing.expect(loaded.types[0] == .func);
+    try testing.expect(loaded.types[1] == .instance);
+
+    // The bubbled-up import desc must follow the renumbering: the
+    // instance now lives at wrapper-idx 1, not consumer-idx 0.
+    try testing.expectEqual(@as(usize, 1), loaded.imports.len);
+    try testing.expect(loaded.imports[0].desc == .instance);
+    try testing.expectEqual(@as(u32, 1), loaded.imports[0].desc.instance);
+
+    // The instance body's outer alias must point at wrapper-idx 0
+    // (the func), reflecting the renumber.
+    const body = loaded.types[1].instance.decls;
+    var found_alias = false;
+    for (body) |d| {
+        if (d != .alias) continue;
+        if (d.alias != .outer) continue;
+        if (d.alias.outer.sort != .type) continue;
+        try testing.expectEqual(@as(u32, 1), d.alias.outer.outer_count);
+        try testing.expectEqual(@as(u32, 0), d.alias.outer.idx);
+        found_alias = true;
+    }
+    try testing.expect(found_alias);
 }


### PR DESCRIPTION
Fixes #121.

The compose wrapper used to copy a single `TypeDef` per unresolved import into its top-level `types[]`, leaving every depth-0 reference inside that `TypeDef`'s body — outer aliases (`(alias outer 1 X)`) and depth-0 valtype refs in nested instance/func types — pointing at consumer-typespace idxs that were never materialised in the wrapper. `wasm-tools validate` rejected the result with `unknown type N: type index out of bounds (at offset 0x12f|0x18)`.

## Fix

- BFS the transitive consumer-typespace-idx closure from each unresolved import's `ExternDesc`.
- DFS post-order topo-sort it so each emitted type's body only references strictly smaller wrapper indices.
- Deep-clone every `TypeDef` through a consumer→wrapper remap so all depth-0 operands (including body-level outer aliases inside instance types) hit the wrapper's renumbered indexspace.
- Bubbled-up imports now follow the same remap via `type_walk.cloneExternDesc`, so descs other than `.instance` also renumber correctly.

## Refactor

The depth-aware walk/clone primitives that were previously file-private to `src/component/adapter/world_gc.zig` are extracted into a new shared module `src/component/type_walk.zig` and reused by both call sites. No behaviour change for the adapter splice path; `world_gc.zig` now just delegates ref-collection and operand-renumbering to `type_walk`.

## Verification

- `zig build test`: **355/355 pass** (was 353; +2 regression tests).
- New tests:
  - `composeBinaries: copies transitive type deps when bubbling up instance import` — synthesised consumer with a func dep referenced through an outer alias inside an instance import's body.
  - `composeBinaries: emits types in topological order` — same shape with consumer-side indices in reverse dep order; asserts the wrapper hoists the dep ahead of the dependent and renumbers the bubbled-up import accordingly.
- End-to-end against the issue's acceptance matrix with real `wasm-tools`-built fixtures (`wt-adder.wasm` × `wt-calc.wasm`): `wabt component compose -d wt-adder.wasm wt-calc.wasm` now emits a component that `wasm-tools validate` accepts.

## Out of scope

The matrix rows with a `wbt-calc` consumer (built by `wabt component new`) surface a separate pre-existing defect: `wabt component new` doesn't lift imported core funcs into component-level imports + canon-lower bridging, so the produced component is missing the import / alias / canon-lower / module-instantiation-with machinery. That error was masked previously by the type-section forward-ref bug fixed here. Will be filed as a separate issue.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>