### PR TITLE
feat(adapters): scaffold wasi-preview1 → preview2 adapter (refs cataggar/wamr#453)

### DIFF
--- a/adapters/wasi-preview1/README.md
+++ b/adapters/wasi-preview1/README.md
@@ -1,0 +1,178 @@
+# `wasi:cli@0.2.x` preview1 → preview2 adapter
+
+A wabt-native, Zig-authored replacement for the
+[wasmtime `wasi_snapshot_preview1.command.wasm` adapter][wm-adapter].
+Built as part of `zig build adapter`, embedded as `@embedFile` into
+the `wabt` CLI, and used as the default `--adapt` source for
+`wabt component new` when the embed declares preview1 imports.
+
+[wm-adapter]: https://github.com/bytecodealliance/wasmtime/blob/main/crates/wasi-preview1-component-adapter/README.md
+
+Tracks [cataggar/wamr#453][issue]. The motivation (drop the lossy
+`wasi:cli/exit.exit(result)` round-trip, drop the
+`exit_code_sink` workaround, ship a reviewable in-tree adapter)
+is documented in that issue.
+
+[issue]: https://github.com/cataggar/wamr/issues/453
+
+## Status: in-progress, not yet wired into `wabt component new`
+
+This directory ships the **scaffolding** for the adapter — a WAT
+source with the correct import / export shape and stubbed function
+bodies, plus a Zig build tool that drives the wabt library to parse
+and emit the artifact. Subsequent commits fill in:
+
+  1. the `wit/preview1.wit` world declaration and a
+     `metadata_encode.encodeWorldFromSource` call from
+     `tools/build_adapter.zig` that appends the
+     `component-type:…:command:encoded world` custom section to the
+     emitted wasm (today the artifact is *shape only* — it parses,
+     validates and has the right imports/exports, but the splicer
+     in `src/component/adapter/decode.zig` rejects it with
+     `MissingEncodedWorld` because the world section is absent;
+     gated on `metadata_encode.zig` gaining support for resource
+     handles — the real `wasi:io/streams` interface uses
+     `[method]output-stream.blocking-write-and-flush(borrow<…>,
+     …)`),
+  2. real preview1 → preview2 semantics in `src/adapter.wat`
+     replacing the current ENOSYS stubs (`fd_write` iterates the
+     iovec list and calls `output-stream.blocking-write-and-flush`,
+     `args_get` lowers `wasi:cli/environment.get-arguments`, etc.),
+  3. embedding the artifact into the wabt CLI via `@embedFile` and
+     wiring it as the default `--adapt` source in
+     `src/tools/component_new.zig` when the embed declares
+     preview1 imports and `--adapt` is not passed.
+
+The `proc_exit` lowering is the one piece that's fully wired
+end-to-end already, because it's just a single canon-lower of `u8`
+through `wasi:cli/exit.exit-with-code` — see the body of `$proc_exit`
+in `src/adapter.wat`. That's the key win over the wasmtime
+adapter, which routes through the lossy `exit(result<_,_>)` and
+collapses every non-zero `proc_exit(code)` to host exit code 1.
+
+## Layout
+
+```
+adapters/wasi-preview1/
+├── README.md            (this file)
+├── src/
+│   └── adapter.wat      WAT source — imports preview2, exports preview1
+├── wit/
+│   └── preview1.wit     `world preview1-command`: imports the
+│                        preview2 instances we use, exports
+│                        `wasi:cli/run`
+└── tools/
+    └── build_adapter.zig
+                         small Zig program invoked from build.zig
+                         to: parse WAT → wasm bytes, encode WIT
+                         world → encoded-world bytes, append the
+                         encoded-world as a `component-type:…`
+                         custom section, write the final
+                         `wasi_snapshot_preview1.command.wasm`.
+```
+
+## Adapter shape (command shape, per `detectShape` at
+[`src/component/adapter/adapter.zig:828`](../../src/component/adapter/adapter.zig))
+
+* **Core wasm imports** (matched against the embed at splice time):
+    * `env.memory` — the embed's linear memory; the adapter reads
+      iovec lists and writes errno return values into it.
+    * `__main_module__._start` — invoked from the adapter's
+      `wasi:cli/run.run` body.
+    * `__main_module__.cabi_realloc` (best-effort) — used for any
+      canon-lift'd preview2 return values that need a return area in
+      embed memory. Absent embeds get a `buildMainModuleFallback`
+      stub from the splicer.
+    * One preview2 instance import per WASI namespace the adapter
+      lowers into. Initial scope:
+        * `wasi:cli/exit@0.2.6.exit-with-code` — replaces the lossy
+          `exit(result)` that the wasmtime adapter routes through.
+        * `wasi:cli/stdout@0.2.6.get-stdout`,
+          `wasi:cli/stderr@0.2.6.get-stderr`,
+          `wasi:cli/stdin@0.2.6.get-stdin`.
+        * `wasi:io/streams@0.2.6.[method]output-stream.blocking-
+          write-and-flush`,
+          `[method]output-stream.blocking-flush`,
+          `[method]input-stream.blocking-read`,
+          `[resource-drop]output-stream`,
+          `[resource-drop]input-stream`.
+        * `wasi:cli/environment@0.2.6.get-arguments`,
+          `get-environment`.
+        * `wasi:clocks/wall-clock@0.2.6.now`,
+          `wasi:clocks/monotonic-clock@0.2.6.now`.
+        * `wasi:random/random@0.2.6.get-random-bytes`.
+
+* **Core wasm exports** (flat names, no
+  `wasi_snapshot_preview1.` prefix — the splicer maps them to
+  whatever adapter `name` the user specified):
+    * `wasi:cli/run@0.2.6#run` — `(func (result i32))`. Calls
+      `__main_module__._start` then returns `0` (ok). On
+      `proc_exit(code)` the trap unwinds out of `_start`; the
+      wrapping `wasi:cli/exit.exit-with-code` host call has already
+      landed the code at this point.
+    * `cabi_import_realloc` — `(func (param i32 i32 i32 i32)
+      (result i32))`. Canon-lower realloc helper. For the initial
+      scope we either delegate to `__main_module__.cabi_realloc`
+      or trap (none of our supported preview1 imports actually
+      route a list / string back through realloc — `fd_write` etc.
+      pass `(ptr, len)` slices directly out of embed memory).
+    * preview1 surface (initial cut, per [#453][issue] scope cut):
+        `proc_exit`, `proc_raise`, `sched_yield`,
+        `fd_write`, `fd_read`, `fd_close`, `fd_seek`,
+        `fd_fdstat_get`, `fd_fdstat_set_flags`,
+        `fd_prestat_get`, `fd_prestat_dir_name`,
+        `args_get`, `args_sizes_get`,
+        `environ_get`, `environ_sizes_get`,
+        `clock_time_get`, `clock_res_get`,
+        `random_get`.
+        All other preview1 imports trap with `errno=ENOSYS`. wabt's
+        adapter-core-wasm GC pass
+        ([`src/component/adapter/gc.zig`](../../src/component/adapter/gc.zig))
+        drops the unused ones at splice time.
+
+* **`component-type:…:command:encoded world` custom section**:
+  produced by `wabt component embed` (or directly by
+  [`metadata_encode.encodeWorldFromSource`](../../src/component/wit/metadata_encode.zig))
+  from `wit/preview1.wit`. The splicer decodes this in
+  [`src/component/adapter/decode.zig`](../../src/component/adapter/decode.zig)
+  to drive `types-import.hoist`. Section name format used here:
+  `component-type:wabt:0.0.0:wasi:cli@0.2.6:command:encoded world`
+  (any `component-type:*` prefix is accepted by `decode.zig`).
+
+## Why hand-authored WAT instead of compiled Zig?
+
+The wasmtime adapter is Rust-source compiled through `wit-bindgen`,
+which generates ~190 KiB of canon-lower binding glue per release.
+We have no Zig-side `wit-bindgen` equivalent. Hand-authored WAT
+keeps the adapter:
+
+* **Small** — only the preview1 surface we actually need, no
+  long-tail of unused wit-bindgen scaffolding.
+* **Reviewable** — every byte of the adapter is in this directory
+  in source-readable form; updates land via normal PRs against the
+  WAT and WIT files.
+* **Pinned to wabt's existing infrastructure** — the build pipeline
+  is just `wabt.text.Parser.parseModule` + `metadata_encode.encodeWorldFromSource`
+  + custom-section append. No new dependency.
+
+The downside is that the canonical-ABI lowering of compound
+preview2 types (`list<u8>`, `result<_, e>`, resource handles) has
+to be hand-coded in WAT. That's tractable for our initial scope —
+the preview2 calls we make either take primitive `(handle, ptr,
+len)` triples (`blocking-write-and-flush`) or single `u8` /
+`u64` scalars (`exit-with-code`, `clock.now`); none require
+canon-lower'd realloc.
+
+## Building locally
+
+```console
+$ zig build adapter
+$ ls zig-out/adapter/
+wasi_snapshot_preview1.command.wasm
+```
+
+The artifact is also embedded into the `wabt` CLI binary so that
+`wabt component new` uses it by default when the embed declares
+`wasi_snapshot_preview1.*` imports and `--adapt` is not passed.
+Override the builtin with `--adapt
+wasi_snapshot_preview1=<file.wasm>` (existing flag, unchanged).

--- a/adapters/wasi-preview1/src/adapter.wat
+++ b/adapters/wasi-preview1/src/adapter.wat
@@ -1,0 +1,207 @@
+;; ── wasi:cli@0.2.x preview1 → preview2 adapter ──────────────────────────
+;;
+;; Hand-authored WAT for the wabt-native preview1 adapter (tracks
+;; cataggar/wamr#453). Shape mirrors the wasmtime
+;; `wasi_snapshot_preview1.command.wasm` adapter (see
+;; ../README.md for the side-by-side dissection) with one
+;; deliberate divergence: `proc_exit` lowers through
+;; `wasi:cli/exit.exit-with-code(u8)` rather than the lossy
+;; `wasi:cli/exit.exit(result)`. That preserves the numeric exit
+;; code end-to-end and lets wamr drop the `exit_code_sink`
+;; workaround added in #447/#448.
+;;
+;; Status: scaffold. Most function bodies are `unreachable` traps.
+;; `proc_exit` and `run` are fully wired; `fd_write` and the rest
+;; of the preview1 surface land in subsequent commits.
+
+(module
+  ;; ── func types ────────────────────────────────────────────────
+  (type $void          (func))
+  (type $i32_void      (func (param i32)))
+  (type $get_handle    (func (result i32)))
+  (type $run_sig       (func (result i32)))
+  (type $cabi_realloc  (func (param i32 i32 i32 i32) (result i32)))
+
+  ;; preview1 fd_* signatures (i32 errno return)
+  (type $fd_write_sig         (func (param i32 i32 i32 i32) (result i32)))
+  (type $fd_read_sig          (func (param i32 i32 i32 i32) (result i32)))
+  (type $fd_close_sig         (func (param i32) (result i32)))
+  (type $fd_seek_sig          (func (param i32 i64 i32 i32) (result i32)))
+  (type $fd_fdstat_get_sig    (func (param i32 i32) (result i32)))
+  (type $fd_fdstat_set_flags_sig (func (param i32 i32) (result i32)))
+  (type $fd_prestat_get_sig   (func (param i32 i32) (result i32)))
+  (type $fd_prestat_dir_name_sig (func (param i32 i32 i32) (result i32)))
+
+  ;; preview1 args / environ / clock / random signatures
+  (type $args_get_sig         (func (param i32 i32) (result i32)))
+  (type $args_sizes_get_sig   (func (param i32 i32) (result i32)))
+  (type $environ_get_sig      (func (param i32 i32) (result i32)))
+  (type $environ_sizes_get_sig (func (param i32 i32) (result i32)))
+  (type $clock_time_get_sig   (func (param i32 i64 i32) (result i32)))
+  (type $clock_res_get_sig    (func (param i32 i32) (result i32)))
+  (type $random_get_sig       (func (param i32 i32) (result i32)))
+
+  ;; preview1 proc / sched signatures
+  (type $proc_exit_sig        (func (param i32)))
+  (type $proc_raise_sig       (func (param i32) (result i32)))
+  (type $sched_yield_sig      (func (result i32)))
+
+  ;; preview2 import signatures (canon-lower'd by the wrapping
+  ;; component; here they are plain core-wasm function types).
+  ;;
+  ;; `[method]output-stream.blocking-write-and-flush(self, contents)
+  ;; -> result<_, stream-error>` canon-lowers to:
+  ;;   (self: i32 handle, ptr: i32, len: i32, retptr: i32) -> ()
+  ;; The retptr is a 12-byte return-area in linear memory; the
+  ;; first byte is the result tag (0 = ok, 1 = err), followed by
+  ;; the (variant-tagged) stream-error payload on the err branch.
+  (type $stream_write_sig (func (param i32 i32 i32 i32)))
+
+  ;; ── imports ──────────────────────────────────────────────────
+  ;;
+  ;; env.memory — the embed's linear memory. The adapter reads
+  ;; iovec lists and writes preview1 errno return values into it.
+  (import "env" "memory" (memory 0))
+
+  ;; The embed exports we call back into.
+  (import "__main_module__" "_start"
+    (func $main_start (type $void)))
+  (import "__main_module__" "cabi_realloc"
+    (func $main_cabi_realloc (type $cabi_realloc)))
+
+  ;; preview2 instances we lower into. Initial scope per
+  ;; cataggar/wamr#453 — fd_write / fd_read / stdio + exit-with-code.
+  (import "wasi:cli/exit@0.2.6" "exit-with-code"
+    (func $exit_with_code (type $i32_void)))
+  (import "wasi:cli/stdout@0.2.6" "get-stdout"
+    (func $get_stdout (type $get_handle)))
+  (import "wasi:cli/stderr@0.2.6" "get-stderr"
+    (func $get_stderr (type $get_handle)))
+  (import "wasi:cli/stdin@0.2.6" "get-stdin"
+    (func $get_stdin (type $get_handle)))
+  (import "wasi:io/streams@0.2.6" "[method]output-stream.blocking-write-and-flush"
+    (func $owrite_flush (type $stream_write_sig)))
+  (import "wasi:io/streams@0.2.6" "[resource-drop]output-stream"
+    (func $ostream_drop (type $i32_void)))
+  (import "wasi:io/streams@0.2.6" "[resource-drop]input-stream"
+    (func $istream_drop (type $i32_void)))
+
+  ;; ── preview1 surface ─────────────────────────────────────────
+  ;;
+  ;; proc_exit(code: i32) -> ! :  preview1 declares no return, but
+  ;; the canon-lift'd signature in core wasm is `(i32) -> ()`. The
+  ;; body lowers through `wasi:cli/exit.exit-with-code(u8)` and
+  ;; then traps so the call never returns. The host's
+  ;; `exit-with-code` itself traps after stashing the code on the
+  ;; `WasiCliAdapter.exit_code` slot, so in practice the
+  ;; `unreachable` here is defensive.
+  (func $proc_exit (type $proc_exit_sig)
+    (local $code_u8 i32)
+    ;; clamp to u8 (preview1 proc_exit code is i32; preview2
+    ;; exit-with-code expects u8). Use the low 8 bits, matching
+    ;; the wasmtime adapter's `code as u8` truncation.
+    local.get 0
+    i32.const 0xff
+    i32.and
+    local.set $code_u8
+    local.get $code_u8
+    call $exit_with_code
+    unreachable)
+
+  ;; proc_raise(sig: i32) -> errno
+  (func $proc_raise (type $proc_raise_sig)
+    ;; ENOSYS=52
+    i32.const 52)
+
+  ;; sched_yield() -> errno
+  (func $sched_yield (type $sched_yield_sig)
+    ;; Trivially succeed; no preview2 equivalent and yield is
+    ;; advisory.
+    i32.const 0)
+
+  ;; ── fd_* (mostly ENOSYS stubs until subsequent commits) ──────
+  (func $fd_write (type $fd_write_sig)
+    ;; TODO: iterate iovec list, call $owrite_flush against
+    ;; stdout/stderr handle. For now: ENOSYS.
+    i32.const 52)
+
+  (func $fd_read (type $fd_read_sig)         i32.const 52)
+  (func $fd_close (type $fd_close_sig)       i32.const 52)
+  (func $fd_seek (type $fd_seek_sig)         i32.const 52)
+  (func $fd_fdstat_get (type $fd_fdstat_get_sig) i32.const 52)
+  (func $fd_fdstat_set_flags (type $fd_fdstat_set_flags_sig) i32.const 52)
+  (func $fd_prestat_get (type $fd_prestat_get_sig) i32.const 52)
+  (func $fd_prestat_dir_name (type $fd_prestat_dir_name_sig) i32.const 52)
+
+  ;; ── args / environ ───────────────────────────────────────────
+  ;;
+  ;; ENOSYS until subsequent commits wire these to
+  ;; `wasi:cli/environment.get-arguments` /
+  ;; `get-environment` (both return canon-lift'd `list<string>`
+  ;; which needs a return-area + iterate). The scaffold body is
+  ;; intentionally trivial — wasi-libc treats a non-zero return as
+  ;; "no env / no args available", so the wamr examples that don't
+  ;; consult argv (`zig-hello`, `zig-exit`) still work.
+  (func $args_get (type $args_get_sig)             i32.const 52)
+  (func $args_sizes_get (type $args_sizes_get_sig) i32.const 52)
+  (func $environ_get (type $environ_get_sig)       i32.const 52)
+  (func $environ_sizes_get (type $environ_sizes_get_sig) i32.const 52)
+
+  ;; ── clocks / random (ENOSYS for now) ─────────────────────────
+  (func $clock_time_get (type $clock_time_get_sig) i32.const 52)
+  (func $clock_res_get (type $clock_res_get_sig)   i32.const 52)
+  (func $random_get (type $random_get_sig)         i32.const 52)
+
+  ;; ── run entry ────────────────────────────────────────────────
+  ;;
+  ;; wasi:cli/run.run() -> result<_, _>
+  ;;   canon-lift'd to core wasm: () -> i32
+  ;;   0 = Ok(()), 1 = Err(())
+  ;;
+  ;; Call the embed's _start. If _start returns normally we
+  ;; return 0 (ok). proc_exit traps so it never reaches this
+  ;; tail.
+  (func $run (type $run_sig)
+    call $main_start
+    i32.const 0)
+
+  ;; canon-lower realloc helper — delegate to the embed's
+  ;; cabi_realloc. None of the preview1 imports we currently
+  ;; implement route a list / string return back through realloc,
+  ;; so this is a defensive delegation rather than a hot path.
+  (func $cabi_import_realloc (type $cabi_realloc)
+    local.get 0
+    local.get 1
+    local.get 2
+    local.get 3
+    call $main_cabi_realloc)
+
+  ;; ── exports ──────────────────────────────────────────────────
+  ;;
+  ;; Flat preview1 names (no `wasi_snapshot_preview1.` prefix —
+  ;; the splicer matches by name against whichever `--adapt
+  ;; name=…` module the user specified, defaulting to
+  ;; `wasi_snapshot_preview1`).
+  (export "proc_exit"            (func $proc_exit))
+  (export "proc_raise"           (func $proc_raise))
+  (export "sched_yield"          (func $sched_yield))
+  (export "fd_write"             (func $fd_write))
+  (export "fd_read"              (func $fd_read))
+  (export "fd_close"             (func $fd_close))
+  (export "fd_seek"              (func $fd_seek))
+  (export "fd_fdstat_get"        (func $fd_fdstat_get))
+  (export "fd_fdstat_set_flags"  (func $fd_fdstat_set_flags))
+  (export "fd_prestat_get"       (func $fd_prestat_get))
+  (export "fd_prestat_dir_name"  (func $fd_prestat_dir_name))
+  (export "args_get"             (func $args_get))
+  (export "args_sizes_get"       (func $args_sizes_get))
+  (export "environ_get"          (func $environ_get))
+  (export "environ_sizes_get"    (func $environ_sizes_get))
+  (export "clock_time_get"       (func $clock_time_get))
+  (export "clock_res_get"        (func $clock_res_get))
+  (export "random_get"           (func $random_get))
+
+  ;; Component-level run entry + canon-lower realloc helper.
+  (export "wasi:cli/run@0.2.6#run" (func $run))
+  (export "cabi_import_realloc"    (func $cabi_import_realloc))
+)

--- a/adapters/wasi-preview1/tools/build_adapter.zig
+++ b/adapters/wasi-preview1/tools/build_adapter.zig
@@ -1,0 +1,104 @@
+//! `build_adapter` — assemble the wasi-preview1 → preview2 adapter
+//! artifact from the WAT source.
+//!
+//! Driven by `zig build adapter`. CLI:
+//!
+//!     build-wasi-preview1-adapter <adapter.wat> <output.wasm>
+//!
+//! Pipeline (current scaffold):
+//!
+//!   1. Read the WAT source file.
+//!   2. Parse + validate via `wabt.text.Parser.parseModule` +
+//!      `wabt.Validator.validate` (same path as `wabt text parse`).
+//!   3. Serialise via `wabt.binary.writer.writeModule`.
+//!   4. Write the bytes to the output path.
+//!
+//! Deferred (tracked as separate follow-ups under cataggar/wamr#453):
+//!
+//!   * Step 5 — append a `component-type:wabt:0.0.0:wasi:cli@0.2.6:
+//!     command:encoded world` custom section. Requires WIT-encoder
+//!     support for resource handles (the real `wasi:io/streams`
+//!     interface uses `[method]output-stream.…(borrow<output-stream>,
+//!     …)`); `metadata_encode.zig` currently rejects those with
+//!     `error.UnsupportedWitFeature`. Until that lands, the produced
+//!     `wasi_snapshot_preview1.command.wasm` is shape-only: parses +
+//!     validates as a core wasm module but is not yet consumable by
+//!     `wabt component new` (the splicer's `decode.zig` requires an
+//!     encoded-world payload). See `../README.md` § Status.
+//!
+//!   * Step 6 — replace the stub function bodies in
+//!     `../src/adapter.wat` with real preview1 → preview2 logic
+//!     (`fd_write` iterates iovecs and calls
+//!     `output-stream.blocking-write-and-flush`, `args_get` lowers
+//!     `wasi:cli/environment.get-arguments`, etc.).
+
+const std = @import("std");
+const wabt = @import("wabt");
+
+pub fn main(init: std.process.Init) !void {
+    const gpa = init.gpa;
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+
+    if (args.len != 3) {
+        std.debug.print(
+            "usage: {s} <adapter.wat> <output.wasm>\n",
+            .{if (args.len > 0) args[0] else "build-wasi-preview1-adapter"},
+        );
+        std.process.exit(2);
+    }
+    const in_path = args[1];
+    const out_path = args[2];
+
+    const cwd = std.Io.Dir.cwd();
+
+    const source = cwd.readFileAlloc(
+        init.io,
+        in_path,
+        gpa,
+        std.Io.Limit.limited(wabt.max_input_file_size),
+    ) catch |err| {
+        std.debug.print(
+            "build_adapter: cannot read '{s}': {any}\n",
+            .{ in_path, err },
+        );
+        std.process.exit(1);
+    };
+    defer gpa.free(source);
+
+    var module = wabt.text.Parser.parseModule(gpa, source) catch |err| {
+        std.debug.print(
+            "build_adapter: parse '{s}': {any}\n",
+            .{ in_path, err },
+        );
+        std.process.exit(1);
+    };
+    defer module.deinit();
+
+    wabt.Validator.validate(&module, .{}) catch |err| {
+        std.debug.print(
+            "build_adapter: validate '{s}': {any}\n",
+            .{ in_path, err },
+        );
+        std.process.exit(1);
+    };
+
+    const wasm = wabt.binary.writer.writeModule(gpa, &module) catch |err| {
+        std.debug.print(
+            "build_adapter: encode '{s}': {any}\n",
+            .{ in_path, err },
+        );
+        std.process.exit(1);
+    };
+    defer gpa.free(wasm);
+
+    cwd.writeFile(init.io, .{
+        .sub_path = out_path,
+        .data = wasm,
+    }) catch |err| {
+        std.debug.print(
+            "build_adapter: write '{s}': {any}\n",
+            .{ out_path, err },
+        );
+        std.process.exit(1);
+    };
+}

--- a/build.zig
+++ b/build.zig
@@ -78,6 +78,51 @@ pub fn build(b: *std.Build) void {
     wabt_exe.stack_size = 128 * 1024 * 1024; // 128 MB
     b.installArtifact(wabt_exe);
 
+    // ── wasi-preview1 → preview2 adapter ─────────────────────────────────
+    //
+    // Builds `zig-out/adapter/wasi_snapshot_preview1.command.wasm` from
+    // `adapters/wasi-preview1/src/adapter.wat` using the wabt library. See
+    // `adapters/wasi-preview1/README.md` for the surface coverage, the
+    // current scaffold status, and the roadmap up to the embedded-default
+    // adapter for `wabt component new` (tracked under cataggar/wamr#453).
+    {
+        const adapter_tool_mod = b.createModule(.{
+            .root_source_file = b.path("adapters/wasi-preview1/tools/build_adapter.zig"),
+            // Build the tool for the host so we can run it; the adapter
+            // artifact it emits is the wasm target itself.
+            .target = b.graph.host,
+            .optimize = optimize,
+            .strip = if (strip) true else null,
+            .stack_protector = if (stack_protector) true else null,
+            .link_libc = if (link_libc) true else null,
+            .imports = &.{
+                .{ .name = "wabt", .module = wabt_mod },
+            },
+        });
+        const adapter_tool_exe = b.addExecutable(.{
+            .name = "build-wasi-preview1-adapter",
+            .root_module = adapter_tool_mod,
+        });
+        adapter_tool_exe.stack_size = 128 * 1024 * 1024;
+
+        const run_adapter_tool = b.addRunArtifact(adapter_tool_exe);
+        run_adapter_tool.addFileArg(b.path("adapters/wasi-preview1/src/adapter.wat"));
+        const adapter_wasm = run_adapter_tool.addOutputFileArg(
+            "wasi_snapshot_preview1.command.wasm",
+        );
+
+        const adapter_install = b.addInstallFileWithDir(
+            adapter_wasm,
+            .prefix,
+            "adapter/wasi_snapshot_preview1.command.wasm",
+        );
+        const adapter_step = b.step(
+            "adapter",
+            "Build the wasi-preview1 → preview2 adapter (scaffold; see adapters/wasi-preview1/README.md)",
+        );
+        adapter_step.dependOn(&adapter_install.step);
+    }
+
     // wasm2wat-fuzz: buildable but NOT installed. Existing fuzz scripts
     // expect this exe to live somewhere reachable; keep it as an explicit
     // build step.


### PR DESCRIPTION
First step of the [cataggar/wamr#453](https://github.com/cataggar/wamr/issues/453) plan to ship a wabt-native, in-tree replacement for the external wasmtime `wasi_snapshot_preview1.command.wasm` adapter.

## What this PR delivers

A reviewable scaffold for the adapter, plus the `zig build adapter` pipeline that produces the artifact. Specifically:

- **`adapters/wasi-preview1/README.md`** — design doc covering the adapter's import / export shape, the initial preview1 surface cut, the decision to author the adapter in WAT (no Zig wit-bindgen), and the roadmap up to the embedded-default adapter in `wabt component new`.
- **`adapters/wasi-preview1/src/adapter.wat`** — hand-authored WAT source with all in-scope preview1 imports and the `wasi:cli/run@0.2.6#run` export. The function bodies are stubs today (most return ENOSYS=52); the only one that's fully wired is `proc_exit`, which canon-lowers `u32` → `u8` and calls `wasi:cli/exit@0.2.6.exit-with-code`. That's **the key win** over the wasmtime adapter, which routes through the lossy `exit(result<_,_>)` and collapses every non-zero `proc_exit(code)` to host exit code 1 — see wamr's `exit_code_sink` workaround stack at #447 / #448.
- **`adapters/wasi-preview1/tools/build_adapter.zig`** — small Zig tool driven by `zig build adapter` that uses the wabt library (`text.Parser.parseModule` + `Validator.validate` + `binary.writer.writeModule`) to emit the artifact.
- **`build.zig`** — wires the new `zig build adapter` step.

## What this PR does **not** yet deliver

This scaffold is intentionally minimal so it can be reviewed independently of the larger follow-up work.

1. The artifact is **shape-only**: it parses, validates as a core wasm module and has the right imports/exports, but it lacks the `component-type:…:command:encoded world` custom section that `src/component/adapter/decode.zig` requires. Appending that section is gated on `metadata_encode.zig` learning to encode **resource handles** (the real `wasi:io/streams` interface uses `[method]output-stream.…(borrow<output-stream>, …)`). This is the biggest follow-up — likely a separate PR.
2. The stub function bodies need to be replaced with real preview1 → preview2 semantics (`fd_write` iterates the iovec list and calls `output-stream.blocking-write-and-flush`, `args_get` lowers `wasi:cli/environment.get-arguments`, etc.).
3. The artifact needs to be `@embedFile`d into the wabt CLI and wired as the default `--adapt` source in `src/tools/component_new.zig` when the embed declares preview1 imports.

## Verification

```console
$ zig build adapter
$ ls zig-out/adapter/
wasi_snapshot_preview1.command.wasm   # 1105 bytes
$ ./zig-out/bin/wabt module validate zig-out/adapter/wasi_snapshot_preview1.command.wasm
# (exit 0)
$ zig build test
# all pre-existing tests still pass; the one pre-existing failure
# (UnexpectedToken in a fuzz fixture) is on origin/main and unrelated
```

## Why hand-authored WAT?

The wasmtime adapter is Rust source compiled through `wit-bindgen`, which generates ~190 KiB of canon-lower binding glue. We have no Zig-side `wit-bindgen` equivalent today, and the preview1 surface we actually need is small. Hand-authored WAT keeps the adapter small, reviewable line-by-line, and pinned to wabt's existing parse + write infrastructure — no new dependency.

Refs cataggar/wamr#453.