### PR TITLE
fix(shrink): use wasi-safe PID fallback so wasm32-wasi builds (#135)

### DIFF
--- a/src/tools/shrink.zig
+++ b/src/tools/shrink.zig
@@ -87,7 +87,14 @@ pub const PredicateRunner = struct {
             .io = io,
             .predicate = predicate,
             .tmp_dir = tmp,
-            .pid = std.os.linux.getpid(),
+            // wasm32-wasi has no PID concept and `std.os.linux.getpid()`
+            // fails to compile there (no `syscall0`). Since `pid` is only
+            // a tmp-filename uniqueness hint within one process, fall
+            // back to a constant on wasi. Fixes #135.
+            .pid = if (@import("builtin").os.tag == .wasi)
+                1
+            else
+                std.os.linux.getpid(),
         };
     }
 


### PR DESCRIPTION
## Summary

Fixes #135. `zig build -Dtarget=wasm32-wasi` failed to compile
`src/tools/shrink.zig` because `PredicateRunner.init` reached
`std.os.linux.getpid()`, which expands to `syscall0` — and
`arch_bits` for wasm32 is the empty `else => struct {}`, so the
lazy reference failed:

```
.../lib/std/os/linux.zig:61:34:
  error: struct 'os.linux.arch_bits__struct_…' has no member named 'syscall0'
referenced by:
  getpid: /…/lib/std/os/linux.zig:2163:40
  init:   src/tools/shrink.zig:90:39
```

This blocked the Release workflow's `Build wasi` matrix job. Since
the `release` job has `needs: [build, source]`, no GitHub Release
was created for `v3.0.0-dev.2` even though all 9 native targets
succeeded — so `ghr install cataggar/wabt@v3.0.0-dev.2` couldn't
work.

## Fix

`std.posix.getpid()` does not exist in Zig 0.16.0 (issue's first
suggestion); use a target-conditional with a constant on wasi:

```zig
.pid = if (@import("builtin").os.tag == .wasi)
    1
else
    std.os.linux.getpid(),
```

The pid is only used to disambiguate tmp filenames in
`isInteresting` (`{tmp}/wabt-shrink-{pid}-{counter}.wasm`). wasi
has no real PID concept and shrink runs in a single process, so a
deterministic constant is sound. Native targets are unchanged.

## Verification

* `zig build -Doptimize=ReleaseSafe -Dtarget=wasm32-wasi -Dstrip=true -Dversion=3.0.0-dev.3` — succeeds (was the failing command).
* `zig build install` (host) — succeeds.
* `zig build test --summary all` — 379/379 tests passed.

## Follow-up

After merge: push `v3.0.0-dev.3` so the Release workflow can
publish artifacts with the post-#129/#131/#132 fixes.

Closes #135.