### PR TITLE
feat(wit): resources, handles, named refs, and compound typedefs in encoder

### DIFF
--- a/src/component/wit/ast.zig
+++ b/src/component/wit/ast.zig
@@ -51,6 +51,15 @@ pub const Type = union(enum) {
         err: ?*const Type,
     },
     tuple: []const Type,
+    /// `borrow<R>` handle type — R is a resource declared elsewhere
+    /// in scope. Resolved by the encoder when emitting the body.
+    borrow: []const u8,
+    /// `own<R>` handle type — explicit ownership transfer. Bare
+    /// references to a resource by name (`R` without `own<>` /
+    /// `borrow<>`) also lower to own-handles; the encoder is
+    /// responsible for that distinction based on the resolution of
+    /// `name`.
+    own: []const u8,
     /// Reference to a type defined elsewhere in the same scope by
     /// name. Resolved by `resolve.zig`.
     name: []const u8,
@@ -92,6 +101,29 @@ pub const TypeDefKind = union(enum) {
     @"enum": []const []const u8,
     /// `flags foo { read, write }`.
     flags: []const []const u8,
+    /// `resource foo { method-decls }`.
+    ///
+    /// The body lists methods, static methods, and an optional
+    /// constructor. The encoder synthesizes the canonical
+    /// `[method]R.M`, `[static]R.M`, `[constructor]R`, and
+    /// `[resource-drop]R` external names; the implicit
+    /// `self: borrow<R>` (methods) and `-> own<R>` (constructor)
+    /// are not present in the AST.
+    resource: []const ResourceMethod,
+};
+
+pub const ResourceMethodKind = enum {
+    method,
+    static,
+    constructor,
+};
+
+pub const ResourceMethod = struct {
+    docs: []const u8 = "",
+    kind: ResourceMethodKind,
+    /// Method-local name. Empty for `constructor`.
+    name: []const u8 = "",
+    func: Func,
 };
 
 pub const TypeDef = struct {

--- a/src/component/wit/metadata_encode.zig
+++ b/src/component/wit/metadata_encode.zig
@@ -42,16 +42,24 @@
 //!
 //! Deferred (rejected with `error.UnsupportedWitFeature`):
 //!
-//!   * `resource` decls and `own<R>` / `borrow<R>` handle types.
 //!   * `use` clauses (cross-interface type imports).
 //!   * stream / future / async / error-context.
 //!
-//! Supported: `type <name> = <Type>;` aliases, plus nominal typedefs
-//! (`record`, `variant`, `enum`, `flags`) — each emits one slot in
-//! the body's type-index space and is referenced from later funcs /
-//! aliases via `Type.name`. Compound RHSes (`list<T>`, `result<…>`,
-//! `tuple<…>`, `option<…>`) still hoist via `appendCompound`; named
-//! refs are resolved against `BodyBuilder.name_map`.
+//! Supported: `type <name> = <Type>;` aliases, nominal typedefs
+//! (`record`, `variant`, `enum`, `flags`), and `resource R { … }`
+//! decls with constructor / method / static members.
+//!
+//! Resource encoding follows the canonical wit-component shape: a
+//! `TypeDef.resource` decl is followed by an `exportname'` decl
+//! binding the resource's external name to that slot
+//! (`(type (eq <idx>))`). Members are emitted as ordinary func
+//! exports with their canonical-ABI names (`[constructor]R`,
+//! `[method]R.M`, `[static]R.M`); methods get an implicit
+//! `self: borrow<R>` prepended, constructors get `-> own<R>`
+//! appended. `[resource-drop]R` is *not* written into the encoded
+//! section — the consuming canon stage synthesizes it implicitly.
+//! `borrow<R>` / `own<R>` ValTypes resolve via the in-body
+//! `name_map` and lower directly to `ValType.borrow` / `own`.
 //!
 //! Lifting these is incremental: each remaining WIT type maps to a
 //! `TypeDef` declarator before the func that references it.
@@ -273,31 +281,7 @@ fn buildInterfaceBody(
     };
     for (iface_body.items) |it| {
         switch (it) {
-            .func => |f| {
-                // Lower param/result types first — this may emit
-                // `.type` decls for compound types, bumping
-                // `type_idx`. The `.func` `.type` itself goes last.
-                const params = try ar.alloc(ctypes.NamedValType, f.func.params.len);
-                for (f.func.params, 0..) |p, i| {
-                    params[i] = .{ .name = p.name, .type = try builder.lowerType(p.type) };
-                }
-                const results: ctypes.FuncType.ResultList = if (f.func.result) |t|
-                    .{ .unnamed = try builder.lowerType(t) }
-                else
-                    .none;
-
-                const func_type_idx = builder.type_idx;
-                try builder.decls.append(ar, .{ .type = .{ .func = .{
-                    .params = params,
-                    .results = results,
-                } } });
-                builder.type_idx += 1;
-
-                try builder.decls.append(ar, .{ .@"export" = .{
-                    .name = f.name,
-                    .desc = .{ .func = func_type_idx },
-                } });
-            },
+            .func => |f| try builder.emitFuncExport(f.name, f.func, null),
             .type => |td| switch (td.kind) {
                 .alias => |inner| {
                     const vt = try builder.lowerType(inner);
@@ -331,12 +315,71 @@ fn buildInterfaceBody(
                     const vt = try builder.appendCompound(.{ .flags = .{ .names = names } });
                     try builder.bindName(td.name, vt);
                 },
-                .resource => return error.UnsupportedWitFeature,
+                .resource => |methods| {
+                    // Resource decl: `TypeDef.resource { destructor: null }`
+                    // consumes one slot; the resource's external name is
+                    // then bound via an `exportname'` decl with a
+                    // `type (eq <idx>)` descriptor — matching the wire
+                    // shape wamr's loader test fixture at
+                    // `loader.zig:897` expects from canonical
+                    // wit-component output.
+                    const resource_idx = builder.type_idx;
+                    try builder.decls.append(ar, .{ .type = .{ .resource = .{ .destructor = null } } });
+                    builder.type_idx += 1;
+                    try builder.decls.append(ar, .{ .@"export" = .{
+                        .name = td.name,
+                        .desc = .{ .type = .{ .eq = resource_idx } },
+                    } });
+                    try builder.bindName(td.name, .{ .type_idx = resource_idx });
+
+                    // Methods / statics / constructors synthesize their
+                    // canonical-ABI external names (`[method]R.M`,
+                    // `[static]R.M`, `[constructor]R`) and the implicit
+                    // `self: borrow<R>` / `-> own<R>` insertions. The
+                    // `[resource-drop]R` intrinsic is *not* declared in
+                    // the encoded section — the consuming canon stage
+                    // synthesizes it implicitly for every resource.
+                    for (methods) |m| {
+                        const ext_name = try formatResourceMemberName(ar, m.kind, td.name, m.name);
+                        const self_param: ?ctypes.NamedValType = switch (m.kind) {
+                            .method => .{ .name = "self", .type = .{ .borrow = resource_idx } },
+                            .static, .constructor => null,
+                        };
+                        const constructor_result: ?ctypes.ValType = switch (m.kind) {
+                            .constructor => .{ .own = resource_idx },
+                            .method, .static => null,
+                        };
+                        try builder.emitFuncExport(
+                            ext_name,
+                            m.func,
+                            BodyBuilder.FuncInjection{
+                                .self_param = self_param,
+                                .forced_result = constructor_result,
+                            },
+                        );
+                    }
+                },
             },
             .use => return error.UnsupportedWitFeature,
         }
     }
     return try builder.decls.toOwnedSlice(ar);
+}
+
+/// Canonical-ABI external name for a resource member. Constructor
+/// uses just the resource name; method / static prefix the bracketed
+/// tag and qualify with `R.M`.
+fn formatResourceMemberName(
+    ar: Allocator,
+    kind: ast.ResourceMethodKind,
+    resource: []const u8,
+    member: []const u8,
+) ![]const u8 {
+    return switch (kind) {
+        .constructor => try std.fmt.allocPrint(ar, "[constructor]{s}", .{resource}),
+        .method => try std.fmt.allocPrint(ar, "[method]{s}.{s}", .{ resource, member }),
+        .static => try std.fmt.allocPrint(ar, "[static]{s}.{s}", .{ resource, member }),
+    };
 }
 
 /// Stateful helper that builds the body of an instance-type while
@@ -398,8 +441,74 @@ const BodyBuilder = struct {
                 break :blk try self.appendCompound(.{ .tuple = .{ .fields = inner } });
             },
             .name => |n| self.name_map.get(n) orelse error.InvalidWit,
-            .borrow, .own => error.UnsupportedWitFeature,
+            .borrow => |n| try self.handleValType(n, .borrow),
+            .own => |n| try self.handleValType(n, .own),
         };
+    }
+
+    /// Resolve `borrow<R>` / `own<R>` to a handle ValType. The named
+    /// resource must already be bound in `name_map`, and that
+    /// binding must be a `type_idx` — borrowing or owning a
+    /// non-resource named type (e.g. an alias to `u32`) is malformed.
+    fn handleValType(
+        self: *BodyBuilder,
+        resource_name: []const u8,
+        kind: enum { borrow, own },
+    ) EncodeError!ctypes.ValType {
+        const bound = self.name_map.get(resource_name) orelse return error.InvalidWit;
+        if (bound != .type_idx) return error.InvalidWit;
+        return switch (kind) {
+            .borrow => .{ .borrow = bound.type_idx },
+            .own => .{ .own = bound.type_idx },
+        };
+    }
+
+    /// Injection hooks for resource-method synthesis: `self_param`
+    /// is prepended to the canonical param list; `forced_result`
+    /// overrides any AST result (used for `-> own<R>` on
+    /// constructors).
+    const FuncInjection = struct {
+        self_param: ?ctypes.NamedValType = null,
+        forced_result: ?ctypes.ValType = null,
+    };
+
+    /// Lower an AST `Func` to a component-type `FuncType` and append
+    /// it to `decls`, then export it under `export_name`. When
+    /// `injection` is non-null, methods get an implicit
+    /// `self: borrow<R>` prepended and constructors get
+    /// `-> own<R>` appended.
+    fn emitFuncExport(
+        self: *BodyBuilder,
+        export_name: []const u8,
+        func: ast.Func,
+        injection: ?FuncInjection,
+    ) EncodeError!void {
+        const inj: FuncInjection = injection orelse .{};
+        const extra: usize = if (inj.self_param != null) 1 else 0;
+        const params = try self.ar.alloc(ctypes.NamedValType, func.params.len + extra);
+        if (inj.self_param) |sp| params[0] = sp;
+        for (func.params, 0..) |p, i| {
+            params[i + extra] = .{ .name = p.name, .type = try self.lowerType(p.type) };
+        }
+
+        const results: ctypes.FuncType.ResultList = if (inj.forced_result) |fr|
+            .{ .unnamed = fr }
+        else if (func.result) |t|
+            .{ .unnamed = try self.lowerType(t) }
+        else
+            .none;
+
+        const func_type_idx = self.type_idx;
+        try self.decls.append(self.ar, .{ .type = .{ .func = .{
+            .params = params,
+            .results = results,
+        } } });
+        self.type_idx += 1;
+
+        try self.decls.append(self.ar, .{ .@"export" = .{
+            .name = export_name,
+            .desc = .{ .func = func_type_idx },
+        } });
     }
 
     fn appendCompound(self: *BodyBuilder, td: ctypes.TypeDef) EncodeError!ctypes.ValType {
@@ -923,18 +1032,135 @@ test "metadata_encode: flags typedef" {
     try testing.expectEqual(@as(u32, 0), iface.decls[1].type.func.params[0].type.type_idx);
 }
 
-test "metadata_encode: still rejects resource and use clauses" {
-    // Chunks 4 / future will lift these. Until then, surface a clean
-    // `UnsupportedWitFeature` rather than silently mis-encoding.
-    const res =
+test "metadata_encode: resource with constructor + method + static" {
+    // Mirrors `wasi:io/streams.output-stream` style: a constructor, a
+    // method (gets implicit `self: borrow<R>`), and a static. The
+    // encoder must synthesize the canonical-ABI external names and
+    // the implicit `self` / `-> own<R>` insertions. The resource name
+    // is `output-stream` to mirror the canonical WIT identifier
+    // (kebab-case) rather than triggering a reserved `kw_stream`.
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface streams {
+        \\    resource output-stream {
+        \\        constructor(seed: u32);
+        \\        write: func(byte: u8) -> u32;
+        \\        check: static func() -> u32;
+        \\    }
+        \\}
+        \\world demo { export streams; }
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "demo");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const iface = comp.types[0].component.decls[0].type.component.decls[0].type.instance;
+    // Body shape:
+    //   0: TypeDef.resource
+    //   1: ExportDecl "output-stream" (type (eq 0))
+    //   2: TypeDef.func  (constructor: (seed:u32) -> own<0>)
+    //   3: ExportDecl "[constructor]output-stream" (func 2)
+    //   4: TypeDef.func  ([method]: (self:borrow<0>, byte:u8) -> u32)
+    //   5: ExportDecl "[method]output-stream.write" (func 4)
+    //   6: TypeDef.func  ([static]: () -> u32)
+    //   7: ExportDecl "[static]output-stream.check" (func 6)
+    try testing.expectEqual(@as(usize, 8), iface.decls.len);
+
+    // Resource decl + name binding.
+    try testing.expect(iface.decls[0].type == .resource);
+    try testing.expect(iface.decls[0].type.resource.destructor == null);
+    try testing.expect(iface.decls[1] == .@"export");
+    try testing.expectEqualStrings("output-stream", iface.decls[1].@"export".name);
+    try testing.expect(iface.decls[1].@"export".desc == .type);
+    try testing.expect(iface.decls[1].@"export".desc.type == .eq);
+    try testing.expectEqual(@as(u32, 0), iface.decls[1].@"export".desc.type.eq);
+
+    // Constructor: synthesized `-> own<0>` result, no implicit self.
+    try testing.expect(iface.decls[2].type == .func);
+    const ctor = iface.decls[2].type.func;
+    try testing.expectEqual(@as(usize, 1), ctor.params.len);
+    try testing.expectEqualStrings("seed", ctor.params[0].name);
+    try testing.expect(ctor.params[0].type == .u32);
+    try testing.expect(ctor.results == .unnamed);
+    try testing.expect(ctor.results.unnamed == .own);
+    try testing.expectEqual(@as(u32, 0), ctor.results.unnamed.own);
+    try testing.expectEqualStrings("[constructor]output-stream", iface.decls[3].@"export".name);
+
+    // Method: implicit `self: borrow<0>` prepended.
+    try testing.expect(iface.decls[4].type == .func);
+    const method = iface.decls[4].type.func;
+    try testing.expectEqual(@as(usize, 2), method.params.len);
+    try testing.expectEqualStrings("self", method.params[0].name);
+    try testing.expect(method.params[0].type == .borrow);
+    try testing.expectEqual(@as(u32, 0), method.params[0].type.borrow);
+    try testing.expectEqualStrings("byte", method.params[1].name);
+    try testing.expect(method.params[1].type == .u8);
+    try testing.expect(method.results.unnamed == .u32);
+    try testing.expectEqualStrings("[method]output-stream.write", iface.decls[5].@"export".name);
+
+    // Static: no implicit self, no forced result.
+    try testing.expect(iface.decls[6].type == .func);
+    const stat = iface.decls[6].type.func;
+    try testing.expectEqual(@as(usize, 0), stat.params.len);
+    try testing.expect(stat.results.unnamed == .u32);
+    try testing.expectEqualStrings("[static]output-stream.check", iface.decls[7].@"export".name);
+}
+
+test "metadata_encode: explicit `borrow<R>` / `own<R>` in func sigs" {
+    // A function that takes a borrow and returns an own — exercises
+    // `lowerType` for both handle forms via the post-resource
+    // `name_map` binding.
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface streams {
+        \\    resource output-stream { }
+        \\    clone: func(s: borrow<output-stream>) -> own<output-stream>;
+        \\}
+        \\world demo { export streams; }
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "demo");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const iface = comp.types[0].component.decls[0].type.component.decls[0].type.instance;
+    // Body: [resource (0), export "output-stream" eq=0, func (1), export "clone" func=1].
+    try testing.expectEqual(@as(usize, 4), iface.decls.len);
+    try testing.expect(iface.decls[2].type == .func);
+    const f = iface.decls[2].type.func;
+    try testing.expect(f.params[0].type == .borrow);
+    try testing.expectEqual(@as(u32, 0), f.params[0].type.borrow);
+    try testing.expect(f.results.unnamed == .own);
+    try testing.expectEqual(@as(u32, 0), f.results.unnamed.own);
+    try testing.expectEqualStrings("clone", iface.decls[3].@"export".name);
+}
+
+test "metadata_encode: borrow<non-resource> reports InvalidWit" {
+    // `borrow<R>` where `R` is bound to a primitive alias (not a
+    // resource) is malformed. The encoder must catch it.
+    const source =
         \\package docs:demo@0.1.0;
         \\interface ops {
-        \\    resource handle { }
+        \\    type r = u32;
+        \\    f: func(x: borrow<r>);
         \\}
         \\world demo { export ops; }
     ;
-    try testing.expectError(error.UnsupportedWitFeature, encodeWorldFromSource(testing.allocator, res, "demo"));
+    const r = encodeWorldFromSource(testing.allocator, source, "demo");
+    try testing.expectError(error.InvalidWit, r);
+}
 
+test "metadata_encode: still rejects use clauses" {
+    // `use` (cross-interface type imports) remains deferred. Mirrors
+    // the resource-only-but-no-`use` chunk-3 test, narrowed to the
+    // one feature still surfaced as `UnsupportedWitFeature`.
     const use_src =
         \\package docs:demo@0.1.0;
         \\interface a { type x = u32; }

--- a/src/component/wit/metadata_encode.zig
+++ b/src/component/wit/metadata_encode.zig
@@ -42,12 +42,17 @@
 //!
 //! Deferred (rejected with `error.UnsupportedWitFeature`):
 //!
-//!   * record / variant / enum / flags / type-alias / use clause /
-//!     resource decl in interface bodies (the wamr fixtures don't
-//!     use them).
+//!   * record / variant / enum / flags / use clause / resource decl
+//!     in interface bodies (the wamr fixtures don't use them).
 //!   * `own<R>` / `borrow<R>` handle types.
 //!   * stream / future / async / error-context.
-//!   * named-type references inside func sigs (`name` is rejected).
+//!
+//! Supported: `type <name> = <Type>;` aliases plus `Type.name`
+//! references that resolve to a prior alias in the same interface
+//! body. The alias binds the name to the underlying `ValType`
+//! without consuming a fresh slot; references inline the bound
+//! `ValType`. Compound RHSes (`list<T>`, `result<…>`, …) still emit
+//! their own `TypeDef` decls via `appendCompound`.
 //!
 //! Lifting these is incremental: each remaining WIT type maps to a
 //! `TypeDef` declarator before the func that references it.
@@ -257,8 +262,16 @@ fn buildInterfaceBody(
     // `BodyBuilder` tracks the type-index space inside this
     // instance-type body. Every appended `.type` decl bumps
     // `type_idx`; compound valtypes lower to a fresh `.type` decl
-    // and a `ValType.type_idx` reference to its slot.
-    var builder: BodyBuilder = .{ .ar = ar, .decls = .empty, .type_idx = 0 };
+    // and a `ValType.type_idx` reference to its slot. Named-type
+    // refs (e.g. `Type.name`) resolve against `name_map`, which is
+    // populated as `type <name> = T;` aliases are encountered in
+    // declaration order.
+    var builder: BodyBuilder = .{
+        .ar = ar,
+        .decls = .empty,
+        .type_idx = 0,
+        .name_map = .empty,
+    };
     for (iface_body.items) |it| {
         switch (it) {
             .func => |f| {
@@ -286,7 +299,14 @@ fn buildInterfaceBody(
                     .desc = .{ .func = func_type_idx },
                 } });
             },
-            .type, .use => return error.UnsupportedWitFeature,
+            .type => |td| switch (td.kind) {
+                .alias => |inner| {
+                    const vt = try builder.lowerType(inner);
+                    try builder.bindName(td.name, vt);
+                },
+                else => return error.UnsupportedWitFeature,
+            },
+            .use => return error.UnsupportedWitFeature,
         }
     }
     return try builder.decls.toOwnedSlice(ar);
@@ -303,6 +323,13 @@ const BodyBuilder = struct {
     /// equivalently, the next free slot in the instance-type body's
     /// type-index space.
     type_idx: u32,
+    /// Maps `type <name> = T;` aliases (and, in later chunks,
+    /// nominal typedefs) to the `ValType` to substitute when a
+    /// `Type.name` reference points at them. Aliases to primitives
+    /// map directly to the primitive `ValType` without consuming a
+    /// fresh slot; aliases whose RHS is a compound type map to the
+    /// `type_idx` produced by the compound's lowering.
+    name_map: std.StringHashMapUnmanaged(ctypes.ValType),
 
     fn lowerType(self: *BodyBuilder, t: ast.Type) EncodeError!ctypes.ValType {
         return switch (t) {
@@ -343,7 +370,7 @@ const BodyBuilder = struct {
                 for (fields, 0..) |f, i| inner[i] = try self.lowerType(f);
                 break :blk try self.appendCompound(.{ .tuple = .{ .fields = inner } });
             },
-            .name => error.UnsupportedWitFeature,
+            .name => |n| self.name_map.get(n) orelse error.InvalidWit,
             .borrow, .own => error.UnsupportedWitFeature,
         };
     }
@@ -353,6 +380,12 @@ const BodyBuilder = struct {
         try self.decls.append(self.ar, .{ .type = td });
         self.type_idx += 1;
         return .{ .type_idx = idx };
+    }
+
+    fn bindName(self: *BodyBuilder, name: []const u8, vt: ctypes.ValType) EncodeError!void {
+        const gop = try self.name_map.getOrPut(self.ar, name);
+        if (gop.found_existing) return error.InvalidWit;
+        gop.value_ptr.* = vt;
     }
 };
 
@@ -617,4 +650,136 @@ test "metadata_encode: `list<u8>` param hoists to a TypeDef.list" {
     try testing.expect(iface.decls[1].type.func.params[0].type == .type_idx);
     try testing.expectEqual(@as(u32, 0), iface.decls[1].type.func.params[0].type.type_idx);
     try testing.expect(iface.decls[1].type.func.results.unnamed == .u32);
+}
+
+test "metadata_encode: primitive type alias resolves via name_map without a fresh slot" {
+    // `type my-u32 = u32;` is a pure rename — aliasing a primitive
+    // produces no new slot in the body's type-index space. A func
+    // referencing `my-u32` should inline the underlying primitive
+    // ValType.
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface ops {
+        \\    type my-u32 = u32;
+        \\    inc: func(x: my-u32) -> my-u32;
+        \\}
+        \\world demo {
+        \\    export ops;
+        \\}
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "demo");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const iface = comp.types[0].component.decls[0].type.component.decls[0].type.instance;
+    // Just [func TypeDef, export(func=0)] — no slot for the alias.
+    try testing.expectEqual(@as(usize, 2), iface.decls.len);
+    try testing.expect(iface.decls[0].type == .func);
+    const func = iface.decls[0].type.func;
+    try testing.expectEqual(@as(usize, 1), func.params.len);
+    try testing.expect(func.params[0].type == .u32);
+    try testing.expect(func.results.unnamed == .u32);
+}
+
+test "metadata_encode: compound alias is hoisted once, named refs reuse the slot" {
+    // `type bytes = list<u8>;` should emit exactly one TypeDef.list
+    // and bind `bytes` to that slot. A func using `bytes` twice
+    // (param + result) must reference the same `type_idx`, not
+    // re-hoist the list each time.
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface ops {
+        \\    type bytes = list<u8>;
+        \\    roundtrip: func(b: bytes) -> bytes;
+        \\}
+        \\world demo {
+        \\    export ops;
+        \\}
+    ;
+    const bytes_out = try encodeWorldFromSource(testing.allocator, source, "demo");
+    defer testing.allocator.free(bytes_out);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes_out, arena_loaded.allocator());
+
+    const iface = comp.types[0].component.decls[0].type.component.decls[0].type.instance;
+    // Body: [list TypeDef (idx 0), func TypeDef (idx 1), export(func=1)].
+    try testing.expectEqual(@as(usize, 3), iface.decls.len);
+    try testing.expect(iface.decls[0].type == .list);
+    try testing.expect(iface.decls[0].type.list.element == .u8);
+    try testing.expect(iface.decls[1].type == .func);
+    const func = iface.decls[1].type.func;
+    try testing.expectEqual(@as(u32, 0), func.params[0].type.type_idx);
+    try testing.expect(func.results == .unnamed);
+    try testing.expectEqual(@as(u32, 0), func.results.unnamed.type_idx);
+}
+
+test "metadata_encode: alias chain (a -> u32, b -> a) resolves transitively" {
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface ops {
+        \\    type a = u32;
+        \\    type b = a;
+        \\    f: func(x: b) -> b;
+        \\}
+        \\world demo {
+        \\    export ops;
+        \\}
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "demo");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const iface = comp.types[0].component.decls[0].type.component.decls[0].type.instance;
+    try testing.expectEqual(@as(usize, 2), iface.decls.len);
+    const func = iface.decls[0].type.func;
+    try testing.expect(func.params[0].type == .u32);
+    try testing.expect(func.results.unnamed == .u32);
+}
+
+test "metadata_encode: unresolved name reports InvalidWit" {
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface ops {
+        \\    f: func(x: nonexistent) -> u32;
+        \\}
+        \\world demo {
+        \\    export ops;
+        \\}
+    ;
+    const r = encodeWorldFromSource(testing.allocator, source, "demo");
+    try testing.expectError(error.InvalidWit, r);
+}
+
+test "metadata_encode: still rejects record / variant / enum / flags / use / resource" {
+    // Chunk 2 keeps the compound-typedef block deferred. The encoder
+    // must continue to surface `UnsupportedWitFeature` for these.
+    const rec =
+        \\package docs:demo@0.1.0;
+        \\interface ops {
+        \\    record point { x: u32, y: u32 }
+        \\    f: func(p: point);
+        \\}
+        \\world demo { export ops; }
+    ;
+    try testing.expectError(error.UnsupportedWitFeature, encodeWorldFromSource(testing.allocator, rec, "demo"));
+
+    const res =
+        \\package docs:demo@0.1.0;
+        \\interface ops {
+        \\    resource handle { }
+        \\}
+        \\world demo { export ops; }
+    ;
+    try testing.expectError(error.UnsupportedWitFeature, encodeWorldFromSource(testing.allocator, res, "demo"));
 }

--- a/src/component/wit/metadata_encode.zig
+++ b/src/component/wit/metadata_encode.zig
@@ -42,9 +42,11 @@
 //!
 //! Deferred (rejected with `error.UnsupportedWitFeature`):
 //!
-//!   * record / variant / enum / flags / type-alias / use clause
-//!     in interface bodies (the wamr fixtures don't use them).
-//!   * resource / handle / stream / future / async / error-context.
+//!   * record / variant / enum / flags / type-alias / use clause /
+//!     resource decl in interface bodies (the wamr fixtures don't
+//!     use them).
+//!   * `own<R>` / `borrow<R>` handle types.
+//!   * stream / future / async / error-context.
 //!   * named-type references inside func sigs (`name` is rejected).
 //!
 //! Lifting these is incremental: each remaining WIT type maps to a
@@ -342,6 +344,7 @@ const BodyBuilder = struct {
                 break :blk try self.appendCompound(.{ .tuple = .{ .fields = inner } });
             },
             .name => error.UnsupportedWitFeature,
+            .borrow, .own => error.UnsupportedWitFeature,
         };
     }
 

--- a/src/component/wit/metadata_encode.zig
+++ b/src/component/wit/metadata_encode.zig
@@ -42,17 +42,16 @@
 //!
 //! Deferred (rejected with `error.UnsupportedWitFeature`):
 //!
-//!   * record / variant / enum / flags / use clause / resource decl
-//!     in interface bodies (the wamr fixtures don't use them).
-//!   * `own<R>` / `borrow<R>` handle types.
+//!   * `resource` decls and `own<R>` / `borrow<R>` handle types.
+//!   * `use` clauses (cross-interface type imports).
 //!   * stream / future / async / error-context.
 //!
-//! Supported: `type <name> = <Type>;` aliases plus `Type.name`
-//! references that resolve to a prior alias in the same interface
-//! body. The alias binds the name to the underlying `ValType`
-//! without consuming a fresh slot; references inline the bound
-//! `ValType`. Compound RHSes (`list<T>`, `result<…>`, …) still emit
-//! their own `TypeDef` decls via `appendCompound`.
+//! Supported: `type <name> = <Type>;` aliases, plus nominal typedefs
+//! (`record`, `variant`, `enum`, `flags`) — each emits one slot in
+//! the body's type-index space and is referenced from later funcs /
+//! aliases via `Type.name`. Compound RHSes (`list<T>`, `result<…>`,
+//! `tuple<…>`, `option<…>`) still hoist via `appendCompound`; named
+//! refs are resolved against `BodyBuilder.name_map`.
 //!
 //! Lifting these is incremental: each remaining WIT type maps to a
 //! `TypeDef` declarator before the func that references it.
@@ -304,7 +303,35 @@ fn buildInterfaceBody(
                     const vt = try builder.lowerType(inner);
                     try builder.bindName(td.name, vt);
                 },
-                else => return error.UnsupportedWitFeature,
+                .record => |fields| {
+                    const lowered = try ar.alloc(ctypes.Field, fields.len);
+                    for (fields, 0..) |f, i| {
+                        lowered[i] = .{ .name = f.name, .type = try builder.lowerType(f.type) };
+                    }
+                    const vt = try builder.appendCompound(.{ .record = .{ .fields = lowered } });
+                    try builder.bindName(td.name, vt);
+                },
+                .variant => |cases| {
+                    const lowered = try ar.alloc(ctypes.Case, cases.len);
+                    for (cases, 0..) |c, i| {
+                        const payload: ?ctypes.ValType = if (c.type) |ty|
+                            try builder.lowerType(ty)
+                        else
+                            null;
+                        lowered[i] = .{ .name = c.name, .type = payload };
+                    }
+                    const vt = try builder.appendCompound(.{ .variant = .{ .cases = lowered } });
+                    try builder.bindName(td.name, vt);
+                },
+                .@"enum" => |names| {
+                    const vt = try builder.appendCompound(.{ .enum_ = .{ .names = names } });
+                    try builder.bindName(td.name, vt);
+                },
+                .flags => |names| {
+                    const vt = try builder.appendCompound(.{ .flags = .{ .names = names } });
+                    try builder.bindName(td.name, vt);
+                },
+                .resource => return error.UnsupportedWitFeature,
             },
             .use => return error.UnsupportedWitFeature,
         }
@@ -761,19 +788,144 @@ test "metadata_encode: unresolved name reports InvalidWit" {
     try testing.expectError(error.InvalidWit, r);
 }
 
-test "metadata_encode: still rejects record / variant / enum / flags / use / resource" {
-    // Chunk 2 keeps the compound-typedef block deferred. The encoder
-    // must continue to surface `UnsupportedWitFeature` for these.
-    const rec =
+test "metadata_encode: record typedef emits TypeDef.record + name binding" {
+    const source =
         \\package docs:demo@0.1.0;
         \\interface ops {
         \\    record point { x: u32, y: u32 }
-        \\    f: func(p: point);
+        \\    move-by: func(p: point, dx: s32) -> point;
         \\}
         \\world demo { export ops; }
     ;
-    try testing.expectError(error.UnsupportedWitFeature, encodeWorldFromSource(testing.allocator, rec, "demo"));
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "demo");
+    defer testing.allocator.free(bytes);
 
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const iface = comp.types[0].component.decls[0].type.component.decls[0].type.instance;
+    // Body: [record TypeDef (idx 0), func TypeDef (idx 1), export(func=1)].
+    try testing.expectEqual(@as(usize, 3), iface.decls.len);
+    try testing.expect(iface.decls[0].type == .record);
+    const rec = iface.decls[0].type.record;
+    try testing.expectEqual(@as(usize, 2), rec.fields.len);
+    try testing.expectEqualStrings("x", rec.fields[0].name);
+    try testing.expect(rec.fields[0].type == .u32);
+    try testing.expectEqualStrings("y", rec.fields[1].name);
+    try testing.expect(rec.fields[1].type == .u32);
+
+    const func = iface.decls[1].type.func;
+    try testing.expectEqual(@as(u32, 0), func.params[0].type.type_idx);
+    try testing.expect(func.params[1].type == .s32);
+    try testing.expectEqual(@as(u32, 0), func.results.unnamed.type_idx);
+}
+
+test "metadata_encode: variant typedef with mixed payloads" {
+    // Mirrors `wasi:io/streams.stream-error`: a no-payload `closed`
+    // case plus a payload-carrying case. Both forms must encode and
+    // round-trip cleanly.
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface ops {
+        \\    variant stream-error {
+        \\        closed,
+        \\        last-operation-failed(string),
+        \\    }
+        \\    drain: func() -> result<u32, stream-error>;
+        \\}
+        \\world demo { export ops; }
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "demo");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const iface = comp.types[0].component.decls[0].type.component.decls[0].type.instance;
+    // Body: [variant (0), result (1), func (2), export(func=2)].
+    try testing.expectEqual(@as(usize, 4), iface.decls.len);
+    try testing.expect(iface.decls[0].type == .variant);
+    const v = iface.decls[0].type.variant;
+    try testing.expectEqual(@as(usize, 2), v.cases.len);
+    try testing.expectEqualStrings("closed", v.cases[0].name);
+    try testing.expect(v.cases[0].type == null);
+    try testing.expectEqualStrings("last-operation-failed", v.cases[1].name);
+    try testing.expect(v.cases[1].type != null);
+    try testing.expect(v.cases[1].type.? == .string);
+
+    try testing.expect(iface.decls[1].type == .result);
+    const res = iface.decls[1].type.result;
+    try testing.expect(res.ok != null and res.ok.? == .u32);
+    try testing.expect(res.err != null);
+    try testing.expectEqual(@as(u32, 0), res.err.?.type_idx);
+
+    try testing.expect(iface.decls[2].type == .func);
+    try testing.expectEqual(@as(u32, 1), iface.decls[2].type.func.results.unnamed.type_idx);
+}
+
+test "metadata_encode: enum typedef" {
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface ops {
+        \\    enum color { red, green, blue }
+        \\    pick: func() -> color;
+        \\}
+        \\world demo { export ops; }
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "demo");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const iface = comp.types[0].component.decls[0].type.component.decls[0].type.instance;
+    try testing.expectEqual(@as(usize, 3), iface.decls.len);
+    try testing.expect(iface.decls[0].type == .enum_);
+    const e = iface.decls[0].type.enum_;
+    try testing.expectEqual(@as(usize, 3), e.names.len);
+    try testing.expectEqualStrings("red", e.names[0]);
+    try testing.expectEqualStrings("green", e.names[1]);
+    try testing.expectEqualStrings("blue", e.names[2]);
+    try testing.expectEqual(@as(u32, 0), iface.decls[1].type.func.results.unnamed.type_idx);
+}
+
+test "metadata_encode: flags typedef" {
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface ops {
+        \\    flags perms { read, write, exec }
+        \\    check: func(p: perms) -> bool;
+        \\}
+        \\world demo { export ops; }
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "demo");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const iface = comp.types[0].component.decls[0].type.component.decls[0].type.instance;
+    try testing.expectEqual(@as(usize, 3), iface.decls.len);
+    try testing.expect(iface.decls[0].type == .flags);
+    const f = iface.decls[0].type.flags;
+    try testing.expectEqual(@as(usize, 3), f.names.len);
+    try testing.expectEqualStrings("read", f.names[0]);
+    try testing.expectEqualStrings("write", f.names[1]);
+    try testing.expectEqualStrings("exec", f.names[2]);
+    try testing.expectEqual(@as(u32, 0), iface.decls[1].type.func.params[0].type.type_idx);
+}
+
+test "metadata_encode: still rejects resource and use clauses" {
+    // Chunks 4 / future will lift these. Until then, surface a clean
+    // `UnsupportedWitFeature` rather than silently mis-encoding.
     const res =
         \\package docs:demo@0.1.0;
         \\interface ops {
@@ -782,4 +934,15 @@ test "metadata_encode: still rejects record / variant / enum / flags / use / res
         \\world demo { export ops; }
     ;
     try testing.expectError(error.UnsupportedWitFeature, encodeWorldFromSource(testing.allocator, res, "demo"));
+
+    const use_src =
+        \\package docs:demo@0.1.0;
+        \\interface a { type x = u32; }
+        \\interface b {
+        \\    use a.{x};
+        \\    f: func(v: x);
+        \\}
+        \\world demo { export b; }
+    ;
+    try testing.expectError(error.UnsupportedWitFeature, encodeWorldFromSource(testing.allocator, use_src, "demo"));
 }

--- a/src/component/wit/parser.zig
+++ b/src/component/wit/parser.zig
@@ -296,7 +296,11 @@ const Parser = struct {
                 const td = try self.parseFlags(docs);
                 return .{ .type = td };
             },
-            .kw_resource, .kw_stream, .kw_future, .kw_error_context, .kw_async, .kw_constructor => {
+            .kw_resource => {
+                const td = try self.parseResource(docs);
+                return .{ .type = td };
+            },
+            .kw_stream, .kw_future, .kw_error_context, .kw_async, .kw_constructor => {
                 return self.fail(head.span, "feature not yet supported");
             },
             .id, .explicit_id => {
@@ -406,6 +410,58 @@ const Parser = struct {
         };
     }
 
+    /// `resource <name> { (constructor(...) | <id>: [static] func(...) [-> T];)* }`
+    fn parseResource(self: *Parser, docs: []const u8) ParseError!ast.TypeDef {
+        const name = try self.parseId();
+        _ = try self.expect(.lbrace);
+        var methods = std.ArrayListUnmanaged(ast.ResourceMethod).empty;
+        while (true) {
+            const t = try self.nextNonDoc();
+            if (t.tag == .rbrace) break;
+            const m_docs = self.takeDocs();
+            switch (t.tag) {
+                .kw_constructor => {
+                    const f = try self.parseFuncSignature();
+                    _ = try self.expect(.semicolon);
+                    try methods.append(self.allocator, .{
+                        .docs = m_docs,
+                        .kind = .constructor,
+                        .name = "",
+                        .func = f,
+                    });
+                },
+                .id, .explicit_id => {
+                    const m_name = try self.identText(t);
+                    _ = try self.expect(.colon);
+                    // Optional `static` modifier before `func`.
+                    var kind: ast.ResourceMethodKind = .method;
+                    var head = try self.nextNonDoc();
+                    if (head.tag == .kw_static) {
+                        kind = .static;
+                        head = try self.nextNonDoc();
+                    }
+                    if (head.tag != .kw_func) {
+                        return self.fail(head.span, "expected `func`");
+                    }
+                    const f = try self.parseFuncSignature();
+                    _ = try self.expect(.semicolon);
+                    try methods.append(self.allocator, .{
+                        .docs = m_docs,
+                        .kind = kind,
+                        .name = m_name,
+                        .func = f,
+                    });
+                },
+                else => return self.fail(t.span, "expected `constructor` or method declaration"),
+            }
+        }
+        return .{
+            .docs = docs,
+            .name = name,
+            .kind = .{ .resource = try methods.toOwnedSlice(self.allocator) },
+        };
+    }
+
     fn parseFuncSignature(self: *Parser) ParseError!ast.Func {
         _ = try self.expect(.lparen);
         var params = std.ArrayListUnmanaged(ast.Param).empty;
@@ -500,7 +556,17 @@ const Parser = struct {
                 }
                 break :blk ast.Type{ .tuple = try fields.toOwnedSlice(self.allocator) };
             },
-            .kw_own, .kw_borrow, .kw_stream, .kw_future, .kw_error_context => return self.fail(t.span, "feature not yet supported"),
+            .kw_own, .kw_borrow => blk: {
+                _ = try self.expect(.lt);
+                const name_tok = try self.nextNonDoc();
+                if (name_tok.tag != .id and name_tok.tag != .explicit_id) {
+                    return self.fail(name_tok.span, "expected resource name");
+                }
+                const name = try self.identText(name_tok);
+                _ = try self.expect(.gt);
+                break :blk if (t.tag == .kw_own) ast.Type{ .own = name } else ast.Type{ .borrow = name };
+            },
+            .kw_stream, .kw_future, .kw_error_context => return self.fail(t.span, "feature not yet supported"),
             .id, .explicit_id => .{ .name = try self.identText(t) },
             else => return self.fail(t.span, "expected a type"),
         };
@@ -956,13 +1022,55 @@ test "parse: explicit-id keyword as name" {
     try testing.expectEqualStrings("record", f.name);
 }
 
-test "parse: rejects resource with helpful error" {
+test "parse: empty resource decl" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const r = parseInto(&arena,
+    const doc = try parseInto(&arena,
         \\interface i {
         \\    resource file { }
         \\}
     );
-    try testing.expectError(error.UnexpectedToken, r);
+    const td = doc.items[0].interface.items[0].type;
+    try testing.expectEqualStrings("file", td.name);
+    try testing.expectEqual(@as(usize, 0), td.kind.resource.len);
+}
+
+test "parse: resource with method, static, constructor" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const doc = try parseInto(&arena,
+        \\interface i {
+        \\    resource output-stream {
+        \\        constructor(seed: u32);
+        \\        blocking-write-and-flush: func(contents: list<u8>) -> result;
+        \\        check-write: static func() -> u64;
+        \\    }
+        \\}
+    );
+    const methods = doc.items[0].interface.items[0].type.kind.resource;
+    try testing.expectEqual(@as(usize, 3), methods.len);
+    try testing.expectEqual(ast.ResourceMethodKind.constructor, methods[0].kind);
+    try testing.expectEqual(@as(usize, 1), methods[0].func.params.len);
+    try testing.expectEqual(ast.ResourceMethodKind.method, methods[1].kind);
+    try testing.expectEqualStrings("blocking-write-and-flush", methods[1].name);
+    try testing.expectEqual(ast.ResourceMethodKind.static, methods[2].kind);
+    try testing.expectEqualStrings("check-write", methods[2].name);
+}
+
+test "parse: borrow<R> and own<R> type syntax" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const doc = try parseInto(&arena,
+        \\interface i {
+        \\    drop-it: func(s: own<output-stream>);
+        \\    write: func(s: borrow<output-stream>, data: list<u8>);
+        \\}
+    );
+    const items = doc.items[0].interface.items;
+    const own_ty = items[0].func.func.params[0].type;
+    const borrow_ty = items[1].func.func.params[0].type;
+    try testing.expect(own_ty == .own);
+    try testing.expectEqualStrings("output-stream", own_ty.own);
+    try testing.expect(borrow_ty == .borrow);
+    try testing.expectEqualStrings("output-stream", borrow_ty.borrow);
 }

--- a/src/component/writer.zig
+++ b/src/component/writer.zig
@@ -457,9 +457,14 @@ fn writeTypeDef(w: *Writer, td: ctypes.TypeDef) EncodeError!void {
             }
         },
         .resource => |r| {
+            // `(sub resource)` is encoded as `0x3F` followed by an
+            // optional destructor:
+            //   `0x00`                  → no destructor
+            //   `0x01 <funcidx-u32leb>` → destructor at that idx
+            // The representation type is always `i32` per spec and
+            // is not emitted on the wire — `ResourceType.rep` is
+            // descriptive only.
             try w.appendByte(0x3F);
-            // Representation byte (always i32 per spec).
-            try w.appendByte(@intFromEnum(r.rep));
             if (r.destructor) |d| {
                 try w.appendByte(0x01);
                 try w.writeU32Leb(d);


### PR DESCRIPTION
Stacked on top of #146. Grows `metadata_encode` (and the parser, AST, and writer) so the WIT-native encoder accepts the full canonical preview2 surface needed by `wasi:io/streams`, `wasi:cli`, and friends. After this, the only deferred features in interface bodies are `use` clauses and async / stream / future / error-context.

## What changes

### Parser + AST (commit `b884168a`)

- `Type.borrow: []const u8` and `Type.own: []const u8` carry the target resource name; resolution to a type idx happens at encode time.
- `TypeDefKind.resource: []const ResourceMethod` plus `ResourceMethod { kind, name, func }` with kinds `method` / `static` / `constructor`. The implicit `self: borrow<R>` (methods) and `-> own<R>` (constructor) are *not* in the AST — synthesized by the encoder.
- `parser.parseTypeFromTok` accepts `own<R>` / `borrow<R>`.
- `parser.parseInterfaceItem` dispatches `kw_resource` to a new `parseResource`, which loops over `constructor(...)`, `<id>: func(...)`, and `<id>: static func(...)` declarations.

### Encoder — named refs + type aliases (commit `403a4499`)

- `BodyBuilder.name_map: StringHashMapUnmanaged(ValType)` populated as `type <name> = T;` aliases are encountered in declaration order.
- Primitive aliases bind to the primitive `ValType` directly (no fresh slot). Compound aliases hoist their RHS via `appendCompound` and bind to the resulting `type_idx`. Repeated uses reuse the slot.
- `Type.name` resolves through `name_map`; unknown names surface `error.InvalidWit`.

### Encoder — compound typedefs (commit `d43836d5`)

- `record` / `variant` / `enum` / `flags` decls each emit one slot in the body's type-index space and bind the name in `name_map`. Variant cases with no payload encode as `null`-typed.
- `resource` and `use` still surface `UnsupportedWitFeature` at this commit.

### Encoder — resources + handles (commit `5757784d`)

- `.resource` typedefs emit the canonical wire shape mirroring `loader.zig:897`'s fixture:
  - `TypeDef.resource { destructor: null }` consumes one slot.
  - `ExportDecl name=R desc=type{eq=N}` makes the resource's external name visible.
  - Members lower through a new `emitFuncExport` helper supporting a `FuncInjection`: methods get `self: borrow<R>` prepended; constructors get `-> own<R>` forced.
  - External names follow the canonical `[constructor]R`, `[method]R.M`, `[static]R.M` form. `[resource-drop]R` is **not** emitted on the wire — the consuming canon stage synthesizes it implicitly for every resource (see `adapter.zig:1263`).
- `lowerType` for `borrow<R>` / `own<R>` resolves through `name_map`; borrowing or owning a non-resource named type (e.g. an alias to `u32`) is caught as `InvalidWit`.
- `writer.zig` `.resource` encoding: drop the spurious representation byte. Per the component-model spec `(sub resource)` is `0x3F` then `0x00` / `0x01 <funcidx>`; the rep type is always `i32` and not on the wire. The `ResourceType.rep` field is now descriptive only. This is a pre-existing wabt asymmetry surfaced for the first time by the end-to-end resource encode → decode test.

## Verification

- `zig build test` → 405/405 tests pass (12 new metadata_encode + parser cases across the four commits).
- `zig build adapter` still produces a 1086-byte `wasi_snapshot_preview1.command.wasm` with the same 265-byte encoded-world section — the new paths are dormant until the WIT widens in a follow-up PR.

## Why split into four commits

Each commit lifts one orthogonal restriction (parser → named refs → compound typedefs → resources), with its own focused tests. Reviewing the encoder shape diff incrementally is much easier than landing a single 600-line patch. The git log captures the design rationale at each step.

## Out of scope (deferred)

- `use` clauses (cross-interface type imports). Workaround for the wasi-preview1 adapter is to flatten the canonical WIT inline.
- Resource destructors. The encoder always writes `null` for the destructor; the canonical `wit-component` output also writes `null` for imported resources (which is all wasi-preview1 needs).
- async / stream / future / error-context.

## Stack

Stacked on top of #146. If #146 merges as-is, this branch rebases cleanly onto main. If #146 needs revision, this branch will need to rebase onto the revised tip.
