### PR TITLE
adapter: hermetic end-to-end splice test on synthetic mock pair

### DIFF
--- a/src/component/adapter/adapter.zig
+++ b/src/component/adapter/adapter.zig
@@ -1653,3 +1653,53 @@ test "coreToCompValType: maps numeric wasm types to component analogues" {
     try testing.expectEqual(ctypes.ValType.f32, coreToCompValType(.f32));
     try testing.expectEqual(ctypes.ValType.f64, coreToCompValType(.f64));
 }
+
+// ── End-to-end synthetic splice ──────────────────────────────────────────
+
+const test_fixtures = @import("test_fixtures.zig");
+const loader = @import("../loader.zig");
+
+test "splice: end-to-end on synthetic mock adapter + embed" {
+    const a = testing.allocator;
+
+    const adapter_bytes = try test_fixtures.buildSyntheticAdapter(a);
+    defer a.free(adapter_bytes);
+    const embed_bytes = try test_fixtures.buildSyntheticEmbed(a);
+    defer a.free(embed_bytes);
+
+    const out = try splice(a, embed_bytes, adapter_bytes, "wasi_snapshot_preview1");
+    defer a.free(out);
+
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const comp = try loader.load(out, arena.allocator());
+
+    // The wrapping component lifts exactly one top-level export — the
+    // `wasi:cli/run@…` instance — regardless of what the adapter
+    // declared internally.
+    try testing.expectEqual(@as(usize, 1), comp.exports.len);
+    try testing.expect(std.mem.startsWith(u8, comp.exports[0].name, "wasi:cli/run@"));
+    try testing.expect(comp.exports[0].desc == .instance);
+
+    // Top-level imports surface every live WASI namespace post-GC.
+    // The fixture's adapter imports exactly one
+    // (`wasi:cli/stdout@0.1.0`); every other namespace declared by
+    // the encoded world should have been pruned because no canon-lower
+    // import in the GC'd adapter references it.
+    var saw_stdout = false;
+    for (comp.imports) |im| {
+        if (std.mem.eql(u8, im.name, test_fixtures.STDOUT_NAMESPACE)) {
+            saw_stdout = true;
+            try testing.expect(im.desc == .instance);
+        }
+    }
+    try testing.expect(saw_stdout);
+
+    // Inner core modules: shim + embed + adapter + fixup. The
+    // optional `__main_module__` fallback is only emitted when the
+    // adapter imports something from `__main_module__` that the embed
+    // does not export. Our synthetic embed exports `_start` (matching
+    // the adapter's only `__main_module__` import) so the fallback
+    // is omitted.
+    try testing.expectEqual(@as(usize, 4), comp.core_modules.len);
+}

--- a/src/component/adapter/test_fixtures.zig
+++ b/src/component/adapter/test_fixtures.zig
@@ -1,0 +1,398 @@
+//! Test-only synthesizers that produce a splice-shaped (adapter,
+//! embed) pair from scratch.
+//!
+//! The wabt adapter splicer (`adapter.zig::splice`) is exercised in
+//! three layers today:
+//!
+//!   1. Per-module unit tests (`decode.zig`, `core_imports.zig`,
+//!      `shim.zig`, `fixup.zig`, `types_import.zig`, `abi.zig`,
+//!      `gc.zig`, `world_gc.zig`).
+//!   2. Standalone helper tests in `adapter.zig`
+//!      (`stripComponentTypeSections`, `buildMainModuleFallback`,
+//!      `coreToCompValType`).
+//!   3. End-to-end via the wamr fixtures (`zig-hello`,
+//!      `zig-calculator-cmd`, `mixed-zig-rust-calc`) — out-of-tree.
+//!
+//! What's missing — and what this module enables — is an in-tree
+//! end-to-end assertion that `splice()` produces a structurally
+//! correct component on a hermetic synthesised input pair. A
+//! regression in the splicer's choreography that today only fails
+//! the wamr CI lane will then also fail `zig build test`.
+//!
+//! The synthesised pair is the smallest shape that exercises every
+//! phase of `splice()`:
+//!
+//!   * encoded-world AST GC (one live WASI namespace, `stdout`)
+//!   * adapter core-wasm GC (exactly one preview1 export survives)
+//!   * types-import hoist (top-level `wasi:cli/stdout@…` import)
+//!   * canon-lift of `wasi:cli/run@<ver>#run` to top-level
+//!   * shim + fixup choreography for at least one slot
+//!
+//! Constraints met by the current shape:
+//!
+//!   * The world's package MUST be `wasi:cli` because
+//!     `findRunInstanceExport` (adapter.zig:1084) hardcodes
+//!     `startsWith("wasi:cli/run")` to locate the lifted entry.
+//!   * Every WIT func uses primitive params/results so
+//!     `metadata_encode.encodeWorldFromSource` accepts the source
+//!     and `abi.classifyFunc` returns `.direct` (no canon-lower
+//!     memory/realloc options). Indirect-shim coverage exists
+//!     elsewhere; this fixture is intentionally simple.
+//!
+//! Synthesis style is hand-rolled byte streams (mirroring
+//! `core_imports.zig::buildMockAdapterCore`) — `Module.zig` /
+//! `binary/writer.zig` could express the same shape, but going
+//! through the public encoder for tests would couple this fixture
+//! to the encoder's quirks. Hand-rolling keeps the fixture
+//! self-contained.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const leb = @import("../../leb128.zig");
+const metadata_encode = @import("../wit/metadata_encode.zig");
+
+const ADAPTER_WIT =
+    \\package wasi:cli@0.1.0;
+    \\
+    \\interface stdout {
+    \\    flush: func() -> u32;
+    \\}
+    \\
+    \\interface run {
+    \\    run: func() -> u32;
+    \\}
+    \\
+    \\world command {
+    \\    import stdout;
+    \\    export run;
+    \\}
+;
+
+pub const ADAPTER_CT_SECTION_NAME = "component-type:wit-bindgen:0.0.0-mock:wasi:cli@0.1.0:command:encoded world";
+pub const EMBED_CT_SECTION_NAME = "component-type:embed-mock";
+
+pub const PREVIEW1_EXPORT = "fd_write";
+pub const RUN_EXPORT = "wasi:cli/run@0.1.0#run";
+pub const STDOUT_NAMESPACE = "wasi:cli/stdout@0.1.0";
+pub const STDOUT_FUNC = "flush";
+
+/// Build a synthetic preview1-shape adapter core wasm.
+///
+/// Imports:
+///   * `env.memory`                          (memory 0)
+///   * `__main_module__._start`              (func, () -> ())
+///   * `wasi:cli/stdout@0.1.0.flush`         (func, () -> i32 — canon-lower)
+///
+/// Exports:
+///   * `fd_write`                            (preview1 entry; () -> i32)
+///   * `wasi:cli/run@0.1.0#run`              (run entry; () -> i32)
+///   * `cabi_import_realloc`                 (canon-lower realloc helper)
+///
+/// Custom sections:
+///   * `component-type:…wasi:cli@0.1.0:command:encoded world` — payload
+///     is the `wasi:cli@0.1.0`/`world command` encoded by
+///     `metadata_encode.encodeWorldFromSource`.
+///
+/// The first and third defined func bodies are trivial `i32.const 0; end`;
+/// `run` (the middle body) calls the imported `stdout.flush` and
+/// returns its result, so the adapter's GC keeps the stdout import
+/// live and `live_namespaces` survives splice. Caller frees with
+/// the same allocator.
+pub fn buildSyntheticAdapter(allocator: Allocator) ![]u8 {
+    const ct = try metadata_encode.encodeWorldFromSource(allocator, ADAPTER_WIT, "command");
+    defer allocator.free(ct);
+
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+
+    try writeMagic(allocator, &out);
+
+    // Type section: 2 func types — both `() -> i32`, plus `() -> ()`
+    // for `_start`. Indices: 0 = () -> i32, 1 = () -> ().
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02); // count
+        // type 0: () -> i32
+        try b.appendSlice(allocator, &.{ 0x60, 0x00, 0x01, 0x7f });
+        // type 1: () -> ()
+        try b.appendSlice(allocator, &.{ 0x60, 0x00, 0x00 });
+        try writeSection(allocator, &out, 0x01, b.items);
+    }
+
+    // Import section: env.memory, __main_module__._start, wasi:cli/stdout.flush
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x03); // count
+        // env.memory: memory 0 (limits: min 0, no max)
+        try writeName(allocator, &b, "env");
+        try writeName(allocator, &b, "memory");
+        try b.append(allocator, 0x02); // import desc: memory
+        try b.append(allocator, 0x00); // limits flag: no max
+        try b.append(allocator, 0x00); // min 0
+        // __main_module__._start: func type 1
+        try writeName(allocator, &b, "__main_module__");
+        try writeName(allocator, &b, "_start");
+        try b.append(allocator, 0x00); // import desc: func
+        try b.append(allocator, 0x01); // typeidx 1 (() -> ())
+        // wasi:cli/stdout@0.1.0.flush: func type 0
+        try writeName(allocator, &b, STDOUT_NAMESPACE);
+        try writeName(allocator, &b, STDOUT_FUNC);
+        try b.append(allocator, 0x00); // import desc: func
+        try b.append(allocator, 0x00); // typeidx 0 (() -> i32)
+        try writeSection(allocator, &out, 0x02, b.items);
+    }
+
+    // Function section: 3 defined funcs (fd_write, run, cabi_import_realloc), all type 0
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x03); // count
+        try b.appendSlice(allocator, &.{ 0x00, 0x00, 0x00 }); // typeidx 0 ×3
+        try writeSection(allocator, &out, 0x03, b.items);
+    }
+
+    // Export section: fd_write (func 2), run-shape (func 3), cabi_import_realloc (func 4).
+    // Defined func indices start after imports: imported funcs are
+    // _start (idx 0) and stdout.flush (idx 1).
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x03); // count
+        try writeName(allocator, &b, PREVIEW1_EXPORT);
+        try b.appendSlice(allocator, &.{ 0x00, 0x02 }); // func, idx 2
+        try writeName(allocator, &b, RUN_EXPORT);
+        try b.appendSlice(allocator, &.{ 0x00, 0x03 }); // func, idx 3
+        try writeName(allocator, &b, "cabi_import_realloc");
+        try b.appendSlice(allocator, &.{ 0x00, 0x04 }); // func, idx 4
+        try writeSection(allocator, &out, 0x07, b.items);
+    }
+
+    // Code section: 3 bodies. fd_write and cabi_import_realloc are
+    // trivial `i32.const 0; end`; `run` calls `stdout.flush` (imported
+    // func idx 1) and returns its result, so the adapter's GC keeps
+    // the stdout import live and `live_namespaces` survives splice.
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x03); // count
+        // body 0 (fd_write): i32.const 0; end
+        try b.append(allocator, 0x04);
+        try b.append(allocator, 0x00);
+        try b.appendSlice(allocator, &.{ 0x41, 0x00, 0x0b });
+        // body 1 (run): call $1 (stdout.flush); end
+        try b.append(allocator, 0x04);
+        try b.append(allocator, 0x00);
+        try b.appendSlice(allocator, &.{ 0x10, 0x01, 0x0b });
+        // body 2 (cabi_import_realloc): i32.const 0; end
+        try b.append(allocator, 0x04);
+        try b.append(allocator, 0x00);
+        try b.appendSlice(allocator, &.{ 0x41, 0x00, 0x0b });
+        try writeSection(allocator, &out, 0x0a, b.items);
+    }
+
+    // Custom section with the encoded-world payload — last so it
+    // doesn't perturb the standard section ordering.
+    try appendCustomSection(allocator, &out, ADAPTER_CT_SECTION_NAME, ct);
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// Build a synthetic preview1 embed core wasm.
+///
+/// Imports:
+///   * `wasi_snapshot_preview1.fd_write`     (func, () -> i32)
+///
+/// Exports:
+///   * `_start`                              (func, () -> ())
+///   * `memory`                              (memory 0)
+///
+/// The defined `_start` body is `i32.const 0; drop; end` — keeps the
+/// validator happy without producing a meaningful side effect.
+/// Caller frees with the same allocator.
+pub fn buildSyntheticEmbed(allocator: Allocator) ![]u8 {
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+
+    try writeMagic(allocator, &out);
+
+    // Type section: 2 types — () -> i32 (the import sig) and () -> () (_start).
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02);
+        try b.appendSlice(allocator, &.{ 0x60, 0x00, 0x01, 0x7f });
+        try b.appendSlice(allocator, &.{ 0x60, 0x00, 0x00 });
+        try writeSection(allocator, &out, 0x01, b.items);
+    }
+
+    // Import section: wasi_snapshot_preview1.fd_write (func type 0)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try writeName(allocator, &b, "wasi_snapshot_preview1");
+        try writeName(allocator, &b, PREVIEW1_EXPORT);
+        try b.append(allocator, 0x00); // func
+        try b.append(allocator, 0x00); // typeidx 0
+        try writeSection(allocator, &out, 0x02, b.items);
+    }
+
+    // Function section: 1 defined func (_start, type 1)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x01); // typeidx 1
+        try writeSection(allocator, &out, 0x03, b.items);
+    }
+
+    // Memory section: 1 memory (limits: min 0, no max)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x00); // limits flag
+        try b.append(allocator, 0x00); // min
+        try writeSection(allocator, &out, 0x05, b.items);
+    }
+
+    // Export section: _start (func 1), memory (memory 0)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02);
+        try writeName(allocator, &b, "_start");
+        try b.appendSlice(allocator, &.{ 0x00, 0x01 }); // func, defined idx 1 (import is 0)
+        try writeName(allocator, &b, "memory");
+        try b.appendSlice(allocator, &.{ 0x02, 0x00 }); // memory, idx 0
+        try writeSection(allocator, &out, 0x07, b.items);
+    }
+
+    // Code section: _start body is `i32.const 0; drop; end`
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x05);                            // body size
+        try b.append(allocator, 0x00);                            // 0 locals
+        try b.appendSlice(allocator, &.{ 0x41, 0x00, 0x1a, 0x0b }); // i32.const 0; drop; end
+        try writeSection(allocator, &out, 0x0a, b.items);
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+// ── byte-stream helpers ──────────────────────────────────────────────────
+
+fn writeMagic(allocator: Allocator, out: *std.ArrayListUnmanaged(u8)) !void {
+    try out.appendSlice(allocator, &.{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 });
+}
+
+fn writeSection(
+    allocator: Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    id: u8,
+    body: []const u8,
+) !void {
+    try out.append(allocator, id);
+    var len_buf: [leb.max_u32_bytes]u8 = undefined;
+    const n = leb.writeU32Leb128(&len_buf, @intCast(body.len));
+    try out.appendSlice(allocator, len_buf[0..n]);
+    try out.appendSlice(allocator, body);
+}
+
+fn writeName(allocator: Allocator, out: *std.ArrayListUnmanaged(u8), name: []const u8) !void {
+    var len_buf: [leb.max_u32_bytes]u8 = undefined;
+    const n = leb.writeU32Leb128(&len_buf, @intCast(name.len));
+    try out.appendSlice(allocator, len_buf[0..n]);
+    try out.appendSlice(allocator, name);
+}
+
+fn appendCustomSection(
+    allocator: Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    name: []const u8,
+    payload: []const u8,
+) !void {
+    var name_leb_buf: [leb.max_u32_bytes]u8 = undefined;
+    const name_leb_n = leb.writeU32Leb128(&name_leb_buf, @intCast(name.len));
+    const body_len = name_leb_n + name.len + payload.len;
+
+    try out.append(allocator, 0x00); // custom section id
+    var size_leb_buf: [leb.max_u32_bytes]u8 = undefined;
+    const size_leb_n = leb.writeU32Leb128(&size_leb_buf, @intCast(body_len));
+    try out.appendSlice(allocator, size_leb_buf[0..size_leb_n]);
+    try out.appendSlice(allocator, name_leb_buf[0..name_leb_n]);
+    try out.appendSlice(allocator, name);
+    try out.appendSlice(allocator, payload);
+}
+
+// ── self-tests ───────────────────────────────────────────────────────────
+
+const testing = std.testing;
+const reader = @import("../../binary/reader.zig");
+const decode = @import("decode.zig");
+const core_imports = @import("core_imports.zig");
+
+test "buildSyntheticAdapter: parses through reader and exposes expected imports/exports" {
+    const adapter_bytes = try buildSyntheticAdapter(testing.allocator);
+    defer testing.allocator.free(adapter_bytes);
+
+    var owned = try core_imports.extract(testing.allocator, adapter_bytes);
+    defer owned.deinit();
+
+    // Exports the preview1 entry, the run-shape entry, and realloc.
+    try testing.expect(owned.interface.findExport(PREVIEW1_EXPORT) != null);
+    try testing.expect(owned.interface.findExport(RUN_EXPORT) != null);
+    try testing.expect(owned.interface.findExport("cabi_import_realloc") != null);
+
+    // Imports include the canon-lower'd stdout.flush.
+    var saw_stdout = false;
+    for (owned.interface.imports) |im| {
+        if (std.mem.eql(u8, im.module_name, STDOUT_NAMESPACE) and
+            std.mem.eql(u8, im.field_name, STDOUT_FUNC))
+        {
+            saw_stdout = true;
+        }
+    }
+    try testing.expect(saw_stdout);
+}
+
+test "buildSyntheticAdapter: encoded-world section round-trips through decode" {
+    const adapter_bytes = try buildSyntheticAdapter(testing.allocator);
+    defer testing.allocator.free(adapter_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const w = try decode.parseFromAdapterCore(arena.allocator(), adapter_bytes);
+
+    // World imports `stdout`, exports `run`.
+    try testing.expectEqual(@as(usize, 1), w.imports.len);
+    try testing.expectEqualStrings(STDOUT_NAMESPACE, w.imports[0].name);
+    try testing.expectEqual(@as(usize, 1), w.exports.len);
+    try testing.expect(std.mem.startsWith(u8, w.exports[0].name, "wasi:cli/run@"));
+}
+
+test "buildSyntheticEmbed: parses through reader and matches preview1 contract" {
+    const embed_bytes = try buildSyntheticEmbed(testing.allocator);
+    defer testing.allocator.free(embed_bytes);
+
+    var owned = try core_imports.extract(testing.allocator, embed_bytes);
+    defer owned.deinit();
+
+    // Embed imports preview1.fd_write so `splice` will GC the adapter
+    // down to that one preview1 export.
+    var saw_p1 = false;
+    for (owned.interface.imports) |im| {
+        if (std.mem.eql(u8, im.module_name, "wasi_snapshot_preview1") and
+            std.mem.eql(u8, im.field_name, PREVIEW1_EXPORT))
+        {
+            saw_p1 = true;
+        }
+    }
+    try testing.expect(saw_p1);
+    try testing.expect(owned.interface.findExport("_start") != null);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -85,6 +85,7 @@ test {
     _ = @import("component/adapter/adapter.zig");
     _ = @import("component/adapter/gc.zig");
     _ = @import("component/adapter/world_gc.zig");
+    _ = @import("component/adapter/test_fixtures.zig");
     _ = @import("integration_tests.zig");
     _ = @import("spec_tests.zig");
 }


### PR DESCRIPTION
Resolves #115.

Adds an in-tree end-to-end assertion that `adapter.splice()` produces a structurally correct component on a hermetic synthesised (adapter, embed) pair.

### Why

Today the splice pipeline (~12 phases) is covered by:

1. Per-module unit tests (`decode.zig`, `core_imports.zig`, `shim.zig`, `fixup.zig`, `types_import.zig`, `abi.zig`, `gc.zig`, `world_gc.zig`).
2. Standalone helper tests in `adapter.zig` (`stripComponentTypeSections`, `buildMainModuleFallback`, `coreToCompValType`).
3. End-to-end via the wamr fixtures (`zig-hello`, `zig-calculator-cmd`, `mixed-zig-rust-calc`) — out-of-tree.

A regression in the splicer's choreography that today only fails the wamr CI lane will now also fail `zig build test`.

### What

New test-only module `src/component/adapter/test_fixtures.zig` synthesises the smallest splice-shaped pair:

- **Adapter core wasm** with a `wasi:cli/run@0.1.0#run` export (matched by `findRunInstanceExport`'s hardcoded `wasi:cli/run` prefix), one live WASI namespace `wasi:cli/stdout@0.1.0` (whose `flush` import is actually called by the run body so adapter GC keeps it), a preview1 `fd_write` export, and a `cabi_import_realloc` export. The encoded-world component-type custom section is produced by `metadata_encode.encodeWorldFromSource`.
- **Embed core wasm** importing `wasi_snapshot_preview1.fd_write` and exporting `_start` + `memory`.

The new test in `adapter.zig` drives `splice()` end-to-end and asserts:

- exactly one top-level `wasi:cli/run@*` instance export
- `wasi:cli/stdout@0.1.0` survives as a top-level instance import
- 4 inner core modules (shim + embed + adapter + fixup; no main-module fallback because the embed exports `_start`)

Structural shape, not byte-for-byte output. Fully hermetic (no shell-outs, no on-PATH binaries).

### Verification

`zig build test`: 359 → 363 (3 fixture self-tests + 1 splice E2E).