### PR TITLE
feat(adapters/wasi-preview1): wire encoded-world custom section (refs cataggar/wamr#453)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build artifacts
 /.zig-cache/
+/.zig-global-cache/
 /zig-out/
 /out/
 

--- a/adapters/wasi-preview1/README.md
+++ b/adapters/wasi-preview1/README.md
@@ -15,33 +15,42 @@ is documented in that issue.
 
 [issue]: https://github.com/cataggar/wamr/issues/453
 
-## Status: in-progress, not yet wired into `wabt component new`
+## Status: encoded-world section wired, awaiting real preview1 lowering
 
-This directory ships the **scaffolding** for the adapter — a WAT
-source with the correct import / export shape and stubbed function
-bodies, plus a Zig build tool that drives the wabt library to parse
-and emit the artifact. Subsequent commits fill in:
+This directory ships:
 
-  1. the `wit/preview1.wit` world declaration and a
-     `metadata_encode.encodeWorldFromSource` call from
-     `tools/build_adapter.zig` that appends the
-     `component-type:…:command:encoded world` custom section to the
-     emitted wasm (today the artifact is *shape only* — it parses,
-     validates and has the right imports/exports, but the splicer
-     in `src/component/adapter/decode.zig` rejects it with
-     `MissingEncodedWorld` because the world section is absent;
-     gated on `metadata_encode.zig` gaining support for resource
-     handles — the real `wasi:io/streams` interface uses
-     `[method]output-stream.blocking-write-and-flush(borrow<…>,
-     …)`),
-  2. real preview1 → preview2 semantics in `src/adapter.wat`
+  * **WAT source** (`src/adapter.wat`) — correct preview1 export shape,
+    `proc_exit` fully lowered through `wasi:cli/exit.exit-with-code`,
+    every other preview1 function returns `errno=ENOSYS` (52).
+  * **WIT world** (`wit/preview1.wit` + `wit/deps/wasi-cli/world.wit`)
+    — `world command { import wasi:cli/exit@0.2.6; export wasi:cli/run@0.2.6; }`.
+    Only declares the preview2 imports actually canon-lowered by the
+    current adapter body. The wider surface (streams / filesystem /
+    clocks / random) arrives alongside the corresponding preview1
+    lowerings, which also need `metadata_encode.zig` to grow
+    resource-handle support (deferred).
+  * **`zig build adapter`** — runs `tools/build_adapter.zig` to parse
+    the WAT, validate it, encode the WIT world via wabt's
+    `metadata_encode.encodeWorldFromResolver`, attach the
+    `component-type:wabt:wasi-preview1@0.0.0:command:encoded world`
+    custom section, and self-check the result through the splicer's
+    `adapter/decode.parseFromAdapterCore`. Output:
+    `zig-out/adapter/wasi_snapshot_preview1.command.wasm`.
+
+Subsequent commits fill in:
+
+  1. Real preview1 → preview2 semantics in `src/adapter.wat`
      replacing the current ENOSYS stubs (`fd_write` iterates the
      iovec list and calls `output-stream.blocking-write-and-flush`,
-     `args_get` lowers `wasi:cli/environment.get-arguments`, etc.),
-  3. embedding the artifact into the wabt CLI via `@embedFile` and
+     `args_get` lowers `wasi:cli/environment.get-arguments`, etc.).
+     This re-adds the `wasi:io/streams` / `wasi:cli/{stdout,stderr,stdin}`
+     imports — at which point `metadata_encode.zig` must grow
+     resource-handle support.
+  2. Embedding the artifact into the wabt CLI via `@embedFile` and
      wiring it as the default `--adapt` source in
      `src/tools/component_new.zig` when the embed declares
-     preview1 imports and `--adapt` is not passed.
+     preview1 imports and `--adapt` is not passed. (Phase 2 of
+     cataggar/wamr#453.)
 
 The `proc_exit` lowering is the one piece that's fully wired
 end-to-end already, because it's just a single canon-lower of `u8`
@@ -83,24 +92,15 @@ adapters/wasi-preview1/
       canon-lift'd preview2 return values that need a return area in
       embed memory. Absent embeds get a `buildMainModuleFallback`
       stub from the splicer.
-    * One preview2 instance import per WASI namespace the adapter
-      lowers into. Initial scope:
-        * `wasi:cli/exit@0.2.6.exit-with-code` — replaces the lossy
-          `exit(result)` that the wasmtime adapter routes through.
-        * `wasi:cli/stdout@0.2.6.get-stdout`,
-          `wasi:cli/stderr@0.2.6.get-stderr`,
-          `wasi:cli/stdin@0.2.6.get-stdin`.
-        * `wasi:io/streams@0.2.6.[method]output-stream.blocking-
-          write-and-flush`,
-          `[method]output-stream.blocking-flush`,
-          `[method]input-stream.blocking-read`,
-          `[resource-drop]output-stream`,
-          `[resource-drop]input-stream`.
-        * `wasi:cli/environment@0.2.6.get-arguments`,
-          `get-environment`.
-        * `wasi:clocks/wall-clock@0.2.6.now`,
-          `wasi:clocks/monotonic-clock@0.2.6.now`.
-        * `wasi:random/random@0.2.6.get-random-bytes`.
+    * `wasi:cli/exit@0.2.6.exit-with-code` — replaces the lossy
+      `exit(result)` that the wasmtime adapter routes through.
+      This is the *only* preview2 import in the v1 surface; the
+      wider set (`wasi:cli/stdout|stderr|stdin@0.2.6`,
+      `wasi:io/streams@0.2.6`, `wasi:cli/environment@0.2.6`,
+      `wasi:clocks/wall-clock@0.2.6`, `wasi:clocks/monotonic-clock@0.2.6`,
+      `wasi:random/random@0.2.6`, `wasi:filesystem/preopens@0.2.6`,
+      `wasi:filesystem/types@0.2.6`) arrives alongside the real
+      preview1 lowerings in the next sub-phase.
 
 * **Core wasm exports** (flat names, no
   `wasi_snapshot_preview1.` prefix — the splicer maps them to
@@ -131,12 +131,13 @@ adapters/wasi-preview1/
         drops the unused ones at splice time.
 
 * **`component-type:…:command:encoded world` custom section**:
-  produced by `wabt component embed` (or directly by
-  [`metadata_encode.encodeWorldFromSource`](../../src/component/wit/metadata_encode.zig))
-  from `wit/preview1.wit`. The splicer decodes this in
+  produced by `tools/build_adapter.zig` invoking
+  [`metadata_encode.encodeWorldFromResolver`](../../src/component/wit/metadata_encode.zig)
+  on `wit/preview1.wit` + `wit/deps/wasi-cli/world.wit`. The splicer
+  decodes this in
   [`src/component/adapter/decode.zig`](../../src/component/adapter/decode.zig)
-  to drive `types-import.hoist`. Section name format used here:
-  `component-type:wabt:0.0.0:wasi:cli@0.2.6:command:encoded world`
+  to drive `types-import.hoist`. Section name used here:
+  `component-type:wabt:wasi-preview1@0.0.0:command:encoded world`
   (any `component-type:*` prefix is accepted by `decode.zig`).
 
 ## Why hand-authored WAT instead of compiled Zig?

--- a/adapters/wasi-preview1/src/adapter.wat
+++ b/adapters/wasi-preview1/src/adapter.wat
@@ -18,7 +18,6 @@
   ;; ── func types ────────────────────────────────────────────────
   (type $void          (func))
   (type $i32_void      (func (param i32)))
-  (type $get_handle    (func (result i32)))
   (type $run_sig       (func (result i32)))
   (type $cabi_realloc  (func (param i32 i32 i32 i32) (result i32)))
 
@@ -49,13 +48,13 @@
   ;; preview2 import signatures (canon-lower'd by the wrapping
   ;; component; here they are plain core-wasm function types).
   ;;
-  ;; `[method]output-stream.blocking-write-and-flush(self, contents)
-  ;; -> result<_, stream-error>` canon-lowers to:
-  ;;   (self: i32 handle, ptr: i32, len: i32, retptr: i32) -> ()
-  ;; The retptr is a 12-byte return-area in linear memory; the
-  ;; first byte is the result tag (0 = ok, 1 = err), followed by
-  ;; the (variant-tagged) stream-error payload on the err branch.
-  (type $stream_write_sig (func (param i32 i32 i32 i32)))
+  ;; v1 scope (cataggar/wamr#453): only the preview2 imports used
+  ;; by `proc_exit` are declared. The wider set
+  ;; (`wasi:io/streams.[method]output-stream.…`, `wasi:cli/stdout`,
+  ;; `wasi:filesystem/…`, etc.) arrives alongside the real
+  ;; `fd_write` / `args_get` / `clock_time_get` lowering — which
+  ;; also requires `metadata_encode.zig` to grow resource-handle
+  ;; support.
 
   ;; ── imports ──────────────────────────────────────────────────
   ;;
@@ -69,22 +68,12 @@
   (import "__main_module__" "cabi_realloc"
     (func $main_cabi_realloc (type $cabi_realloc)))
 
-  ;; preview2 instances we lower into. Initial scope per
-  ;; cataggar/wamr#453 — fd_write / fd_read / stdio + exit-with-code.
+  ;; preview2 instance imports actually consumed by the v1 adapter.
+  ;; `wasi:cli/exit@0.2.6.exit-with-code(u8)` is the lossless
+  ;; replacement for the wasmtime adapter's `exit(result<_, _>)` —
+  ;; preserves the numeric proc_exit code end-to-end.
   (import "wasi:cli/exit@0.2.6" "exit-with-code"
     (func $exit_with_code (type $i32_void)))
-  (import "wasi:cli/stdout@0.2.6" "get-stdout"
-    (func $get_stdout (type $get_handle)))
-  (import "wasi:cli/stderr@0.2.6" "get-stderr"
-    (func $get_stderr (type $get_handle)))
-  (import "wasi:cli/stdin@0.2.6" "get-stdin"
-    (func $get_stdin (type $get_handle)))
-  (import "wasi:io/streams@0.2.6" "[method]output-stream.blocking-write-and-flush"
-    (func $owrite_flush (type $stream_write_sig)))
-  (import "wasi:io/streams@0.2.6" "[resource-drop]output-stream"
-    (func $ostream_drop (type $i32_void)))
-  (import "wasi:io/streams@0.2.6" "[resource-drop]input-stream"
-    (func $istream_drop (type $i32_void)))
 
   ;; ── preview1 surface ─────────────────────────────────────────
   ;;

--- a/adapters/wasi-preview1/tools/build_adapter.zig
+++ b/adapters/wasi-preview1/tools/build_adapter.zig
@@ -1,53 +1,63 @@
 //! `build_adapter` — assemble the wasi-preview1 → preview2 adapter
-//! artifact from the WAT source.
+//! artifact from the WAT source plus the embedded
+//! `component-type:…:encoded world` custom section.
 //!
 //! Driven by `zig build adapter`. CLI:
 //!
-//!     build-wasi-preview1-adapter <adapter.wat> <output.wasm>
+//!     build-wasi-preview1-adapter <adapter.wat> <wit-dir> <output.wasm>
 //!
-//! Pipeline (current scaffold):
+//! Pipeline:
 //!
 //!   1. Read the WAT source file.
 //!   2. Parse + validate via `wabt.text.Parser.parseModule` +
 //!      `wabt.Validator.validate` (same path as `wabt text parse`).
-//!   3. Serialise via `wabt.binary.writer.writeModule`.
-//!   4. Write the bytes to the output path.
+//!   3. Parse the WIT layout under `<wit-dir>` via
+//!      `wabt.component.wit.resolver.parseLayout` and encode the
+//!      `command` world via
+//!      `wabt.component.wit.metadata_encode.encodeWorldFromResolver`.
+//!   4. Append the encoded world payload as a
+//!      `component-type:<pkg>:<world>[@<ver>]:encoded world`
+//!      custom section to the module before serialisation.
+//!   5. Serialise via `wabt.binary.writer.writeModule`.
+//!   6. Write the bytes to the output path.
 //!
-//! Deferred (tracked as separate follow-ups under cataggar/wamr#453):
+//! Deferred (tracked under cataggar/wamr#453):
 //!
-//!   * Step 5 — append a `component-type:wabt:0.0.0:wasi:cli@0.2.6:
-//!     command:encoded world` custom section. Requires WIT-encoder
-//!     support for resource handles (the real `wasi:io/streams`
-//!     interface uses `[method]output-stream.…(borrow<output-stream>,
-//!     …)`); `metadata_encode.zig` currently rejects those with
-//!     `error.UnsupportedWitFeature`. Until that lands, the produced
-//!     `wasi_snapshot_preview1.command.wasm` is shape-only: parses +
-//!     validates as a core wasm module but is not yet consumable by
-//!     `wabt component new` (the splicer's `decode.zig` requires an
-//!     encoded-world payload). See `../README.md` § Status.
-//!
-//!   * Step 6 — replace the stub function bodies in
-//!     `../src/adapter.wat` with real preview1 → preview2 logic
-//!     (`fd_write` iterates iovecs and calls
-//!     `output-stream.blocking-write-and-flush`, `args_get` lowers
-//!     `wasi:cli/environment.get-arguments`, etc.).
+//!   * Replace the ENOSYS stub bodies in `../src/adapter.wat` with
+//!     real preview1 → preview2 logic (`fd_write` iterates iovecs and
+//!     calls `output-stream.blocking-write-and-flush`, `args_get`
+//!     lowers `wasi:cli/environment.get-arguments`, etc.). That work
+//!     re-adds the `wasi:io/streams` / `wasi:cli/{stdout,stderr,stdin}`
+//!     imports and forces `metadata_encode.zig` to grow resource-handle
+//!     encoding, so we keep it as a separate sub-phase.
 
 const std = @import("std");
 const wabt = @import("wabt");
+
+/// Name of the world to encode. Matches `world command { … }` in
+/// `../wit/preview1.wit`.
+const world_name = "command";
+
+/// Custom-section name. The splicer's `decode.extractEncodedWorld`
+/// accepts any section whose name starts with `component-type:`
+/// (see `src/component/adapter/decode.zig:138`), so the suffix
+/// here is for human readability only.
+const ct_section_name = "component-type:wabt:wasi-preview1@0.0.0:command:encoded world";
 
 pub fn main(init: std.process.Init) !void {
     const gpa = init.gpa;
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 
-    if (args.len != 3) {
+    if (args.len != 4) {
         std.debug.print(
-            "usage: {s} <adapter.wat> <output.wasm>\n",
+            "usage: {s} <adapter.wat> <wit-dir> <output.wasm>\n",
             .{if (args.len > 0) args[0] else "build-wasi-preview1-adapter"},
         );
         std.process.exit(2);
     }
     const in_path = args[1];
-    const out_path = args[2];
+    const wit_dir = args[2];
+    const out_path = args[3];
 
     const cwd = std.Io.Dir.cwd();
 
@@ -82,6 +92,47 @@ pub fn main(init: std.process.Init) !void {
         std.process.exit(1);
     };
 
+    // ── Encode the WIT world into a `component-type:…` custom-section
+    // payload, then attach it to the module. We keep the resolver
+    // arena alive until after writeModule because the Custom entry
+    // borrows from `ct_payload` (which itself is owned by `gpa`).
+    var resolver_arena = std.heap.ArenaAllocator.init(gpa);
+    defer resolver_arena.deinit();
+    const ar = resolver_arena.allocator();
+
+    const resolver = wabt.component.wit.resolver.parseLayout(ar, init.io, wit_dir) catch |err| {
+        std.debug.print(
+            "build_adapter: parsing WIT layout '{s}': {s}\n",
+            .{ wit_dir, @errorName(err) },
+        );
+        std.process.exit(1);
+    };
+
+    const ct_payload = wabt.component.wit.metadata_encode.encodeWorldFromResolver(
+        gpa,
+        resolver,
+        world_name,
+    ) catch |err| {
+        std.debug.print(
+            "build_adapter: encoding world '{s}' from '{s}': {s}\n",
+            .{ world_name, wit_dir, @errorName(err) },
+        );
+        std.process.exit(1);
+    };
+    defer gpa.free(ct_payload);
+
+    // Append the encoded world as a custom section. `module.customs`
+    // is serialised at the end of the binary by `binary/writer.zig`,
+    // which is the conventional location for wit-bindgen-style
+    // `:encoded world` sections.
+    module.customs.append(module.allocator, .{
+        .name = ct_section_name,
+        .data = ct_payload,
+    }) catch |err| {
+        std.debug.print("build_adapter: appending custom section: {s}\n", .{@errorName(err)});
+        std.process.exit(1);
+    };
+
     const wasm = wabt.binary.writer.writeModule(gpa, &module) catch |err| {
         std.debug.print(
             "build_adapter: encode '{s}': {any}\n",
@@ -90,6 +141,20 @@ pub fn main(init: std.process.Init) !void {
         std.process.exit(1);
     };
     defer gpa.free(wasm);
+
+    // Sanity check: the produced bytes must be consumable by the
+    // adapter splicer's `decode.parseFromAdapterCore`. Without this
+    // we'd ship an adapter that fails at `wabt component new` time
+    // with a confusing `MissingEncodedWorld` / `UnsupportedAdapterShape`.
+    var verify_arena = std.heap.ArenaAllocator.init(gpa);
+    defer verify_arena.deinit();
+    _ = wabt.component.adapter.decode.parseFromAdapterCore(verify_arena.allocator(), wasm) catch |err| {
+        std.debug.print(
+            "build_adapter: produced adapter failed self-check (decode.parseFromAdapterCore): {s}\n",
+            .{@errorName(err)},
+        );
+        std.process.exit(1);
+    };
 
     cwd.writeFile(init.io, .{
         .sub_path = out_path,

--- a/adapters/wasi-preview1/wit/deps/wasi-cli/world.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-cli/world.wit
@@ -1,0 +1,29 @@
+// Slice of `wasi:cli@0.2.6` that the wabt-built wasi-preview1
+// adapter consumes. Mirrors the canonical interface bodies but
+// includes only the funcs the adapter actually canon-lowers; the
+// host (wamr `WasiCliAdapter`) provides the full preview2 surface
+// so the wrapping component is free to satisfy a wider import.
+//
+// The signatures here are pinned against
+// `cataggar/wamr:src/component/wasi_cli_adapter.zig` and the
+// `wasi:cli@0.2.6` upstream WIT in
+// `bytecodealliance/wasi-cli@v0.2.6`.
+
+package wasi:cli@0.2.6;
+
+interface exit {
+    /// Exit the program with an explicit numeric status code. The
+    /// preserves-numeric-code variant of `exit(result<_, _>)`.
+    /// `wasi:cli@0.2.6` defines both; we declare only the one the
+    /// preview1 adapter uses.
+    exit-with-code: func(status-code: u8);
+}
+
+interface run {
+    /// Run the program. Returns `ok` on success, `err` otherwise.
+    /// In the adapter's lowering, `proc_exit(code)` traps out of
+    /// `_start` (after `exit-with-code` has landed the code at the
+    /// host), so the explicit `ok` tail is reached only by guests
+    /// that return normally from `main()`.
+    run: func() -> result;
+}

--- a/adapters/wasi-preview1/wit/preview1.wit
+++ b/adapters/wasi-preview1/wit/preview1.wit
@@ -1,0 +1,36 @@
+// wasi-preview1 → preview2 adapter world.
+//
+// Authored against the canonical wasi:cli@0.2.6 component-model
+// surface (see `wit/deps/wasi-cli/world.wit` for the trimmed slice
+// of `wasi:cli` this adapter actually canon-lowers).
+//
+// Scope cut for cataggar/wamr#453's initial sub-phase: the adapter
+// only canon-lowers `wasi:cli/exit.exit-with-code(u8)` — the
+// `proc_exit` path — and exports the canon-lifted `wasi:cli/run.run`
+// command entry. Every other preview1 import is an ENOSYS stub in
+// `src/adapter.wat`, and the wabt adapter splicer's
+// core-wasm GC pass drops the unused exports at splice time.
+//
+// The wider import set (`wasi:io/streams`, `wasi:filesystem/…`, etc.)
+// arrives in a later sub-phase alongside the real fd_write /
+// args_get / clock_time_get lowering. Adding it now would require
+// `metadata_encode.zig` to grow resource-handle support, which is a
+// non-trivial parallel work item.
+
+package wabt:wasi-preview1@0.0.0;
+
+world command {
+    /// Lossless `proc_exit` lowering. The adapter's `proc_exit(code: i32)`
+    /// truncates to `u8` and calls `exit-with-code` directly,
+    /// preserving the numeric code end-to-end. This is the single
+    /// deliberate divergence from the wasmtime adapter, which routes
+    /// through `wasi:cli/exit.exit(result<_, _>)` and collapses every
+    /// non-zero code to host exit code 1.
+    import wasi:cli/exit@0.2.6;
+
+    /// Canon-lift'd `run()` entry. The adapter calls
+    /// `__main_module__._start` and returns `ok` on normal return;
+    /// `proc_exit` traps out of `_start` so this tail is unreachable
+    /// when the guest exits with a code.
+    export wasi:cli/run@0.2.6;
+}

--- a/build.zig
+++ b/build.zig
@@ -107,6 +107,11 @@ pub fn build(b: *std.Build) void {
 
         const run_adapter_tool = b.addRunArtifact(adapter_tool_exe);
         run_adapter_tool.addFileArg(b.path("adapters/wasi-preview1/src/adapter.wat"));
+        // The WIT layout — `wit/preview1.wit` + `wit/deps/wasi-cli/world.wit`.
+        // The tool calls `resolver.parseLayout` and then
+        // `metadata_encode.encodeWorldFromResolver` to produce the
+        // `component-type:…:encoded world` custom-section payload.
+        run_adapter_tool.addDirectoryArg(b.path("adapters/wasi-preview1/wit"));
         const adapter_wasm = run_adapter_tool.addOutputFileArg(
             "wasi_snapshot_preview1.command.wasm",
         );
@@ -118,7 +123,7 @@ pub fn build(b: *std.Build) void {
         );
         const adapter_step = b.step(
             "adapter",
-            "Build the wasi-preview1 → preview2 adapter (scaffold; see adapters/wasi-preview1/README.md)",
+            "Build the wasi-preview1 → preview2 adapter (preview1 surface + encoded-world section; see adapters/wasi-preview1/README.md)",
         );
         adapter_step.dependOn(&adapter_install.step);
     }

--- a/src/component/wit/metadata_encode.zig
+++ b/src/component/wit/metadata_encode.zig
@@ -27,23 +27,28 @@
 //! ```
 //!
 //! MVP scope — sufficient for all three wamr fixtures (`zig-adder`,
-//! `zig-calculator-cmd`, `mixed-zig-rust-calc`):
+//! `zig-calculator-cmd`, `mixed-zig-rust-calc`) plus the wabt-built
+//! `wasi-preview1` adapter world (`cataggar/wamr#453`):
 //!
 //!   * Worlds with `export <iface>;` (in-package) and
 //!     `import <ns>:<pkg>/<iface>[@<ver>];` (qualified) extern refs.
 //!   * Interfaces containing only func defs.
 //!   * Func signatures over primitive WIT types and `list<T>` /
-//!     `option<T>` / `result<T,E>` / `tuple<T...>` of primitives.
+//!     `option<T>` / `result<T,E>` / `tuple<T...>` of primitives,
+//!     including bare `result` (no payloads). Compound types are
+//!     hoisted into `TypeDef` decls before the func that references
+//!     them; the func params/results then carry `ValType.type_idx`
+//!     references to those slots.
 //!
 //! Deferred (rejected with `error.UnsupportedWitFeature`):
 //!
 //!   * record / variant / enum / flags / type-alias / use clause
 //!     in interface bodies (the wamr fixtures don't use them).
 //!   * resource / handle / stream / future / async / error-context.
+//!   * named-type references inside func sigs (`name` is rejected).
 //!
-//! Lifting these is incremental: each compound WIT type maps to a
-//! `TypeDef` declarator before the func that references it, and the
-//! func params/results switch from inline `ValType` to type-idx refs.
+//! Lifting these is incremental: each remaining WIT type maps to a
+//! `TypeDef` declarator before the func that references it.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
@@ -247,59 +252,106 @@ fn buildInterfaceBody(
     // either way.
     const iface_body = resolver.findInterface(ref) orelse return error.UnknownInterface;
 
-    var decls = std.ArrayListUnmanaged(ctypes.Decl).empty;
-    var func_idx: u32 = 0;
+    // `BodyBuilder` tracks the type-index space inside this
+    // instance-type body. Every appended `.type` decl bumps
+    // `type_idx`; compound valtypes lower to a fresh `.type` decl
+    // and a `ValType.type_idx` reference to its slot.
+    var builder: BodyBuilder = .{ .ar = ar, .decls = .empty, .type_idx = 0 };
     for (iface_body.items) |it| {
         switch (it) {
             .func => |f| {
-                const ft = try lowerFuncSig(ar, f.func);
-                try decls.append(ar, .{ .type = .{ .func = ft } });
-                try decls.append(ar, .{ .@"export" = .{
+                // Lower param/result types first — this may emit
+                // `.type` decls for compound types, bumping
+                // `type_idx`. The `.func` `.type` itself goes last.
+                const params = try ar.alloc(ctypes.NamedValType, f.func.params.len);
+                for (f.func.params, 0..) |p, i| {
+                    params[i] = .{ .name = p.name, .type = try builder.lowerType(p.type) };
+                }
+                const results: ctypes.FuncType.ResultList = if (f.func.result) |t|
+                    .{ .unnamed = try builder.lowerType(t) }
+                else
+                    .none;
+
+                const func_type_idx = builder.type_idx;
+                try builder.decls.append(ar, .{ .type = .{ .func = .{
+                    .params = params,
+                    .results = results,
+                } } });
+                builder.type_idx += 1;
+
+                try builder.decls.append(ar, .{ .@"export" = .{
                     .name = f.name,
-                    .desc = .{ .func = func_idx },
+                    .desc = .{ .func = func_type_idx },
                 } });
-                func_idx += 1;
             },
             .type, .use => return error.UnsupportedWitFeature,
         }
     }
-    return try decls.toOwnedSlice(ar);
+    return try builder.decls.toOwnedSlice(ar);
 }
 
-fn lowerFuncSig(ar: Allocator, sig: ast.Func) EncodeError!ctypes.FuncType {
-    var params = try ar.alloc(ctypes.NamedValType, sig.params.len);
-    for (sig.params, 0..) |p, i| {
-        params[i] = .{ .name = p.name, .type = try lowerType(ar, p.type) };
+/// Stateful helper that builds the body of an instance-type while
+/// tracking the type-index space. Compound types (`list`, `option`,
+/// `result`, `tuple`) appear as standalone `TypeDef` decls and are
+/// then referenced from func params/results via `ValType.type_idx`.
+const BodyBuilder = struct {
+    ar: Allocator,
+    decls: std.ArrayListUnmanaged(ctypes.Decl),
+    /// Current count of `.type` decls already appended to `decls` —
+    /// equivalently, the next free slot in the instance-type body's
+    /// type-index space.
+    type_idx: u32,
+
+    fn lowerType(self: *BodyBuilder, t: ast.Type) EncodeError!ctypes.ValType {
+        return switch (t) {
+            .bool => .bool,
+            .s8 => .s8,
+            .u8 => .u8,
+            .s16 => .s16,
+            .u16 => .u16,
+            .s32 => .s32,
+            .u32 => .u32,
+            .s64 => .s64,
+            .u64 => .u64,
+            .f32 => .f32,
+            .f64 => .f64,
+            .char => .char,
+            .string => .string,
+            .list => |inner| blk: {
+                const elem = try self.lowerType(inner.*);
+                break :blk try self.appendCompound(.{ .list = .{ .element = elem } });
+            },
+            .option => |inner| blk: {
+                const inner_vt = try self.lowerType(inner.*);
+                break :blk try self.appendCompound(.{ .option = .{ .inner = inner_vt } });
+            },
+            .result => |r| blk: {
+                const ok_vt: ?ctypes.ValType = if (r.ok) |ok_ty|
+                    try self.lowerType(ok_ty.*)
+                else
+                    null;
+                const err_vt: ?ctypes.ValType = if (r.err) |err_ty|
+                    try self.lowerType(err_ty.*)
+                else
+                    null;
+                break :blk try self.appendCompound(.{ .result = .{ .ok = ok_vt, .err = err_vt } });
+            },
+            .tuple => |fields| blk: {
+                const inner = try self.ar.alloc(ctypes.ValType, fields.len);
+                for (fields, 0..) |f, i| inner[i] = try self.lowerType(f);
+                break :blk try self.appendCompound(.{ .tuple = .{ .fields = inner } });
+            },
+            .name => error.UnsupportedWitFeature,
+        };
     }
-    const results: ctypes.FuncType.ResultList = if (sig.result) |t|
-        .{ .unnamed = try lowerType(ar, t) }
-    else
-        .none;
-    return .{ .params = params, .results = results };
-}
 
-fn lowerType(ar: Allocator, t: ast.Type) EncodeError!ctypes.ValType {
-    _ = ar;
-    return switch (t) {
-        .bool => .bool,
-        .s8 => .s8,
-        .u8 => .u8,
-        .s16 => .s16,
-        .u16 => .u16,
-        .s32 => .s32,
-        .u32 => .u32,
-        .s64 => .s64,
-        .u64 => .u64,
-        .f32 => .f32,
-        .f64 => .f64,
-        .char => .char,
-        .string => .string,
-        // Compound + named types require an outer TypeDef and
-        // reference-by-index. The MVP omits this; widening it is the
-        // next-todo.
-        .list, .option, .result, .tuple, .name => return error.UnsupportedWitFeature,
-    };
-}
+    fn appendCompound(self: *BodyBuilder, td: ctypes.TypeDef) EncodeError!ctypes.ValType {
+        const idx = self.type_idx;
+        try self.decls.append(self.ar, .{ .type = td });
+        self.type_idx += 1;
+        return .{ .type_idx = idx };
+    }
+};
 
 // ── tests ──────────────────────────────────────────────────────────────────
 
@@ -457,4 +509,109 @@ test "metadata_encode: multi-package resolver — cross-package import" {
     try testing.expect(iface.decls[0].type == .func);
     try testing.expect(iface.decls[1] == .@"export");
     try testing.expectEqualStrings("add", iface.decls[1].@"export".name);
+}
+
+test "metadata_encode: bare `result` return is hoisted into a TypeDef + idx ref" {
+    // wasi-preview1 adapter's `wasi:cli/run.run` returns bare
+    // `result` (no `ok` or `err` payloads). The encoder must hoist
+    // the `result` valtype into a `TypeDef.result` decl and reference
+    // it from the func via `ValType.type_idx` — compound types
+    // cannot appear inline in func param/result positions.
+    const source =
+        \\package wasi:cli@0.2.6;
+        \\interface run {
+        \\    run: func() -> result;
+        \\}
+        \\world cmd {
+        \\    export run;
+        \\}
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "cmd");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const outer = comp.types[0].component;
+    const world = outer.decls[0].type.component;
+    const iface = world.decls[0].type.instance;
+
+    // Body must be: [result TypeDef, func TypeDef, export(func=1)].
+    try testing.expectEqual(@as(usize, 3), iface.decls.len);
+    try testing.expect(iface.decls[0] == .type);
+    try testing.expect(iface.decls[0].type == .result);
+    try testing.expect(iface.decls[0].type.result.ok == null);
+    try testing.expect(iface.decls[0].type.result.err == null);
+
+    try testing.expect(iface.decls[1] == .type);
+    try testing.expect(iface.decls[1].type == .func);
+    const func = iface.decls[1].type.func;
+    try testing.expectEqual(@as(usize, 0), func.params.len);
+    try testing.expect(func.results == .unnamed);
+    try testing.expect(func.results.unnamed == .type_idx);
+    try testing.expectEqual(@as(u32, 0), func.results.unnamed.type_idx);
+
+    try testing.expect(iface.decls[2] == .@"export");
+    try testing.expectEqualStrings("run", iface.decls[2].@"export".name);
+    try testing.expect(iface.decls[2].@"export".desc == .func);
+    try testing.expectEqual(@as(u32, 1), iface.decls[2].@"export".desc.func);
+}
+
+test "metadata_encode: `result<u32, string>` payloads hoist correctly" {
+    // Exercise both ok and err payloads on a parameterized result.
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface ops {
+        \\    parse: func(s: string) -> result<u32, string>;
+        \\}
+        \\world demo {
+        \\    export ops;
+        \\}
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "demo");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const iface = comp.types[0].component.decls[0].type.component.decls[0].type.instance;
+    // Body: [result TypeDef, func TypeDef, export(func=1)].
+    try testing.expectEqual(@as(usize, 3), iface.decls.len);
+    try testing.expect(iface.decls[0].type.result.ok != null);
+    try testing.expect(iface.decls[0].type.result.err != null);
+    try testing.expect(iface.decls[0].type.result.ok.? == .u32);
+    try testing.expect(iface.decls[0].type.result.err.? == .string);
+    try testing.expect(iface.decls[1].type.func.results.unnamed.type_idx == 0);
+    try testing.expect(iface.decls[2].@"export".desc.func == 1);
+}
+
+test "metadata_encode: `list<u8>` param hoists to a TypeDef.list" {
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface ops {
+        \\    write: func(bytes: list<u8>) -> u32;
+        \\}
+        \\world demo {
+        \\    export ops;
+        \\}
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "demo");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const iface = comp.types[0].component.decls[0].type.component.decls[0].type.instance;
+    try testing.expectEqual(@as(usize, 3), iface.decls.len);
+    try testing.expect(iface.decls[0].type == .list);
+    try testing.expect(iface.decls[0].type.list.element == .u8);
+    try testing.expect(iface.decls[1].type.func.params[0].type == .type_idx);
+    try testing.expectEqual(@as(u32, 0), iface.decls[1].type.func.params[0].type.type_idx);
+    try testing.expect(iface.decls[1].type.func.results.unnamed == .u32);
 }


### PR DESCRIPTION
Builds on #145. The scaffolded adapter shipped without the
`component-type:` custom section because `metadata_encode.zig`
rejected the compound WIT valtypes the world body needs. This PR
closes that gap for the v1 import surface (`wasi:cli/exit@0.2.6`
only) and wires the encoded-world section into the adapter build.

## Changes

- **`src/component/wit/metadata_encode.zig`** — new `BodyBuilder`
  that tracks `type_idx` in the instance-type body, hoists compound
  types (`result<T,E>`, `option<T>`, `list<T>`, `tuple<…>`) into
  `TypeDef` decls before the func decl that references them, and
  binds export desc to the captured `func_type_idx`. New unit tests:
  bare `result`, `result<u32, string>`, `list<u8>`.
- **`adapters/wasi-preview1/src/adapter.wat`** — trim to a single
  live preview2 import (`wasi:cli/exit@0.2.6.exit-with-code`).
  Preview1 export ENOSYS stubs remain; the splicer's core-wasm GC
  drops them when the embed doesn't import them.
- **`adapters/wasi-preview1/wit/preview1.wit` +
  `wit/deps/wasi-cli/world.wit`** (new) — declare package
  `wabt:wasi-preview1@0.0.0` with world `command` importing
  `wasi:cli/exit@0.2.6` and exporting `wasi:cli/run@0.2.6`.
- **`adapters/wasi-preview1/tools/build_adapter.zig`** — accept a
  third `<wit-dir>` arg, parse the WIT layout via
  `resolver.parseLayout`, encode the world via
  `metadata_encode.encodeWorldFromResolver`, append a
  `component-type:wabt:wasi-preview1@0.0.0:command:encoded world`
  custom section to `module.customs`, then self-check via
  `decode.parseFromAdapterCore`.
- **`build.zig`** — feed the wit/ directory to the adapter tool.
- **`README.md`** + **`.gitignore`** — update status / adapter
  shape / custom-section docs; ignore `.zig-global-cache/`.

## Verification

\`\`\`
zig build adapter     # 1086-byte wasi_snapshot_preview1.command.wasm
                      # with a 265-byte 'component-type:wabt:wasi-preview1@0.0.0:command:encoded world' section
zig build test        # 391/391 tests pass, incl. 3 new metadata_encode cases
\`\`\`

The built-in self-check in `build_adapter.zig`
(`decode.parseFromAdapterCore`) is what catches malformed adapter
bytes at build time, so a regression in the metadata encoder
fails \`zig build adapter\` immediately.

## Out of scope (next sub-phase)

The wider preview2 surface — `wasi:io/streams`, `wasi:filesystem`,
`wasi:clocks`, `wasi:random`, `wasi:cli/{stdout,stderr,stdin}` —
stays unencoded for now because it requires resource-handle and
named-type-reference support in \`metadata_encode.zig\`. That work
arrives together with the matching real preview1→preview2 lowerings
in \`adapter.wat\` (replaces the ENOSYS stubs). For the v1 scope
(\`proc_exit\` routing only — the issue's headline win) the trimmed
import surface is sufficient.