### PR TITLE
Support reactor-shape adapter splicing

### DIFF
--- a/src/component/adapter/adapter.zig
+++ b/src/component/adapter/adapter.zig
@@ -41,6 +41,8 @@ const fixup = @import("fixup.zig");
 const abi = @import("abi.zig");
 const gc = @import("gc.zig");
 const world_gc = @import("world_gc.zig");
+const metadata_decode = @import("../wit/metadata_decode.zig");
+const leb = @import("../../leb128.zig");
 
 pub const SpliceError = error{
     OutOfMemory,
@@ -74,10 +76,13 @@ pub const SpliceError = error{
     InvalidIndex,
     // Multi-adapter errors.
     NoAdapters,
-    MissingRunAdapter,
-    AmbiguousRunAdapter,
+    MissingPrimaryAdapter,
+    AmbiguousPrimaryAdapter,
     AdapterNamespaceCollision,
     SecondaryAdapterUnsupported,
+    // Reactor-shape errors.
+    MissingEmbedMetadata,
+    InvalidComponentType,
 } || writer.EncodeError;
 
 /// One preview1-style adapter to splice in. `name` is the core
@@ -171,6 +176,15 @@ pub fn splice(
         break :blk decode.parse(a, payload) catch null;
     };
 
+    // Reactor mode needs per-export-interface FuncTypes for canon-lift,
+    // which `metadata_decode.decode` produces. Decode once here while
+    // the embed's component-type section is still attached.
+    const embed_metadata: ?metadata_decode.DecodedWorld = blk: {
+        const ct = decode.extractEncodedWorld(embed_bytes) catch break :blk null;
+        const payload = ct orelse break :blk null;
+        break :blk metadata_decode.decode(a, payload) catch null;
+    };
+
     const preview1_slots = try collectPreview1Slots(a, embed_owned.interface, adapter_name);
     const buckets = try classifyAdapterImports(a, adapter_owned.interface, world, hoisted);
     const indirect_slots = try collectIndirectSlots(a, buckets);
@@ -201,6 +215,8 @@ pub fn splice(
         .adapter_iface = adapter_owned.interface,
         .preview1_slots = preview1_slots,
         .buckets = buckets,
+        .shape = detectShape(adapter_owned.interface),
+        .embed_metadata = embed_metadata,
     });
 }
 
@@ -262,6 +278,12 @@ fn spliceN(gpa: Allocator, embed_bytes: []const u8, adapters: []const Adapter) !
         const ct = decode.extractEncodedWorld(embed_bytes) catch break :blk null;
         const payload = ct orelse break :blk null;
         break :blk decode.parse(a, payload) catch null;
+    };
+
+    const embed_metadata: ?metadata_decode.DecodedWorld = blk: {
+        const ct = decode.extractEncodedWorld(embed_bytes) catch break :blk null;
+        const payload = ct orelse break :blk null;
+        break :blk metadata_decode.decode(a, payload) catch null;
     };
 
     const preview1_slots = try collectPreview1Slots(a, embed_owned.interface, primary.name);
@@ -352,29 +374,44 @@ fn spliceN(gpa: Allocator, embed_bytes: []const u8, adapters: []const Adapter) !
         .adapter_iface = primary_owned.interface,
         .preview1_slots = preview1_slots,
         .buckets = buckets,
+        .shape = detectShape(primary_owned.interface),
         .secondaries = secondary_inputs,
+        .embed_metadata = embed_metadata,
     });
 }
 
-/// Find the primary adapter — the unique one declaring an export
-/// whose name contains `#` (the canonical splice run-export shape,
-/// e.g. `wasi:cli/run@0.1.0#run`). Reject if none or > 1.
+/// Find the primary adapter — the unique one with at least one
+/// non-`env` core import. Bare-shim secondaries import only
+/// `env.<x>` (validated separately by `validateBareShimSecondary`),
+/// so the primary is the **complement** of the secondary partition.
+///
+/// This signal works for both shapes:
+///   * **command** primary — imports `__main_module__.<x>` and a
+///     WASI namespace (e.g. `wasi:cli/stdout@…`);
+///   * **reactor** primary — imports a WASI namespace but no
+///     `__main_module__`.
+///
+/// Returns:
+///   * `MissingPrimaryAdapter` if every adapter is `env`-only;
+///   * `AmbiguousPrimaryAdapter` if more than one has non-`env`
+///     imports.
 fn findPrimaryAdapter(arena: Allocator, adapters: []const Adapter) SpliceError!usize {
     var primary_idx: ?usize = null;
     for (adapters, 0..) |ad, i| {
         const owned = try core_imports.extract(arena, ad.bytes);
-        const has_run = blk: {
-            for (owned.interface.exports) |ex| {
-                if (std.mem.indexOfScalar(u8, ex.name, '#') != null) break :blk true;
+        var has_non_env = false;
+        for (owned.interface.imports) |im| {
+            if (!std.mem.eql(u8, im.module_name, "env")) {
+                has_non_env = true;
+                break;
             }
-            break :blk false;
-        };
-        if (has_run) {
-            if (primary_idx != null) return error.AmbiguousRunAdapter;
+        }
+        if (has_non_env) {
+            if (primary_idx != null) return error.AmbiguousPrimaryAdapter;
             primary_idx = i;
         }
     }
-    return primary_idx orelse error.MissingRunAdapter;
+    return primary_idx orelse error.MissingPrimaryAdapter;
 }
 
 /// Validate that an adapter is a bare-shim secondary: every core
@@ -748,6 +785,19 @@ const Inputs = struct {
     adapter_iface: core_imports.CoreInterface,
     preview1_slots: []const Preview1Slot,
     buckets: []NamespaceBucket,
+    /// Adapter shape — drives whether `assemble()` emits the
+    /// command-style `__main_module__` plumbing + run sub-component
+    /// (`.command`) or the reactor per-export-interface lift loop
+    /// (`.reactor`). Defaults to `.command` for backward compatibility
+    /// with tests that don't set it explicitly.
+    shape: Shape = .command,
+    /// Pre-decoded embed metadata for the reactor branch. Populated
+    /// by `splice`/`spliceN` from the embed's `component-type:*`
+    /// custom section before that section is stripped from
+    /// `embed_bytes`. Required only when `shape == .reactor`; the
+    /// reactor branch reads it to recover per-export-interface
+    /// FuncTypes for canon-lift.
+    embed_metadata: ?metadata_decode.DecodedWorld = null,
     /// Optional secondary "bare-shim" adapters layered alongside the
     /// primary. Each secondary contributes additional slots to the
     /// shim/fixup table (located at
@@ -756,6 +806,31 @@ const Inputs = struct {
     /// component. Empty for the single-adapter case.
     secondaries: []const SecondaryInputs = &.{},
 };
+
+/// Adapter shape, mirroring the wit-component reference encoder's
+/// `command` / `reactor` distinction. `library` is deferred to #127.
+///
+///   * `.command`  — the adapter declares `wasi:cli/run@…` and
+///     drives the embed via `__main_module__._start`. The
+///     wrapping component lifts a single `wasi:cli/run` export.
+///   * `.reactor`  — the adapter has no `<iface>#name` exports and
+///     no `__main_module__.<x>` imports. The wrapping component
+///     lifts each `<iface>#<func>` export the **embed** declares
+///     into one top-level instance per export interface.
+pub const Shape = enum { command, reactor };
+
+/// Classify an adapter's core wasm shape from its exports. The
+/// presence of any `<iface>#<name>`-shaped export means the
+/// adapter implements a `wasi:cli/run`-style lifted entry —
+/// command shape. Their absence means the adapter is a passive
+/// preview1→component bridge whose entry points live in the
+/// embed — reactor shape.
+pub fn detectShape(iface: core_imports.CoreInterface) Shape {
+    for (iface.exports) |ex| {
+        if (std.mem.indexOfScalar(u8, ex.name, '#') != null) return .command;
+    }
+    return .reactor;
+}
 
 /// Per-secondary data needed by `assemble`. Built by `spliceN`.
 pub const SecondaryInputs = struct {
@@ -1090,7 +1165,14 @@ fn assemble(in: Inputs) ![]u8 {
     // single `_start` symbol. If your embed uses a different name,
     // expose all exports we can recognize; the adapter ignores
     // anything it doesn't import.
-    const main_module_inst = blk: {
+    //
+    // Reactor adapters have no `__main_module__.<x>` imports — they
+    // wrap long-lived embeds whose entry points come from the
+    // wrapping component's lifted exports, not `_start`. Skip the
+    // entire `__main_module__` plumbing in that case; assert the
+    // adapter has no such imports to surface a clean error if our
+    // shape detector misclassified.
+    const main_module_inst: ?u32 = if (in.shape == .command) blk: {
         // Mirror the wasm-tools reference: alias every __main_module__
         // import the adapter requires. If the embed has a matching
         // export, alias the embed. Otherwise alias the fallback module.
@@ -1135,6 +1217,13 @@ fn assemble(in: Inputs) ![]u8 {
             });
         }
         break :blk try b.addCoreInstance(.{ .exports = try exps.toOwnedSlice(a) });
+    } else blk: {
+        for (in.adapter_iface.imports) |im| {
+            if (std.mem.eql(u8, im.module_name, "__main_module__")) {
+                return error.UnsupportedAdapterShape;
+            }
+        }
+        break :blk null;
     };
 
     // ── Step 7b: instantiate each secondary core module ──────────────
@@ -1214,7 +1303,9 @@ fn assemble(in: Inputs) ![]u8 {
     // ── Step 9: instantiate adapter ──────────────────────────────────
     var adapter_args = std.ArrayListUnmanaged(ctypes.CoreInstantiateArg).empty;
     try adapter_args.append(a, .{ .name = "env", .instance_idx = env_inst });
-    try adapter_args.append(a, .{ .name = "__main_module__", .instance_idx = main_module_inst });
+    if (main_module_inst) |mmi| {
+        try adapter_args.append(a, .{ .name = "__main_module__", .instance_idx = mmi });
+    }
     for (in.buckets, 0..) |bk, bi| {
         try adapter_args.append(a, .{ .name = bk.name, .instance_idx = bucket_inst_idx[bi] });
     }
@@ -1331,42 +1422,115 @@ fn assemble(in: Inputs) ![]u8 {
         .args = fixup_args,
     } });
 
-    // ── Step 11: canon lift of wasi:cli/run@<ver>#run ────────────────
-    const run_ie = try findRunInstanceExport(in.hoisted, a);
-    if (in.adapter_iface.findExport(run_ie.core_export_name) == null) {
-        return error.AdapterMissingRunExport;
+    // ── Step 11: top-level lift + export ─────────────────────────────
+    //
+    // Command shape: canon-lift the adapter's `wasi:cli/run@<ver>#run`
+    // export, wrap it in an inline sub-component re-exporting it as
+    // `run`, and emit a single top-level `(export "wasi:cli/run@…"
+    // instance N)`.
+    //
+    // Reactor shape: lift each `<iface>#<func>` export the embed
+    // declares from the embed core instance, bundle per-interface
+    // into a component instance, emit one `(export "<iface>"
+    // instance N)` per interface.
+    if (in.shape == .command) {
+        const run_ie = try findRunInstanceExport(in.hoisted, a);
+        if (in.adapter_iface.findExport(run_ie.core_export_name) == null) {
+            return error.AdapterMissingRunExport;
+        }
+        const run_core_func_idx = try b.addAlias(.{ .instance_export = .{
+            .sort = .{ .core = .func },
+            .instance_idx = adapter_inst,
+            .name = run_ie.core_export_name,
+        } });
+        const lifted_run_func_idx = try b.addCanon(.{ .lift = .{
+            .core_func_idx = run_core_func_idx,
+            .type_idx = run_func_type_idx,
+            .opts = &.{},
+        } });
+
+        const sub = try buildRunSubComponent(a);
+        const sub_idx = try b.addNestedComponent(sub);
+
+        const sub_args = try a.alloc(ctypes.InstantiateArg, 1);
+        sub_args[0] = .{
+            .name = "import-func-run",
+            .sort_idx = .{ .sort = .func, .idx = lifted_run_func_idx },
+        };
+        const wrap_inst_idx = try b.addInstance(.{ .instantiate = .{
+            .component_idx = sub_idx,
+            .args = sub_args,
+        } });
+
+        try b.addExport(.{
+            .name = run_ie.qualified_name,
+            .desc = .{ .instance = run_ie.body_type_idx },
+            .sort_idx = .{ .sort = .instance, .idx = wrap_inst_idx },
+        });
+    } else {
+        // Reactor needs the embed's `component-type:*` custom section
+        // for the export interface signatures — without it we can't
+        // produce a typed top-level export. The section is stripped
+        // from `in.embed_bytes` before assemble runs, so callers
+        // pre-decode and supply via `in.embed_metadata`.
+        const decoded = in.embed_metadata orelse return error.MissingEmbedMetadata;
+
+        // Ensure there's at least one export — a reactor with no
+        // exports is degenerate (would produce a wrapping component
+        // with no top-level export, equivalent to a library shape
+        // tracked in #127).
+        var any_export = false;
+        for (decoded.externs) |ext| if (ext.is_export) {
+            any_export = true;
+            break;
+        };
+        if (!any_export) return error.UnsupportedAdapterShape;
+
+        for (decoded.externs) |ext| {
+            if (!ext.is_export) continue;
+
+            // Per-func: alias `<iface>#<func>` from the embed core
+            // instance, build the component func type, canon-lift,
+            // append to the per-interface inline-export bundle.
+            var inline_exports = std.ArrayListUnmanaged(ctypes.InlineExport).empty;
+            for (ext.funcs) |fn_ref| {
+                const core_export_name = try std.fmt.allocPrint(a, "{s}#{s}", .{ ext.qualified_name, fn_ref.name });
+                if (in.embed_iface.findExport(core_export_name) == null) {
+                    return error.EmbedMissingRequiredExport;
+                }
+                const core_func_idx = try b.addAlias(.{ .instance_export = .{
+                    .sort = .{ .core = .func },
+                    .instance_idx = main_inst,
+                    .name = core_export_name,
+                } });
+                const ftype_idx = try b.addType(.{ .func = fn_ref.sig });
+                const lifted_idx = try b.addCanon(.{ .lift = .{
+                    .core_func_idx = core_func_idx,
+                    .type_idx = ftype_idx,
+                    .opts = &.{},
+                } });
+                try inline_exports.append(a, .{
+                    .name = fn_ref.name,
+                    .sort_idx = .{ .sort = .func, .idx = lifted_idx },
+                });
+            }
+            const iface_inst_idx = try b.addInstance(.{ .exports = try inline_exports.toOwnedSlice(a) });
+
+            // The wrapping component's `(export …)` is emitted in
+            // un-ascribed form (`desc = .instance = 0`) so the
+            // loader re-derives the instance type from the
+            // sort_idx-pointed instance — matches the
+            // `component_new.zig::buildComponent` (no-adapter) path
+            // and round-trips through `loader.load`. A proper
+            // instance-type ascription falls out of #127's
+            // world-merge work.
+            try b.addExport(.{
+                .name = ext.qualified_name,
+                .desc = .{ .instance = 0 },
+                .sort_idx = .{ .sort = .instance, .idx = iface_inst_idx },
+            });
+        }
     }
-    const run_core_func_idx = try b.addAlias(.{ .instance_export = .{
-        .sort = .{ .core = .func },
-        .instance_idx = adapter_inst,
-        .name = run_ie.core_export_name,
-    } });
-    const lifted_run_func_idx = try b.addCanon(.{ .lift = .{
-        .core_func_idx = run_core_func_idx,
-        .type_idx = run_func_type_idx,
-        .opts = &.{},
-    } });
-
-    // ── Step 12: inline sub-component wrapping `run` ────────────────
-    const sub = try buildRunSubComponent(a);
-    const sub_idx = try b.addNestedComponent(sub);
-
-    const sub_args = try a.alloc(ctypes.InstantiateArg, 1);
-    sub_args[0] = .{
-        .name = "import-func-run",
-        .sort_idx = .{ .sort = .func, .idx = lifted_run_func_idx },
-    };
-    const wrap_inst_idx = try b.addInstance(.{ .instantiate = .{
-        .component_idx = sub_idx,
-        .args = sub_args,
-    } });
-
-    // ── Step 13: top-level export ────────────────────────────────────
-    try b.addExport(.{
-        .name = run_ie.qualified_name,
-        .desc = .{ .instance = run_ie.body_type_idx },
-        .sort_idx = .{ .sort = .instance, .idx = wrap_inst_idx },
-    });
 
     // ── Encode ───────────────────────────────────────────────────────
     const comp = ctypes.Component{
@@ -2092,7 +2256,177 @@ test "spliceMany: end-to-end on synthetic primary + bare secondary adapter pair"
     try testing.expectEqual(@as(usize, 5), comp.core_modules.len);
 }
 
-test "spliceMany: rejects zero adapters declaring wasi:cli/run" {
+test "splice: end-to-end on synthetic reactor adapter + reactor embed" {
+    const a = testing.allocator;
+
+    const adapter_bytes = try test_fixtures.buildSyntheticReactorAdapter(a);
+    defer a.free(adapter_bytes);
+    const embed_bytes = try test_fixtures.buildSyntheticReactorEmbed(a);
+    defer a.free(embed_bytes);
+
+    const out = try splice(a, embed_bytes, adapter_bytes, "wasi_snapshot_preview1");
+    defer a.free(out);
+
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const comp = try loader.load(out, arena.allocator());
+
+    // Reactor: one top-level export per embed export interface.
+    // Our synthetic embed exports the single `docs:counter/api@…`
+    // interface, so exactly one instance export and NO
+    // `wasi:cli/run@…` (this is the visible reactor signature).
+    try testing.expectEqual(@as(usize, 1), comp.exports.len);
+    try testing.expectEqualStrings(test_fixtures.REACTOR_API_NAMESPACE, comp.exports[0].name);
+    try testing.expect(comp.exports[0].desc == .instance);
+    for (comp.exports) |ex| {
+        try testing.expect(!std.mem.startsWith(u8, ex.name, "wasi:cli/run@"));
+    }
+
+    // Top-level imports surface live WASI namespaces post-GC. The
+    // reactor adapter imports exactly one (`wasi:cli/stdout@…`).
+    var saw_stdout = false;
+    for (comp.imports) |im| {
+        if (std.mem.eql(u8, im.name, test_fixtures.STDOUT_NAMESPACE)) {
+            saw_stdout = true;
+            try testing.expect(im.desc == .instance);
+        }
+    }
+    try testing.expect(saw_stdout);
+
+    // Inner core modules: shim + embed + adapter + fixup. NO
+    // `__main_module__` fallback module — the reactor adapter has
+    // zero `__main_module__.<x>` imports, so Step 7's fallback
+    // path is skipped entirely.
+    try testing.expectEqual(@as(usize, 4), comp.core_modules.len);
+}
+
+test "spliceMany: end-to-end on reactor primary + bare secondary adapter pair" {
+    const a = testing.allocator;
+
+    const primary_bytes = try test_fixtures.buildSyntheticReactorAdapter(a);
+    defer a.free(primary_bytes);
+    const secondary_bytes = try test_fixtures.buildBareSecondaryAdapter(a);
+    defer a.free(secondary_bytes);
+    const embed_bytes = try test_fixtures.buildSyntheticReactorEmbedWithSecondary(a);
+    defer a.free(embed_bytes);
+
+    const adapters = [_]Adapter{
+        .{ .name = "wasi_snapshot_preview1", .bytes = primary_bytes },
+        .{ .name = test_fixtures.SECONDARY_NAME, .bytes = secondary_bytes },
+    };
+    const out = try spliceMany(a, embed_bytes, &adapters);
+    defer a.free(out);
+
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const comp = try loader.load(out, arena.allocator());
+
+    // Reactor primary + secondary: exactly one top-level export
+    // (the embed's single export interface) — no `wasi:cli/run@…`.
+    try testing.expectEqual(@as(usize, 1), comp.exports.len);
+    try testing.expectEqualStrings(test_fixtures.REACTOR_API_NAMESPACE, comp.exports[0].name);
+
+    // Inner core modules: shim + embed + primary + fixup + secondary.
+    try testing.expectEqual(@as(usize, 5), comp.core_modules.len);
+}
+
+test "splice: rejects a reactor-shaped adapter that imports __main_module__" {
+    const a = testing.allocator;
+
+    // Hand-roll a "fake reactor" adapter: no `<iface>#name` exports
+    // (so `detectShape` classifies it `.reactor`) but it imports
+    // `__main_module__._start` — illegal for a reactor. The
+    // assemble() Step 7 reactor branch must catch this and surface
+    // `error.UnsupportedAdapterShape`.
+    //
+    // The fixture is otherwise structurally valid: env.memory +
+    // wasi:cli/stdout.flush imports keep the GC happy, fd_write +
+    // cabi_import_realloc satisfy the embed's preview1 import.
+    var ad = std.ArrayListUnmanaged(u8).empty;
+    defer ad.deinit(a);
+    try ad.appendSlice(a, &.{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 });
+
+    // Type section: () -> i32, () -> ()
+    try ad.appendSlice(a, &.{ 0x01, 0x08, 0x02, 0x60, 0x00, 0x01, 0x7f, 0x60, 0x00, 0x00 });
+
+    // Import section: env.memory, __main_module__._start, wasi:cli/stdout.flush
+    {
+        var imp = std.ArrayListUnmanaged(u8).empty;
+        defer imp.deinit(a);
+        try imp.append(a, 0x03);
+        // env.memory
+        try imp.appendSlice(a, &.{ 3, 'e', 'n', 'v', 6, 'm', 'e', 'm', 'o', 'r', 'y', 0x02, 0x00, 0x00 });
+        // __main_module__._start (typeidx 1)
+        try imp.appendSlice(a, &.{ 15, '_', '_', 'm', 'a', 'i', 'n', '_', 'm', 'o', 'd', 'u', 'l', 'e', '_', '_', 6, '_', 's', 't', 'a', 'r', 't', 0x00, 0x01 });
+        // wasi:cli/stdout@0.1.0.flush (typeidx 0)
+        const ns = "wasi:cli/stdout@0.1.0";
+        try imp.append(a, @intCast(ns.len));
+        try imp.appendSlice(a, ns);
+        try imp.appendSlice(a, &.{ 5, 'f', 'l', 'u', 's', 'h', 0x00, 0x00 });
+        try ad.append(a, 0x02);
+        var len_buf: [5]u8 = undefined;
+        const n = leb.writeU32Leb128(&len_buf, @intCast(imp.items.len));
+        try ad.appendSlice(a, len_buf[0..n]);
+        try ad.appendSlice(a, imp.items);
+    }
+    // Function section: 2 funcs, type 0
+    try ad.appendSlice(a, &.{ 0x03, 0x03, 0x02, 0x00, 0x00 });
+    // Export section: fd_write (func 2), cabi_import_realloc (func 3)
+    // Imported funcs: _start (idx 0), stdout.flush (idx 1).
+    {
+        var exp = std.ArrayListUnmanaged(u8).empty;
+        defer exp.deinit(a);
+        try exp.append(a, 0x02);
+        try exp.appendSlice(a, &.{ 8, 'f', 'd', '_', 'w', 'r', 'i', 't', 'e', 0x00, 0x02 });
+        try exp.appendSlice(a, &.{ 19, 'c', 'a', 'b', 'i', '_', 'i', 'm', 'p', 'o', 'r', 't', '_', 'r', 'e', 'a', 'l', 'l', 'o', 'c', 0x00, 0x03 });
+        try ad.append(a, 0x07);
+        var len_buf: [5]u8 = undefined;
+        const n = leb.writeU32Leb128(&len_buf, @intCast(exp.items.len));
+        try ad.appendSlice(a, len_buf[0..n]);
+        try ad.appendSlice(a, exp.items);
+    }
+    // Code section: 2 bodies
+    // body 0 (fd_write): call $0 (_start); call $1 (stdout.flush); drop; i32.const 0; end
+    //   — calls both imports so neither gets GC'd.
+    // body 1 (cabi_import_realloc): i32.const 0; end
+    try ad.appendSlice(a, &.{
+        0x0a, 0x10, 0x02,
+        0x09, 0x00, 0x10, 0x00, 0x10, 0x01, 0x1a, 0x41, 0x00, 0x0b,
+        0x04, 0x00, 0x41, 0x00, 0x0b,
+    });
+
+    // Encoded-world custom section — splice() parses this early, so
+    // we must supply one even though the test will reject the shape
+    // before it's used.
+    const metadata_encode = @import("../wit/metadata_encode.zig");
+    const ct = try metadata_encode.encodeWorldFromSource(a,
+        "package wasi:cli@0.1.0;\ninterface stdout { flush: func() -> u32; }\nworld reactor { import stdout; }",
+        "reactor");
+    defer a.free(ct);
+
+    const sec_name = "component-type:wasi:cli@0.1.0:reactor:encoded world";
+    var name_leb_buf: [5]u8 = undefined;
+    const name_leb_n = leb.writeU32Leb128(&name_leb_buf, @intCast(sec_name.len));
+    const body_len = name_leb_n + sec_name.len + ct.len;
+
+    try ad.append(a, 0x00);
+    var size_leb_buf: [5]u8 = undefined;
+    const size_leb_n = leb.writeU32Leb128(&size_leb_buf, @intCast(body_len));
+    try ad.appendSlice(a, size_leb_buf[0..size_leb_n]);
+    try ad.appendSlice(a, name_leb_buf[0..name_leb_n]);
+    try ad.appendSlice(a, sec_name);
+    try ad.appendSlice(a, ct);
+
+    const embed_bytes = try test_fixtures.buildSyntheticReactorEmbed(a);
+    defer a.free(embed_bytes);
+
+    try testing.expectError(
+        error.UnsupportedAdapterShape,
+        splice(a, embed_bytes, ad.items, "wasi_snapshot_preview1"),
+    );
+}
+
+test "spliceMany: rejects zero non-env-import adapters" {
     const a = testing.allocator;
 
     const secondary_bytes = try test_fixtures.buildBareSecondaryAdapter(a);
@@ -2104,10 +2438,10 @@ test "spliceMany: rejects zero adapters declaring wasi:cli/run" {
         .{ .name = test_fixtures.SECONDARY_NAME, .bytes = secondary_bytes },
         .{ .name = "another", .bytes = secondary_bytes },
     };
-    try testing.expectError(error.MissingRunAdapter, spliceMany(a, embed_bytes, &adapters));
+    try testing.expectError(error.MissingPrimaryAdapter, spliceMany(a, embed_bytes, &adapters));
 }
 
-test "spliceMany: rejects two adapters declaring wasi:cli/run" {
+test "spliceMany: rejects two non-env-import adapters" {
     const a = testing.allocator;
 
     const primary_bytes = try test_fixtures.buildSyntheticAdapter(a);
@@ -2119,10 +2453,10 @@ test "spliceMany: rejects two adapters declaring wasi:cli/run" {
         .{ .name = "wasi_snapshot_preview1", .bytes = primary_bytes },
         .{ .name = "second_run", .bytes = primary_bytes },
     };
-    try testing.expectError(error.AmbiguousRunAdapter, spliceMany(a, embed_bytes, &adapters));
+    try testing.expectError(error.AmbiguousPrimaryAdapter, spliceMany(a, embed_bytes, &adapters));
 }
 
-test "spliceMany: rejects a secondary adapter with non-env imports" {
+test "spliceMany: rejects two adapters with non-env imports" {
     const a = testing.allocator;
 
     const primary_bytes = try test_fixtures.buildSyntheticAdapter(a);
@@ -2130,9 +2464,10 @@ test "spliceMany: rejects a secondary adapter with non-env imports" {
     const embed_bytes = try test_fixtures.buildSyntheticEmbedWithSecondary(a);
     defer a.free(embed_bytes);
 
-    // Hand-roll a tiny "bad secondary": no `#` export (so it
-    // doesn't claim to be primary) but imports `__main_module__.x`
-    // — bare-shim contract requires every import to be `env.<x>`.
+    // Hand-roll a tiny adapter that imports `__main_module__.x`
+    // — under the post-#116 partition, ANY non-`env` import makes
+    // an adapter a primary candidate, so this collides with the
+    // synthetic primary and surfaces `AmbiguousPrimaryAdapter`.
     const bad = [_]u8{
         0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
         // Type section: () -> ()
@@ -2154,5 +2489,5 @@ test "spliceMany: rejects a secondary adapter with non-env imports" {
         .{ .name = "wasi_snapshot_preview1", .bytes = primary_bytes },
         .{ .name = test_fixtures.SECONDARY_NAME, .bytes = &bad },
     };
-    try testing.expectError(error.SecondaryAdapterUnsupported, spliceMany(a, embed_bytes, &adapters));
+    try testing.expectError(error.AmbiguousPrimaryAdapter, spliceMany(a, embed_bytes, &adapters));
 }

--- a/src/component/adapter/test_fixtures.zig
+++ b/src/component/adapter/test_fixtures.zig
@@ -69,13 +69,42 @@ const ADAPTER_WIT =
     \\}
 ;
 
+const REACTOR_ADAPTER_WIT =
+    \\package wasi:cli@0.1.0;
+    \\
+    \\interface stdout {
+    \\    flush: func() -> u32;
+    \\}
+    \\
+    \\world reactor {
+    \\    import stdout;
+    \\}
+;
+
+const REACTOR_EMBED_WIT =
+    \\package docs:counter@0.1.0;
+    \\
+    \\interface api {
+    \\    bump: func() -> u32;
+    \\}
+    \\
+    \\world counter {
+    \\    export api;
+    \\}
+;
+
 pub const ADAPTER_CT_SECTION_NAME = "component-type:wit-bindgen:0.0.0-mock:wasi:cli@0.1.0:command:encoded world";
+pub const REACTOR_ADAPTER_CT_SECTION_NAME = "component-type:wit-bindgen:0.0.0-mock:wasi:cli@0.1.0:reactor:encoded world";
 pub const EMBED_CT_SECTION_NAME = "component-type:embed-mock";
+pub const REACTOR_EMBED_CT_SECTION_NAME = "component-type:docs:counter@0.1.0:counter:encoded world";
 
 pub const PREVIEW1_EXPORT = "fd_write";
 pub const RUN_EXPORT = "wasi:cli/run@0.1.0#run";
 pub const STDOUT_NAMESPACE = "wasi:cli/stdout@0.1.0";
 pub const STDOUT_FUNC = "flush";
+pub const REACTOR_API_NAMESPACE = "docs:counter/api@0.1.0";
+pub const REACTOR_API_FUNC = "bump";
+pub const REACTOR_API_CORE_EXPORT = "docs:counter/api@0.1.0#bump";
 
 /// Build a synthetic preview1-shape adapter core wasm.
 ///
@@ -458,6 +487,322 @@ pub fn buildSyntheticEmbedWithSecondary(allocator: Allocator) ![]u8 {
     return out.toOwnedSlice(allocator);
 }
 
+/// Build a synthetic preview1-shape **reactor** adapter core wasm.
+///
+/// Differs from `buildSyntheticAdapter` in two structural ways that
+/// classify it as a reactor under `adapter.detectShape`:
+///
+///   * No `<iface>#<name>` core export (no `wasi:cli/run` lifted entry).
+///   * No `__main_module__.<x>` core import (long-lived, not driven
+///     by `_start`).
+///
+/// Imports:
+///   * `env.memory`                          (memory 0)
+///   * `wasi:cli/stdout@0.1.0.flush`         (func, () -> i32 — canon-lower)
+///
+/// Exports:
+///   * `fd_write`                            (preview1 entry; () -> i32)
+///   * `cabi_import_realloc`                 (canon-lower realloc helper)
+///
+/// Custom section: `component-type:…wasi:cli@0.1.0:reactor:encoded world`
+/// — payload is the `wasi:cli@0.1.0`/`world reactor` (import-only)
+/// produced by `metadata_encode.encodeWorldFromSource`. Caller frees
+/// with the same allocator.
+pub fn buildSyntheticReactorAdapter(allocator: Allocator) ![]u8 {
+    const ct = try metadata_encode.encodeWorldFromSource(allocator, REACTOR_ADAPTER_WIT, "reactor");
+    defer allocator.free(ct);
+
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+
+    try writeMagic(allocator, &out);
+
+    // Type section: 1 type — () -> i32 (every defined func + the
+    // imported stdout.flush share this signature).
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01); // count
+        try b.appendSlice(allocator, &.{ 0x60, 0x00, 0x01, 0x7f });
+        try writeSection(allocator, &out, 0x01, b.items);
+    }
+
+    // Import section: env.memory, wasi:cli/stdout.flush
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02); // count
+        // env.memory: memory 0 (limits: min 0, no max)
+        try writeName(allocator, &b, "env");
+        try writeName(allocator, &b, "memory");
+        try b.append(allocator, 0x02); // memory
+        try b.append(allocator, 0x00); // limits flag
+        try b.append(allocator, 0x00); // min
+        // wasi:cli/stdout@0.1.0.flush: func type 0
+        try writeName(allocator, &b, STDOUT_NAMESPACE);
+        try writeName(allocator, &b, STDOUT_FUNC);
+        try b.append(allocator, 0x00); // func
+        try b.append(allocator, 0x00); // typeidx 0
+        try writeSection(allocator, &out, 0x02, b.items);
+    }
+
+    // Function section: 2 defined funcs (fd_write, cabi_import_realloc), all type 0
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02); // count
+        try b.appendSlice(allocator, &.{ 0x00, 0x00 }); // typeidx 0 ×2
+        try writeSection(allocator, &out, 0x03, b.items);
+    }
+
+    // Export section: fd_write (func 1), cabi_import_realloc (func 2).
+    // Imported func is at idx 0 (stdout.flush).
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02); // count
+        try writeName(allocator, &b, PREVIEW1_EXPORT);
+        try b.appendSlice(allocator, &.{ 0x00, 0x01 }); // func, idx 1
+        try writeName(allocator, &b, "cabi_import_realloc");
+        try b.appendSlice(allocator, &.{ 0x00, 0x02 }); // func, idx 2
+        try writeSection(allocator, &out, 0x07, b.items);
+    }
+
+    // Code section: 2 bodies. fd_write calls stdout.flush (imported
+    // func idx 0) and returns its result, so the adapter's GC keeps
+    // the stdout import live. cabi_import_realloc is trivial.
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02); // count
+        // body 0 (fd_write): call $0 (stdout.flush); end
+        try b.append(allocator, 0x04);
+        try b.append(allocator, 0x00);
+        try b.appendSlice(allocator, &.{ 0x10, 0x00, 0x0b });
+        // body 1 (cabi_import_realloc): i32.const 0; end
+        try b.append(allocator, 0x04);
+        try b.append(allocator, 0x00);
+        try b.appendSlice(allocator, &.{ 0x41, 0x00, 0x0b });
+        try writeSection(allocator, &out, 0x0a, b.items);
+    }
+
+    try appendCustomSection(allocator, &out, REACTOR_ADAPTER_CT_SECTION_NAME, ct);
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// Build a synthetic **reactor** embed core wasm.
+///
+/// Differs from `buildSyntheticEmbed` in two ways:
+///
+///   * No `_start` export (long-lived; entry comes from the
+///     wrapping component's lifted exports).
+///   * Has a `<iface>#<func>`-shape core export
+///     (`docs:counter/api@0.1.0#bump`) — the lift target.
+///
+/// Imports:
+///   * `wasi_snapshot_preview1.fd_write`     (func, () -> i32)
+///
+/// Exports:
+///   * `docs:counter/api@0.1.0#bump`         (func, () -> i32)
+///   * `memory`                              (memory 0)
+///
+/// Custom section: `component-type:counter` — payload is the
+/// `docs:counter@0.1.0`/`world counter { export api; }` produced by
+/// `metadata_encode.encodeWorldFromSource`. The reactor branch in
+/// `assemble()` reads this to recover the WIT signature for canon-lift.
+///
+/// `bump` calls `fd_write` (drops result) and returns `i32.const 42`.
+/// Caller frees with the same allocator.
+pub fn buildSyntheticReactorEmbed(allocator: Allocator) ![]u8 {
+    const ct = try metadata_encode.encodeWorldFromSource(allocator, REACTOR_EMBED_WIT, "counter");
+    defer allocator.free(ct);
+
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+
+    try writeMagic(allocator, &out);
+
+    // Type section: 1 type — () -> i32 (shared by the import and bump).
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.appendSlice(allocator, &.{ 0x60, 0x00, 0x01, 0x7f });
+        try writeSection(allocator, &out, 0x01, b.items);
+    }
+
+    // Import section: wasi_snapshot_preview1.fd_write (func type 0)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try writeName(allocator, &b, "wasi_snapshot_preview1");
+        try writeName(allocator, &b, PREVIEW1_EXPORT);
+        try b.append(allocator, 0x00); // func
+        try b.append(allocator, 0x00); // typeidx 0
+        try writeSection(allocator, &out, 0x02, b.items);
+    }
+
+    // Function section: 1 defined func (bump, type 0)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x00); // typeidx 0
+        try writeSection(allocator, &out, 0x03, b.items);
+    }
+
+    // Memory section: 1 memory (limits: min 0, no max)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x00);
+        try b.append(allocator, 0x00);
+        try writeSection(allocator, &out, 0x05, b.items);
+    }
+
+    // Export section: <iface>#bump (func 1 — import takes 0), memory (0)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02);
+        try writeName(allocator, &b, REACTOR_API_CORE_EXPORT);
+        try b.appendSlice(allocator, &.{ 0x00, 0x01 }); // func, idx 1
+        try writeName(allocator, &b, "memory");
+        try b.appendSlice(allocator, &.{ 0x02, 0x00 });
+        try writeSection(allocator, &out, 0x07, b.items);
+    }
+
+    // Code section: bump = call $0; drop; i32.const 42; end
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x07); // body size: 1 (locals) + 6 (code)
+        try b.append(allocator, 0x00); // 0 locals
+        try b.appendSlice(allocator, &.{
+            0x10, 0x00, 0x1a, // call $0; drop
+            0x41, 42, // i32.const 42
+            0x0b, // end
+        });
+        try writeSection(allocator, &out, 0x0a, b.items);
+    }
+
+    try appendCustomSection(allocator, &out, REACTOR_EMBED_CT_SECTION_NAME, ct);
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// Build a synthetic **reactor** embed that imports BOTH preview1
+/// and a bare-shim secondary's host function — exercises
+/// `spliceMany` on a reactor primary + bare secondary.
+///
+/// Differs from `buildSyntheticEmbedWithSecondary`:
+///   * No `_start` export (reactor shape).
+///   * Has `<iface>#bump` core export — the lift target.
+///   * Carries a `component-type:counter` custom section.
+///
+/// Imports:
+///   * `wasi_snapshot_preview1.fd_write`     (func, () -> i32)
+///   * `mock_host.do_thing`                  (func, () -> i32)
+///
+/// Exports:
+///   * `docs:counter/api@0.1.0#bump`         (func, () -> i32)
+///   * `memory`                              (memory 0)
+///
+/// `bump` calls both imports (drops their results) so the adapter
+/// GC keeps both imports live across `spliceMany`. Returns
+/// `i32.const 42`. Caller frees with the same allocator.
+pub fn buildSyntheticReactorEmbedWithSecondary(allocator: Allocator) ![]u8 {
+    const ct = try metadata_encode.encodeWorldFromSource(allocator, REACTOR_EMBED_WIT, "counter");
+    defer allocator.free(ct);
+
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+
+    try writeMagic(allocator, &out);
+
+    // Type section: 1 type — () -> i32.
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.appendSlice(allocator, &.{ 0x60, 0x00, 0x01, 0x7f });
+        try writeSection(allocator, &out, 0x01, b.items);
+    }
+
+    // Import section: preview1.fd_write, mock_host.do_thing
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02);
+        // wasi_snapshot_preview1.fd_write — type 0
+        try writeName(allocator, &b, "wasi_snapshot_preview1");
+        try writeName(allocator, &b, PREVIEW1_EXPORT);
+        try b.append(allocator, 0x00);
+        try b.append(allocator, 0x00);
+        // mock_host.do_thing — type 0
+        try writeName(allocator, &b, SECONDARY_NAME);
+        try writeName(allocator, &b, SECONDARY_EXPORT);
+        try b.append(allocator, 0x00);
+        try b.append(allocator, 0x00);
+        try writeSection(allocator, &out, 0x02, b.items);
+    }
+
+    // Function section: 1 defined func (bump, type 0)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x00);
+        try writeSection(allocator, &out, 0x03, b.items);
+    }
+
+    // Memory section: 1 memory
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x00);
+        try b.append(allocator, 0x00);
+        try writeSection(allocator, &out, 0x05, b.items);
+    }
+
+    // Export section: <iface>#bump (func 2 — imports take 0,1), memory (0)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02);
+        try writeName(allocator, &b, REACTOR_API_CORE_EXPORT);
+        try b.appendSlice(allocator, &.{ 0x00, 0x02 });
+        try writeName(allocator, &b, "memory");
+        try b.appendSlice(allocator, &.{ 0x02, 0x00 });
+        try writeSection(allocator, &out, 0x07, b.items);
+    }
+
+    // Code section: bump = call $0; drop; call $1; drop; i32.const 42; end
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x0a); // body size: 1 (locals) + 9 (code)
+        try b.append(allocator, 0x00); // 0 locals
+        try b.appendSlice(allocator, &.{
+            0x10, 0x00, 0x1a, // call $0; drop
+            0x10, 0x01, 0x1a, // call $1; drop
+            0x41, 42, // i32.const 42
+            0x0b, // end
+        });
+        try writeSection(allocator, &out, 0x0a, b.items);
+    }
+
+    try appendCustomSection(allocator, &out, REACTOR_EMBED_CT_SECTION_NAME, ct);
+
+    return out.toOwnedSlice(allocator);
+}
+
 // ── byte-stream helpers ──────────────────────────────────────────────────
 
 fn writeMagic(allocator: Allocator, out: *std.ArrayListUnmanaged(u8)) !void {
@@ -607,4 +952,86 @@ test "buildSyntheticEmbedWithSecondary: imports both preview1 and mock_host" {
     try testing.expect(saw_p1);
     try testing.expect(saw_sec);
     try testing.expect(owned.interface.findExport("_start") != null);
+}
+
+test "buildSyntheticReactorAdapter: parses through reader, no run export, no __main_module__ import" {
+    const ad_bytes = try buildSyntheticReactorAdapter(testing.allocator);
+    defer testing.allocator.free(ad_bytes);
+
+    var owned = try core_imports.extract(testing.allocator, ad_bytes);
+    defer owned.deinit();
+
+    // Preview1 entry + canon-lower realloc are the only exports.
+    try testing.expect(owned.interface.findExport(PREVIEW1_EXPORT) != null);
+    try testing.expect(owned.interface.findExport("cabi_import_realloc") != null);
+    // No `<iface>#name` export — that's the reactor signal.
+    for (owned.interface.exports) |ex| {
+        try testing.expect(std.mem.indexOfScalar(u8, ex.name, '#') == null);
+    }
+    // No `__main_module__.<x>` import — reactor adapters have none.
+    for (owned.interface.imports) |im| {
+        try testing.expect(!std.mem.eql(u8, im.module_name, "__main_module__"));
+    }
+    // Stdout import must survive — adapter GC keeps it live via fd_write's body.
+    var saw_stdout = false;
+    for (owned.interface.imports) |im| {
+        if (std.mem.eql(u8, im.module_name, STDOUT_NAMESPACE) and
+            std.mem.eql(u8, im.field_name, STDOUT_FUNC)) saw_stdout = true;
+    }
+    try testing.expect(saw_stdout);
+}
+
+test "buildSyntheticReactorAdapter: encoded-world section round-trips through decode" {
+    const ad_bytes = try buildSyntheticReactorAdapter(testing.allocator);
+    defer testing.allocator.free(ad_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const w = try decode.parseFromAdapterCore(arena.allocator(), ad_bytes);
+
+    // World imports stdout, exports nothing — pure import shape.
+    try testing.expectEqual(@as(usize, 1), w.imports.len);
+    try testing.expectEqualStrings(STDOUT_NAMESPACE, w.imports[0].name);
+    try testing.expectEqual(@as(usize, 0), w.exports.len);
+}
+
+test "buildSyntheticReactorEmbed: parses through reader, no _start, exports <iface>#bump" {
+    const embed_bytes = try buildSyntheticReactorEmbed(testing.allocator);
+    defer testing.allocator.free(embed_bytes);
+
+    var owned = try core_imports.extract(testing.allocator, embed_bytes);
+    defer owned.deinit();
+
+    // `<iface>#bump` is exported; `_start` is NOT.
+    try testing.expect(owned.interface.findExport(REACTOR_API_CORE_EXPORT) != null);
+    try testing.expect(owned.interface.findExport("_start") == null);
+
+    // preview1.fd_write is imported.
+    var saw_p1 = false;
+    for (owned.interface.imports) |im| {
+        if (std.mem.eql(u8, im.module_name, "wasi_snapshot_preview1") and
+            std.mem.eql(u8, im.field_name, PREVIEW1_EXPORT)) saw_p1 = true;
+    }
+    try testing.expect(saw_p1);
+}
+
+test "buildSyntheticReactorEmbed: encoded-world section decodes the api export" {
+    const embed_bytes = try buildSyntheticReactorEmbed(testing.allocator);
+    defer testing.allocator.free(embed_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ct_payload = (try decode.extractEncodedWorld(embed_bytes)) orelse
+        return error.TestUnexpectedResult;
+
+    const metadata_decode = @import("../wit/metadata_decode.zig");
+    const decoded = try metadata_decode.decode(arena.allocator(), ct_payload);
+
+    // The world is `counter` and exports the `api` interface.
+    try testing.expectEqualStrings("counter", decoded.name);
+    try testing.expectEqual(@as(usize, 1), decoded.externs.len);
+    try testing.expect(decoded.externs[0].is_export);
+    try testing.expectEqualStrings(REACTOR_API_NAMESPACE, decoded.externs[0].qualified_name);
+    try testing.expectEqual(@as(usize, 1), decoded.externs[0].funcs.len);
+    try testing.expectEqualStrings(REACTOR_API_FUNC, decoded.externs[0].funcs[0].name);
 }

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -25,11 +25,25 @@
 //!    delegate to `wabt.component.adapter.adapter.splice`, which
 //!    composes the embed core with the given preview1→component
 //!    adapter into a four- or five-core-module component (shim,
-//!    embed, adapter, fixup, optional `__main_module__` fallback)
-//!    and lifts `wasi:cli/run` for top-level export. Mirrors
-//!    `wasm-tools component new --adapt …` and unblocks the
-//!    `zig-hello`, `zig-calculator-cmd`, and `mixed-zig-rust-calc`
-//!    wamr command-component fixtures.
+//!    embed, adapter, fixup, optional `__main_module__` fallback).
+//!
+//!    Two adapter shapes are supported transparently — `splice`
+//!    classifies via `detectShape`:
+//!      * **command** (the wamr `zig-hello` / `zig-calculator-cmd`
+//!        / `mixed-zig-rust-calc` fixtures): the adapter declares
+//!        `wasi:cli/run@…` and the wrapping component lifts a
+//!        single `wasi:cli/run` top-level export.
+//!      * **reactor**: the adapter has no `<iface>#name` exports
+//!        and no `__main_module__` imports; the wrapping component
+//!        emits one top-level export per `<iface>#<func>` export
+//!        the embed declares.
+//!
+//!    Multi-adapter splicing (`--adapt` repeated): the **primary**
+//!    is the unique adapter with at least one non-`env` core
+//!    import. Remaining adapters are treated as bare host-shim
+//!    secondaries (every import must be `env.<x>`).
+//!
+//!    Mirrors `wasm-tools component new --adapt …`.
 
 const std = @import("std");
 const wabt = @import("wabt");
@@ -51,10 +65,15 @@ pub const usage =
     \\Options:
     \\  -o, --output <file>     Output file (default: <input>.component.wasm)
     \\      --skip-validation   Skip post-encoding component validation
-    \\      --adapt <n>=<file>  Splice in an adapter (may repeat). The first
-    \\                          adapter declaring `wasi:cli/run` is the
-    \\                          primary; remaining adapters must import only
+    \\      --adapt <n>=<file>  Splice in an adapter (may repeat). The
+    \\                          primary is the unique adapter with at
+    \\                          least one non-`env` core import; the
+    \\                          remaining adapters must import only
     \\                          `env.<x>` (bare host-shim restriction).
+    \\                          Both command-shape (lifts wasi:cli/run)
+    \\                          and reactor-shape (lifts each
+    \\                          <iface>#<func>) primaries are supported
+    \\                          and detected automatically.
     \\  -h, --help              Show this help
     \\
 ;


### PR DESCRIPTION
Generalizes the adapter splicer to handle wasmtime's preview1 **reactor** adapter shape alongside the existing **command** shape, including N≥2 multi-adapter pipelines with a reactor primary.

## Shape detection

`Shape = { command, reactor }` + `detectShape(iface)` classify on the presence of `<iface>#<name>`-shaped core exports — wit-component's heuristic. Threading: `splice` and `spliceN` set `Inputs.shape` once; `assemble()` branches on it.

## Reactor branch in assemble()

* **Step 7** (`__main_module__` aliasing): `main_module_inst` is `?u32`. Reactor returns `null` after asserting no `__main_module__.<x>` imports remain (`error.UnsupportedAdapterShape` if violated). Step 7c fallback module is consequently skipped.
* **Step 9**: conditionally appends the `__main_module__` arg only when command shape produced one.
* **Steps 11–13**: command path is byte-identical to before. Reactor path reads pre-decoded `embed_metadata` (new `Inputs` field, populated by `splice`/`spliceN` from the embed's `component-type:*` section before `stripComponentTypeSections`), lifts each `<iface>#<func>` export from the embed core instance, builds one per-interface inline-export bundle, and emits one `(export "<iface>" instance N)` per export interface in un-ascribed form (matches `component_new.zig::buildComponent`'s no-adapter pattern).

## Multi-adapter primary detection

`findPrimaryAdapter`'s `#`-rule collapses for reactor adapters (which have no `#`-shape exports). Replaced with: **primary = the unique adapter with at least one non-`env` core import**. The renamed partition is consistent with `validateBareShimSecondary`. Errors renamed:

* `MissingRunAdapter` → `MissingPrimaryAdapter`
* `AmbiguousRunAdapter` → `AmbiguousPrimaryAdapter`

## Hermetic fixtures + tests

* `buildSyntheticReactorAdapter` — preview1-shape adapter with no `<iface>#name` export and no `__main_module__` import.
* `buildSyntheticReactorEmbed` / `buildSyntheticReactorEmbedWithSecondary` — counter-style reactor embeds carrying their own `component-type:counter@0.1.0:counter:encoded world` custom section.
* 4 fixture self-tests (parse, encoded-world round-trip via `metadata_decode`).
* `splice: end-to-end on synthetic reactor adapter + reactor embed` — asserts 1 top-level export per embed export interface, 4 inner core modules (no fallback), no `wasi:cli/run`.
* `spliceMany: end-to-end on reactor primary + bare secondary adapter pair` — asserts 5 inner core modules.
* `splice: rejects a reactor-shaped adapter that imports __main_module__` — `UnsupportedAdapterShape` guard.

## CLI

`component_new.zig` is shape-agnostic; updated docstring + `--adapt` help to describe both shapes and the post-#116 primary-detection rule.

## Out of scope

Library shape (output is itself a library imported by another component, with `wasi:*` imports passed through unchanged) — tracked in #127 per the issue body.

## Tests

369/369 → 376/376 (7 new). Existing N=1 + N=2 command paths unchanged byte-identically.

Closes #116