### PR TITLE
adapter: support multiple --adapt flags via spliceMany (#114)

### DIFF
--- a/src/component/adapter/adapter.zig
+++ b/src/component/adapter/adapter.zig
@@ -72,10 +72,40 @@ pub const SpliceError = error{
     InvalidBody,
     MissingRequiredExport,
     InvalidIndex,
+    // Multi-adapter errors.
+    NoAdapters,
+    MissingRunAdapter,
+    AmbiguousRunAdapter,
+    AdapterNamespaceCollision,
+    SecondaryAdapterUnsupported,
 } || writer.EncodeError;
 
-/// Splice a preview1 embed and an adapter into a wrapping component.
+/// One preview1-style adapter to splice in. `name` is the core
+/// import module name the embed uses to refer to this adapter (e.g.
+/// `wasi_snapshot_preview1`); `bytes` is the adapter core wasm.
+pub const Adapter = struct {
+    name: []const u8,
+    bytes: []const u8,
+};
+
+/// Splice an embed against one or more preview1-style adapters into
+/// a wrapping component. Mirrors the `wasm-tools component new
+/// --adapt name1=… --adapt name2=…` surface; adapters are
+/// instantiated in declaration order. Exactly one adapter must
+/// declare a `wasi:cli/run` export.
+///
 /// Caller frees the returned slice via `gpa`.
+pub fn spliceMany(gpa: Allocator, embed_bytes: []const u8, adapters: []const Adapter) ![]u8 {
+    if (adapters.len == 0) return error.NoAdapters;
+    if (adapters.len == 1) {
+        return splice(gpa, embed_bytes, adapters[0].bytes, adapters[0].name);
+    }
+    return spliceN(gpa, embed_bytes, adapters);
+}
+
+/// Single-adapter splice. Preserved as a thin wrapper around the
+/// canonical implementation for backward compatibility and for the
+/// (common) N=1 path's byte-equivalence.
 pub fn splice(
     gpa: Allocator,
     embed_bytes: []const u8,
@@ -172,6 +202,213 @@ pub fn splice(
         .preview1_slots = preview1_slots,
         .buckets = buckets,
     });
+}
+
+/// Multi-adapter splice (N >= 2). Routes the primary (the unique
+/// adapter declaring `wasi:cli/run@…`) through the existing single-
+/// adapter pipeline and layers each secondary's bare host-shim
+/// exports through the shim/fixup table alongside the primary's
+/// preview1 slots.
+///
+/// Restrictions for #114 — see plan.md and #116:
+///   * exactly one adapter declares `wasi:cli/run@…` (the primary);
+///   * each secondary imports only `env.<x>` (no WASI namespaces, no
+///     `__main_module__.<x>`).
+fn spliceN(gpa: Allocator, embed_bytes: []const u8, adapters: []const Adapter) ![]u8 {
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // ── Identify primary + validate secondaries ────────────────────────────
+    const primary_idx = try findPrimaryAdapter(a, adapters);
+    const primary = adapters[primary_idx];
+
+    // Pre-validate every secondary against the bare-shim contract
+    // before doing any GC / decode work; surfaces a clean error
+    // before any expensive operations.
+    for (adapters, 0..) |ad, i| {
+        if (i == primary_idx) continue;
+        try validateBareShimSecondary(a, ad);
+    }
+
+    // ── Phase A.0: GC the primary core wasm ────────────────────────────────
+    const primary_required = try computeRequiredAdapterExports(a, embed_bytes, primary.bytes, primary.name);
+    const primary_gc_initial = try gc.run(gpa, primary.bytes, primary_required);
+    defer gpa.free(primary_gc_initial);
+
+    // ── Phase A.1: GC the primary's encoded-world AST ──────────────────────
+    const pristine_world = try decode.parseFromAdapterCore(a, primary_gc_initial);
+    var pristine_iface = try core_imports.extract(gpa, primary_gc_initial);
+    defer pristine_iface.deinit();
+
+    const live_namespaces = try collectLiveNamespaces(a, pristine_iface.interface);
+    const live_methods_by_namespace = try collectLiveMethodsByNamespace(a, pristine_iface.interface);
+    const live_export_names = try collectLiveExportNames(a, pristine_world);
+
+    const gc_world_result = try world_gc.gcWorld(a, pristine_world, live_namespaces, live_methods_by_namespace, live_export_names);
+    const primary_gc_bytes = try world_gc.replaceEncodedWorldSection(a, primary_gc_initial, gc_world_result.payload_bytes);
+
+    // ── Phase A: decode + classify (primary only) ──────────────────────────
+    const world = gc_world_result.world;
+
+    var primary_owned = try core_imports.extract(gpa, primary_gc_bytes);
+    defer primary_owned.deinit();
+    var embed_owned = try core_imports.extract(gpa, embed_bytes);
+    defer embed_owned.deinit();
+
+    const hoisted = try types_import.hoist(a, world);
+
+    const embed_world: ?decode.AdapterWorld = blk: {
+        const ct = decode.extractEncodedWorld(embed_bytes) catch break :blk null;
+        const payload = ct orelse break :blk null;
+        break :blk decode.parse(a, payload) catch null;
+    };
+
+    const preview1_slots = try collectPreview1Slots(a, embed_owned.interface, primary.name);
+    const buckets = try classifyAdapterImports(a, primary_owned.interface, world, hoisted);
+    const indirect_slots = try collectIndirectSlots(a, buckets);
+
+    // ── Phase A.2: GC each secondary + collect its slots ───────────────────
+    // Secondary required exports are the bare names the embed imports
+    // under `<sec.name>.<x>`. (No `<iface>#…` exports — that's the
+    // primary's role.)
+    const SecondaryOwned = struct {
+        owned: core_imports.Owned,
+        gc_bytes: []const u8,
+        slots: []const Preview1Slot,
+    };
+    const secondaries_owned = try a.alloc(SecondaryOwned, adapters.len - 1);
+    var sec_i: usize = 0;
+    var total_secondary_slots: u32 = 0;
+    for (adapters, 0..) |ad, i| {
+        if (i == primary_idx) continue;
+        const sec_required = try computeBareSecondaryRequiredExports(a, embed_bytes, ad.name);
+        const sec_gc = try gc.run(gpa, ad.bytes, sec_required);
+        // Note: we deliberately don't `defer gpa.free(sec_gc)` here
+        // because the bytes need to live until `assemble` consumes
+        // them. We free them all at the end of this function.
+        const sec_owned = try core_imports.extract(gpa, sec_gc);
+        const slots = try collectPreview1Slots(a, embed_owned.interface, ad.name);
+        secondaries_owned[sec_i] = .{ .owned = sec_owned, .gc_bytes = sec_gc, .slots = slots };
+        total_secondary_slots += @intCast(slots.len);
+        sec_i += 1;
+    }
+    defer for (secondaries_owned) |*s| {
+        gpa.free(s.gc_bytes);
+        s.owned.deinit();
+    };
+
+    // ── Build SecondaryInputs (with slot_offsets) ──────────────────────────
+    const secondary_inputs = try a.alloc(SecondaryInputs, secondaries_owned.len);
+    {
+        var slot_cursor: u32 = @intCast(preview1_slots.len);
+        var k: usize = 0;
+        for (adapters, 0..) |ad, i| {
+            if (i == primary_idx) continue;
+            secondary_inputs[k] = .{
+                .name = ad.name,
+                .bytes = secondaries_owned[k].gc_bytes,
+                .iface = secondaries_owned[k].owned.interface,
+                .slots = secondaries_owned[k].slots,
+                .slot_offset = slot_cursor,
+            };
+            slot_cursor += @intCast(secondaries_owned[k].slots.len);
+            k += 1;
+        }
+    }
+
+    // ── Phase B: build shim + fixup with the COMBINED slot table ───────────
+    var all_slots = try a.alloc(shim.Slot, preview1_slots.len + total_secondary_slots + indirect_slots.len);
+    for (preview1_slots, 0..) |p1, i| {
+        all_slots[i] = .{ .params = p1.params, .results = p1.results };
+    }
+    {
+        var cursor: usize = preview1_slots.len;
+        for (secondary_inputs) |sin| {
+            for (sin.slots) |s| {
+                all_slots[cursor] = .{ .params = s.params, .results = s.results };
+                cursor += 1;
+            }
+        }
+    }
+    @memcpy(all_slots[preview1_slots.len + total_secondary_slots ..], indirect_slots);
+
+    const shim_bytes = try shim.build(a, all_slots);
+    const fixup_bytes = try fixup.build(a, all_slots);
+
+    // ── Phase C: assemble + encode ─────────────────────────────────────────
+    return try assemble(.{
+        .gpa = gpa,
+        .arena = a,
+        .embed_bytes = try stripComponentTypeSections(a, embed_bytes),
+        .adapter_bytes = primary_gc_bytes,
+        .shim_bytes = shim_bytes,
+        .fixup_bytes = fixup_bytes,
+        .adapter_name = primary.name,
+        .world = world,
+        .embed_world = embed_world,
+        .hoisted = hoisted,
+        .embed_iface = embed_owned.interface,
+        .adapter_iface = primary_owned.interface,
+        .preview1_slots = preview1_slots,
+        .buckets = buckets,
+        .secondaries = secondary_inputs,
+    });
+}
+
+/// Find the primary adapter — the unique one declaring an export
+/// whose name contains `#` (the canonical splice run-export shape,
+/// e.g. `wasi:cli/run@0.1.0#run`). Reject if none or > 1.
+fn findPrimaryAdapter(arena: Allocator, adapters: []const Adapter) SpliceError!usize {
+    var primary_idx: ?usize = null;
+    for (adapters, 0..) |ad, i| {
+        const owned = try core_imports.extract(arena, ad.bytes);
+        const has_run = blk: {
+            for (owned.interface.exports) |ex| {
+                if (std.mem.indexOfScalar(u8, ex.name, '#') != null) break :blk true;
+            }
+            break :blk false;
+        };
+        if (has_run) {
+            if (primary_idx != null) return error.AmbiguousRunAdapter;
+            primary_idx = i;
+        }
+    }
+    return primary_idx orelse error.MissingRunAdapter;
+}
+
+/// Validate that an adapter is a bare-shim secondary: every core
+/// import has `module_name == "env"`. Reject anything else with
+/// `error.SecondaryAdapterUnsupported` — `__main_module__`,
+/// `wasi:*`, and any other host module imports require the
+/// reactor/library plumbing tracked in #116.
+fn validateBareShimSecondary(arena: Allocator, ad: Adapter) SpliceError!void {
+    const owned = try core_imports.extract(arena, ad.bytes);
+    for (owned.interface.imports) |im| {
+        if (!std.mem.eql(u8, im.module_name, "env")) {
+            return error.SecondaryAdapterUnsupported;
+        }
+    }
+}
+
+/// Compute the required core-wasm exports a secondary must keep
+/// alive after GC: every name the embed imports under
+/// `<secondary.name>.<x>`. Secondaries don't have `<iface>#…`
+/// exports.
+fn computeBareSecondaryRequiredExports(
+    arena: Allocator,
+    embed_bytes: []const u8,
+    secondary_name: []const u8,
+) SpliceError![]const []const u8 {
+    const owned_embed = try core_imports.extract(arena, embed_bytes);
+    var out = std.ArrayListUnmanaged([]const u8).empty;
+    for (owned_embed.interface.imports) |im| {
+        if (im.kind != .func) continue;
+        if (!std.mem.eql(u8, im.module_name, secondary_name)) continue;
+        const name = try arena.dupe(u8, im.field_name);
+        try out.append(arena, name);
+    }
+    return out.toOwnedSlice(arena);
 }
 
 /// Collect the set of unique component-instance import names from the
@@ -511,6 +748,29 @@ const Inputs = struct {
     adapter_iface: core_imports.CoreInterface,
     preview1_slots: []const Preview1Slot,
     buckets: []NamespaceBucket,
+    /// Optional secondary "bare-shim" adapters layered alongside the
+    /// primary. Each secondary contributes additional slots to the
+    /// shim/fixup table (located at
+    /// `[primary preview1 | secondary[0] | … | secondary[N-1] | primary indirect]`)
+    /// and one extra core module + core instance in the assembled
+    /// component. Empty for the single-adapter case.
+    secondaries: []const SecondaryInputs = &.{},
+};
+
+/// Per-secondary data needed by `assemble`. Built by `spliceN`.
+pub const SecondaryInputs = struct {
+    name: []const u8,
+    /// Already-GC'd core wasm bytes.
+    bytes: []const u8,
+    iface: core_imports.CoreInterface,
+    /// Preview1-style export slots — names this secondary exports
+    /// that the embed imports under `<name>.<x>`. Treated identically
+    /// to primary preview1 slots downstream.
+    slots: []const Preview1Slot,
+    /// Position in the combined shim/fixup slot table where this
+    /// secondary's slots begin. Used by `assemble` when emitting
+    /// shim alias names (`{slot_total}`) for each export.
+    slot_offset: u32,
 };
 
 /// `Builder` accumulates per-section arrays + section_order entries
@@ -726,11 +986,17 @@ fn assemble(in: Inputs) ![]u8 {
         .results = .{ .unnamed = .{ .type_idx = run_result_type_idx } },
     } });
 
-    // ── Step 3: core modules (main=0, adapter=1, shim=2, fixup=3) ─────
+    // ── Step 3: core modules (main=0, adapter=1, shim=2, fixup=3, …) ──
     const main_module_idx = try b.addCoreModule(.{ .data = in.embed_bytes });
     const adapter_module_idx = try b.addCoreModule(.{ .data = in.adapter_bytes });
     const shim_module_idx = try b.addCoreModule(.{ .data = in.shim_bytes });
     const fixup_module_idx = try b.addCoreModule(.{ .data = in.fixup_bytes });
+
+    // One core module per secondary adapter, in declaration order.
+    const secondary_module_idxs = try a.alloc(u32, in.secondaries.len);
+    for (in.secondaries, secondary_module_idxs) |sec, *out| {
+        out.* = try b.addCoreModule(.{ .data = sec.bytes });
+    }
 
     // ── Step 4: shim instance ────────────────────────────────────────
     const shim_inst = try b.addCoreInstance(.{ .instantiate = .{
@@ -738,7 +1004,7 @@ fn assemble(in: Inputs) ![]u8 {
         .args = &.{},
     } });
 
-    // ── Step 5: preview1 inline-export instance for embed ────────────
+    // ── Step 5: preview1 inline-export instance for embed (primary) ──
     var preview1_inline = std.ArrayListUnmanaged(ctypes.CoreInlineExport).empty;
     for (in.preview1_slots, 0..) |p1, i| {
         const stub_name = try std.fmt.allocPrint(a, "{d}", .{i});
@@ -754,6 +1020,31 @@ fn assemble(in: Inputs) ![]u8 {
     }
     const preview1_inst = try b.addCoreInstance(.{ .exports = try preview1_inline.toOwnedSlice(a) });
 
+    // ── Step 5a: per-secondary inline-export instance for embed ──────
+    // Each secondary contributes a slice of slots in the combined
+    // shim/fixup table at `[sec.slot_offset, sec.slot_offset + sec.slots.len)`.
+    // We build one inline-export instance per secondary that aliases
+    // those shim slots under the secondary's bare export names; the
+    // embed will be instantiated with each as `<sec.name> = …`.
+    const secondary_preview1_insts = try a.alloc(u32, in.secondaries.len);
+    for (in.secondaries, secondary_preview1_insts) |sec, *out| {
+        var inline_exps = std.ArrayListUnmanaged(ctypes.CoreInlineExport).empty;
+        for (sec.slots, 0..) |s, j| {
+            const slot_total: u32 = sec.slot_offset + @as(u32, @intCast(j));
+            const stub_name = try std.fmt.allocPrint(a, "{d}", .{slot_total});
+            const f_idx = try b.addAlias(.{ .instance_export = .{
+                .sort = .{ .core = .func },
+                .instance_idx = shim_inst,
+                .name = stub_name,
+            } });
+            try inline_exps.append(a, .{
+                .name = s.name,
+                .sort_idx = .{ .sort = .func, .idx = f_idx },
+            });
+        }
+        out.* = try b.addCoreInstance(.{ .exports = try inline_exps.toOwnedSlice(a) });
+    }
+
     // ── Step 5b: lift non-WASI embed imports to component imports ─────
     // The embed may import core funcs from namespaces beyond the
     // WASI adapter (e.g. `docs:adder/add@0.1.0` for the calculator
@@ -763,11 +1054,17 @@ fn assemble(in: Inputs) ![]u8 {
     // inline-export instance the embed can consume directly.
     const embed_extra_args = try buildEmbedExtraImports(&b, a, in);
 
-    // ── Step 6: instantiate main with wasi_snapshot_preview1 + extras ─
-    const main_args = try a.alloc(ctypes.CoreInstantiateArg, 1 + embed_extra_args.len);
+    // ── Step 6: instantiate main with primary + secondaries + extras ─
+    const main_args = try a.alloc(
+        ctypes.CoreInstantiateArg,
+        1 + in.secondaries.len + embed_extra_args.len,
+    );
     main_args[0] = .{ .name = in.adapter_name, .instance_idx = preview1_inst };
+    for (in.secondaries, secondary_preview1_insts, 0..) |sec, sec_inst, i| {
+        main_args[1 + i] = .{ .name = sec.name, .instance_idx = sec_inst };
+    }
     for (embed_extra_args, 0..) |ea, i| {
-        main_args[1 + i] = .{ .name = ea.name, .instance_idx = ea.inst_idx };
+        main_args[1 + in.secondaries.len + i] = .{ .name = ea.name, .instance_idx = ea.inst_idx };
     }
     const main_inst = try b.addCoreInstance(.{ .instantiate = .{
         .module_idx = main_module_idx,
@@ -840,6 +1137,28 @@ fn assemble(in: Inputs) ![]u8 {
         break :blk try b.addCoreInstance(.{ .exports = try exps.toOwnedSlice(a) });
     };
 
+    // ── Step 7b: instantiate each secondary core module ──────────────
+    // Secondaries are bare-shim host modules: they import only
+    // `env.<x>` (validated upstream by `validateBareShimSecondary`).
+    // Instantiate each with `env = env_inst` so the embed's
+    // `<sec.name>.<x>` imports — which we already routed through the
+    // shim — can resolve to real funcs once fixup runs.
+    const secondary_insts = try a.alloc(u32, in.secondaries.len);
+    for (secondary_module_idxs, secondary_insts) |mod_idx, *out| {
+        const sec_args = try a.alloc(ctypes.CoreInstantiateArg, 1);
+        sec_args[0] = .{ .name = "env", .instance_idx = env_inst };
+        out.* = try b.addCoreInstance(.{ .instantiate = .{
+            .module_idx = mod_idx,
+            .args = sec_args,
+        } });
+    }
+
+    const total_secondary_slots: u32 = blk: {
+        var sum: u32 = 0;
+        for (in.secondaries) |s| sum += @intCast(s.slots.len);
+        break :blk sum;
+    };
+
     // ── Step 8: per-namespace bundles ────────────────────────────────
     var bucket_inst_idx = try a.alloc(u32, in.buckets.len);
     for (in.buckets, 0..) |*bucket, bi| {
@@ -876,7 +1195,7 @@ fn assemble(in: Inputs) ![]u8 {
         }
 
         for (bucket.indirect_funcs) |idf| {
-            const slot_total: u32 = @as(u32, @intCast(in.preview1_slots.len)) + idf.slot_idx;
+            const slot_total: u32 = @as(u32, @intCast(in.preview1_slots.len)) + total_secondary_slots + idf.slot_idx;
             const slot_name = try std.fmt.allocPrint(a, "{d}", .{slot_total});
             const cf_idx = try b.addAlias(.{ .instance_export = .{
                 .sort = .{ .core = .func },
@@ -953,8 +1272,30 @@ fn assemble(in: Inputs) ![]u8 {
         });
     }
 
-    // Funcs P..P+I-1: canon lower(memory, [realloc], [string-encoding])
-    // of each indirect adapter wasi import.
+    // Funcs P..P+ΣS-1: per-secondary bare exports. Each secondary's
+    // `slots` list maps positionally onto its already-instantiated
+    // core instance's exports.
+    for (in.secondaries, secondary_insts) |sec, sec_inst| {
+        for (sec.slots, 0..) |s, j| {
+            if (sec.iface.findExport(s.name) == null) {
+                return error.AdapterMissingPreview1Export;
+            }
+            const f_idx = try b.addAlias(.{ .instance_export = .{
+                .sort = .{ .core = .func },
+                .instance_idx = sec_inst,
+                .name = s.name,
+            } });
+            const slot_total: u32 = sec.slot_offset + @as(u32, @intCast(j));
+            const slot_name = try std.fmt.allocPrint(a, "{d}", .{slot_total});
+            try fixup_inline.append(a, .{
+                .name = slot_name,
+                .sort_idx = .{ .sort = .func, .idx = f_idx },
+            });
+        }
+    }
+
+    // Funcs P+ΣS..P+ΣS+I-1: canon lower(memory, [realloc],
+    // [string-encoding]) of each indirect adapter wasi import.
     {
         var indirect_idx: u32 = 0;
         for (in.buckets) |bk| {
@@ -969,7 +1310,7 @@ fn assemble(in: Inputs) ![]u8 {
                     .func_idx = f_idx,
                     .opts = opts,
                 } });
-                const slot_total: u32 = @as(u32, @intCast(in.preview1_slots.len)) + indirect_idx;
+                const slot_total: u32 = @as(u32, @intCast(in.preview1_slots.len)) + total_secondary_slots + indirect_idx;
                 const slot_name = try std.fmt.allocPrint(a, "{d}", .{slot_total});
                 try fixup_inline.append(a, .{
                     .name = slot_name,
@@ -1702,4 +2043,116 @@ test "splice: end-to-end on synthetic mock adapter + embed" {
     // the adapter's only `__main_module__` import) so the fallback
     // is omitted.
     try testing.expectEqual(@as(usize, 4), comp.core_modules.len);
+}
+
+test "spliceMany: end-to-end on synthetic primary + bare secondary adapter pair" {
+    const a = testing.allocator;
+
+    const primary_bytes = try test_fixtures.buildSyntheticAdapter(a);
+    defer a.free(primary_bytes);
+    const secondary_bytes = try test_fixtures.buildBareSecondaryAdapter(a);
+    defer a.free(secondary_bytes);
+    const embed_bytes = try test_fixtures.buildSyntheticEmbedWithSecondary(a);
+    defer a.free(embed_bytes);
+
+    const adapters = [_]Adapter{
+        .{ .name = "wasi_snapshot_preview1", .bytes = primary_bytes },
+        .{ .name = test_fixtures.SECONDARY_NAME, .bytes = secondary_bytes },
+    };
+    const out = try spliceMany(a, embed_bytes, &adapters);
+    defer a.free(out);
+
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const comp = try loader.load(out, arena.allocator());
+
+    // Exactly one top-level export — the lifted `wasi:cli/run@…`
+    // instance from the primary. Secondaries don't contribute
+    // top-level exports.
+    try testing.expectEqual(@as(usize, 1), comp.exports.len);
+    try testing.expect(std.mem.startsWith(u8, comp.exports[0].name, "wasi:cli/run@"));
+
+    // Top-level imports include the primary's live WASI namespace.
+    // Secondaries don't surface a top-level import — they're
+    // wired through inline-export instances under their adapter
+    // name, which the embed binds to internally.
+    var saw_stdout = false;
+    for (comp.imports) |im| {
+        if (std.mem.eql(u8, im.name, test_fixtures.STDOUT_NAMESPACE)) {
+            saw_stdout = true;
+        }
+    }
+    try testing.expect(saw_stdout);
+
+    // Inner core modules: shim + embed + primary + fixup + secondary.
+    // The synthetic embed exports `_start`, matching the primary's
+    // `__main_module__._start` import, so the fallback core module
+    // is not emitted. The secondary's only import is `env.memory`,
+    // which the primary supplies via its env_inst.
+    try testing.expectEqual(@as(usize, 5), comp.core_modules.len);
+}
+
+test "spliceMany: rejects zero adapters declaring wasi:cli/run" {
+    const a = testing.allocator;
+
+    const secondary_bytes = try test_fixtures.buildBareSecondaryAdapter(a);
+    defer a.free(secondary_bytes);
+    const embed_bytes = try test_fixtures.buildSyntheticEmbedWithSecondary(a);
+    defer a.free(embed_bytes);
+
+    const adapters = [_]Adapter{
+        .{ .name = test_fixtures.SECONDARY_NAME, .bytes = secondary_bytes },
+        .{ .name = "another", .bytes = secondary_bytes },
+    };
+    try testing.expectError(error.MissingRunAdapter, spliceMany(a, embed_bytes, &adapters));
+}
+
+test "spliceMany: rejects two adapters declaring wasi:cli/run" {
+    const a = testing.allocator;
+
+    const primary_bytes = try test_fixtures.buildSyntheticAdapter(a);
+    defer a.free(primary_bytes);
+    const embed_bytes = try test_fixtures.buildSyntheticEmbedWithSecondary(a);
+    defer a.free(embed_bytes);
+
+    const adapters = [_]Adapter{
+        .{ .name = "wasi_snapshot_preview1", .bytes = primary_bytes },
+        .{ .name = "second_run", .bytes = primary_bytes },
+    };
+    try testing.expectError(error.AmbiguousRunAdapter, spliceMany(a, embed_bytes, &adapters));
+}
+
+test "spliceMany: rejects a secondary adapter with non-env imports" {
+    const a = testing.allocator;
+
+    const primary_bytes = try test_fixtures.buildSyntheticAdapter(a);
+    defer a.free(primary_bytes);
+    const embed_bytes = try test_fixtures.buildSyntheticEmbedWithSecondary(a);
+    defer a.free(embed_bytes);
+
+    // Hand-roll a tiny "bad secondary": no `#` export (so it
+    // doesn't claim to be primary) but imports `__main_module__.x`
+    // — bare-shim contract requires every import to be `env.<x>`.
+    const bad = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // Type section: () -> ()
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        // Import section: __main_module__.x — func type 0
+        0x02, 0x15, 0x01,
+        15, '_', '_', 'm', 'a', 'i', 'n', '_', 'm', 'o', 'd', 'u', 'l', 'e', '_', '_',
+        1,  'x',
+        0x00, 0x00,
+        // Function section: 1 defined func, type 0
+        0x03, 0x02, 0x01, 0x00,
+        // Export section: bare-name "thing" -> func 1
+        0x07, 0x09, 0x01, 5, 't', 'h', 'i', 'n', 'g', 0x00, 0x01,
+        // Code section: empty body (just end)
+        0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b,
+    };
+
+    const adapters = [_]Adapter{
+        .{ .name = "wasi_snapshot_preview1", .bytes = primary_bytes },
+        .{ .name = test_fixtures.SECONDARY_NAME, .bytes = &bad },
+    };
+    try testing.expectError(error.SecondaryAdapterUnsupported, spliceMany(a, embed_bytes, &adapters));
 }

--- a/src/component/adapter/test_fixtures.zig
+++ b/src/component/adapter/test_fixtures.zig
@@ -285,6 +285,179 @@ pub fn buildSyntheticEmbed(allocator: Allocator) ![]u8 {
     return out.toOwnedSlice(allocator);
 }
 
+pub const SECONDARY_NAME = "mock_host";
+pub const SECONDARY_EXPORT = "do_thing";
+
+/// Build a synthetic bare-shim secondary adapter core wasm.
+///
+/// Imports:
+///   * `env.memory`                          (memory 0)
+///
+/// Exports:
+///   * `do_thing`                            (func, () -> i32)
+///
+/// No `wasi:cli/run` export, no encoded-world custom section, and
+/// no `__main_module__` or WASI namespace imports — exactly the
+/// "bare host-shim" shape `spliceN` accepts as a secondary adapter
+/// in #114. Caller frees with the same allocator.
+pub fn buildBareSecondaryAdapter(allocator: Allocator) ![]u8 {
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+
+    try writeMagic(allocator, &out);
+
+    // Type section: 1 type — () -> i32
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.appendSlice(allocator, &.{ 0x60, 0x00, 0x01, 0x7f });
+        try writeSection(allocator, &out, 0x01, b.items);
+    }
+
+    // Import section: env.memory (memory 0)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try writeName(allocator, &b, "env");
+        try writeName(allocator, &b, "memory");
+        try b.append(allocator, 0x02); // memory
+        try b.append(allocator, 0x00); // limits flag
+        try b.append(allocator, 0x00); // min
+        try writeSection(allocator, &out, 0x02, b.items);
+    }
+
+    // Function section: 1 defined func, type 0
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x00); // typeidx 0
+        try writeSection(allocator, &out, 0x03, b.items);
+    }
+
+    // Export section: do_thing (func 0)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try writeName(allocator, &b, SECONDARY_EXPORT);
+        try b.appendSlice(allocator, &.{ 0x00, 0x00 }); // func, idx 0
+        try writeSection(allocator, &out, 0x07, b.items);
+    }
+
+    // Code section: do_thing body is `i32.const 0; end`
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x04); // body size
+        try b.append(allocator, 0x00); // 0 locals
+        try b.appendSlice(allocator, &.{ 0x41, 0x00, 0x0b }); // i32.const 0; end
+        try writeSection(allocator, &out, 0x0a, b.items);
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// Build a synthetic embed core wasm that imports BOTH preview1
+/// and a bare-shim secondary's host function — exercises
+/// `spliceMany` on N=2.
+///
+/// Imports:
+///   * `wasi_snapshot_preview1.fd_write`     (func, () -> i32)
+///   * `mock_host.do_thing`                  (func, () -> i32)
+///
+/// Exports:
+///   * `_start`                              (func, () -> ())
+///   * `memory`                              (memory 0)
+///
+/// `_start` calls both imports (drops their results) so the
+/// adapter GC keeps both imports live across `spliceMany`.
+pub fn buildSyntheticEmbedWithSecondary(allocator: Allocator) ![]u8 {
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+
+    try writeMagic(allocator, &out);
+
+    // Type section: () -> i32 and () -> ()
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02);
+        try b.appendSlice(allocator, &.{ 0x60, 0x00, 0x01, 0x7f });
+        try b.appendSlice(allocator, &.{ 0x60, 0x00, 0x00 });
+        try writeSection(allocator, &out, 0x01, b.items);
+    }
+
+    // Import section: preview1.fd_write, mock_host.do_thing
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02);
+        // wasi_snapshot_preview1.fd_write — type 0
+        try writeName(allocator, &b, "wasi_snapshot_preview1");
+        try writeName(allocator, &b, PREVIEW1_EXPORT);
+        try b.append(allocator, 0x00);
+        try b.append(allocator, 0x00);
+        // mock_host.do_thing — type 0
+        try writeName(allocator, &b, SECONDARY_NAME);
+        try writeName(allocator, &b, SECONDARY_EXPORT);
+        try b.append(allocator, 0x00);
+        try b.append(allocator, 0x00);
+        try writeSection(allocator, &out, 0x02, b.items);
+    }
+
+    // Function section: 1 defined func (_start, type 1)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x01);
+        try writeSection(allocator, &out, 0x03, b.items);
+    }
+
+    // Memory section: 1 memory
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x00);
+        try b.append(allocator, 0x00);
+        try writeSection(allocator, &out, 0x05, b.items);
+    }
+
+    // Export section: _start (func 2 — imports take 0,1), memory (0)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02);
+        try writeName(allocator, &b, "_start");
+        try b.appendSlice(allocator, &.{ 0x00, 0x02 });
+        try writeName(allocator, &b, "memory");
+        try b.appendSlice(allocator, &.{ 0x02, 0x00 });
+        try writeSection(allocator, &out, 0x07, b.items);
+    }
+
+    // Code section: _start = call $0; drop; call $1; drop; end
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x08); // body size: 1 (locals) + 7 (code) = 8
+        try b.append(allocator, 0x00); // 0 locals
+        try b.appendSlice(allocator, &.{
+            0x10, 0x00, 0x1a, // call $0; drop
+            0x10, 0x01, 0x1a, // call $1; drop
+            0x0b, // end
+        });
+        try writeSection(allocator, &out, 0x0a, b.items);
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
 // ── byte-stream helpers ──────────────────────────────────────────────────
 
 fn writeMagic(allocator: Allocator, out: *std.ArrayListUnmanaged(u8)) !void {
@@ -394,5 +567,44 @@ test "buildSyntheticEmbed: parses through reader and matches preview1 contract" 
         }
     }
     try testing.expect(saw_p1);
+    try testing.expect(owned.interface.findExport("_start") != null);
+}
+
+test "buildBareSecondaryAdapter: parses and exposes do_thing export with env.memory only" {
+    const sec_bytes = try buildBareSecondaryAdapter(testing.allocator);
+    defer testing.allocator.free(sec_bytes);
+
+    var owned = try core_imports.extract(testing.allocator, sec_bytes);
+    defer owned.deinit();
+
+    // do_thing must be exported.
+    try testing.expect(owned.interface.findExport(SECONDARY_EXPORT) != null);
+    // No `wasi:cli/run` export — secondary is bare.
+    for (owned.interface.exports) |ex| {
+        try testing.expect(std.mem.indexOfScalar(u8, ex.name, '#') == null);
+    }
+    // Every import is `env.<x>` — bare-shim contract.
+    for (owned.interface.imports) |im| {
+        try testing.expectEqualStrings("env", im.module_name);
+    }
+}
+
+test "buildSyntheticEmbedWithSecondary: imports both preview1 and mock_host" {
+    const embed_bytes = try buildSyntheticEmbedWithSecondary(testing.allocator);
+    defer testing.allocator.free(embed_bytes);
+
+    var owned = try core_imports.extract(testing.allocator, embed_bytes);
+    defer owned.deinit();
+
+    var saw_p1 = false;
+    var saw_sec = false;
+    for (owned.interface.imports) |im| {
+        if (std.mem.eql(u8, im.module_name, "wasi_snapshot_preview1") and
+            std.mem.eql(u8, im.field_name, PREVIEW1_EXPORT)) saw_p1 = true;
+        if (std.mem.eql(u8, im.module_name, SECONDARY_NAME) and
+            std.mem.eql(u8, im.field_name, SECONDARY_EXPORT)) saw_sec = true;
+    }
+    try testing.expect(saw_p1);
+    try testing.expect(saw_sec);
     try testing.expect(owned.interface.findExport("_start") != null);
 }

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -51,8 +51,10 @@ pub const usage =
     \\Options:
     \\  -o, --output <file>     Output file (default: <input>.component.wasm)
     \\      --skip-validation   Skip post-encoding component validation
-    \\      --adapt <n>=<file>  Splice in a wasi-preview1 adapter (e.g.
-    \\                          --adapt wasi_snapshot_preview1=path/to/adapter.wasm)
+    \\      --adapt <n>=<file>  Splice in an adapter (may repeat). The first
+    \\                          adapter declaring `wasi:cli/run` is the
+    \\                          primary; remaining adapters must import only
+    \\                          `env.<x>` (bare host-shim restriction).
     \\  -h, --help              Show this help
     \\
 ;
@@ -63,8 +65,8 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var output_file: ?[]const u8 = null;
     var skip_validation: bool = false;
     var input_path: ?[]const u8 = null;
-    var adapt_name: ?[]const u8 = null;
-    var adapt_file: ?[]const u8 = null;
+    var adapts = std.ArrayListUnmanaged(struct { name: []const u8, file: []const u8 }).empty;
+    defer adapts.deinit(alloc);
 
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
@@ -92,12 +94,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
                 std.debug.print("error: --adapt expects <name>=<file>, got '{s}'\n", .{spec});
                 std.process.exit(1);
             };
-            if (adapt_name != null) {
-                std.debug.print("error: only one --adapt is supported\n", .{});
-                std.process.exit(1);
-            }
-            adapt_name = spec[0..eq];
-            adapt_file = spec[eq + 1 ..];
+            try adapts.append(alloc, .{ .name = spec[0..eq], .file = spec[eq + 1 ..] });
         } else if (std.mem.startsWith(u8, arg, "-")) {
             std.debug.print("error: unknown option '{s}'. Use `wabt help component`.\n", .{arg});
             std.process.exit(1);
@@ -135,20 +132,27 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     };
 
     const out_bytes = blk: {
-        if (adapt_name) |aname| {
-            const adp_path = adapt_file.?;
-            const adp_bytes = std.Io.Dir.cwd().readFileAlloc(
-                init.io,
-                adp_path,
-                alloc,
-                std.Io.Limit.limited(wabt.max_input_file_size),
-            ) catch |err| {
-                std.debug.print("error: cannot read adapter '{s}': {any}\n", .{ adp_path, err });
-                std.process.exit(1);
-            };
-            defer alloc.free(adp_bytes);
-            break :blk wabt.component.adapter.adapter.splice(alloc, core_bytes, adp_bytes, aname) catch |err| {
-                std.debug.print("error: splicing adapter '{s}': {s}\n", .{ aname, @errorName(err) });
+        if (adapts.items.len > 0) {
+            const Adapter = wabt.component.adapter.adapter.Adapter;
+            const adapter_list = alloc.alloc(Adapter, adapts.items.len) catch unreachable;
+            defer {
+                for (adapter_list) |ad| alloc.free(ad.bytes);
+                alloc.free(adapter_list);
+            }
+            for (adapts.items, 0..) |spec, idx| {
+                const adp_bytes = std.Io.Dir.cwd().readFileAlloc(
+                    init.io,
+                    spec.file,
+                    alloc,
+                    std.Io.Limit.limited(wabt.max_input_file_size),
+                ) catch |err| {
+                    std.debug.print("error: cannot read adapter '{s}': {any}\n", .{ spec.file, err });
+                    std.process.exit(1);
+                };
+                adapter_list[idx] = .{ .name = spec.name, .bytes = adp_bytes };
+            }
+            break :blk wabt.component.adapter.adapter.spliceMany(alloc, core_bytes, adapter_list) catch |err| {
+                std.debug.print("error: splicing adapters: {s}\n", .{@errorName(err)});
                 std.process.exit(1);
             };
         }


### PR DESCRIPTION
Closes #114.

Lifts the singleton `--adapt` cap in `wabt component new`. Introduces `pub const Adapter` and `pub fn spliceMany(gpa, embed_bytes, adapters)`. N=1 calls remain byte-identical (existing 363 N=1 tests unchanged). N≥2 routes through `spliceN`, which:

- Identifies the unique adapter declaring an `<iface>#<name>`-shaped export (`wasi:cli/run@…`) as the **primary**. Rejects 0 primaries with `error.MissingRunAdapter` and ≥2 with `error.AmbiguousRunAdapter`.
- Validates each non-primary as a **bare host-shim**: only `env.<x>` core imports allowed; bare-name exports pulled into the embed via `<adapter_name>.<x>` namespacing. Anything else (WASI namespaces or `__main_module__` imports) yields `error.SecondaryAdapterUnsupported`, pointing at #116 where reactor/library shapes (and proper world-merge) will live.
- Threads each secondary's slots through the existing shim/fixup table layout: `[primary preview1 | secondary[0..N-1] preview1 | primary indirect]`. Secondary instantiation is parameterised on the primary's `env_inst`, avoiding a separate fallback core module when the embed already exports the `__main_module__` symbols (as in the synthetic regression).

CLI layer in `component_new.zig` replaces the singleton `--adapt` fields with an `ArrayListUnmanaged` and forwards to `spliceMany`; usage text updated to document repeat-able `--adapt` + the bare-shim restriction.

### Tests added

- `buildBareSecondaryAdapter` / `buildSyntheticEmbedWithSecondary` fixtures (`env.memory` + `do_thing` bare export + matching embed importing both preview1 + `mock_host`).
- `spliceMany: end-to-end on synthetic primary + bare secondary adapter pair` — asserts 5 inner core modules, lifted run export, surviving `wasi:cli/stdout` import.
- 3 error-path tests covering `MissingRunAdapter`, `AmbiguousRunAdapter`, `SecondaryAdapterUnsupported`.

**Totals:** 363 → 369 tests passing.

### Out of scope (deferred to #116)

- Reactor / library adapter shapes.
- Secondary adapters with their own WASI namespace imports (proper world-merge).
- Adapters importing from earlier adapters (library stacking).