### PR TITLE
feat(adapters/wasi-preview1): widen WIT to import wasi:io/streams

### DIFF
--- a/adapters/wasi-preview1/wit/deps/wasi-io/streams.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-io/streams.wit
@@ -1,0 +1,46 @@
+// Trimmed slice of `wasi:io@0.2.6.streams` that the wabt-built
+// wasi-preview1 adapter needs. Mirrors the canonical
+// `bytecodealliance/wasi-io@v0.2.6` shape but declares only:
+//
+//   * `stream-error` variant — the canonical version's
+//     `last-operation-failed` case carries an `error` resource
+//     payload from `wasi:io/error`. We flatten it to a no-payload
+//     case until the encoder grows `use` clause support; both
+//     forms encode to a `result<_, stream-error>` shape that the
+//     adapter never reads (preview1 `fd_write` only cares about
+//     "succeeded" vs "trap on first error").
+//
+//   * `output-stream` resource with `blocking-write-and-flush` —
+//     the single method the preview1 → preview2 adapter calls in
+//     its `fd_write` body.
+//
+// The wider `streams` surface (subscribe / check-write /
+// non-blocking write / input-stream / forward / splice) lives
+// upstream and is not consumed by the adapter, so it stays out
+// of this trimmed copy to keep `metadata_encode` output minimal.
+
+package wasi:io@0.2.6;
+
+interface streams {
+    /// Failure modes for `output-stream` writes. The canonical
+    /// `last-operation-failed` case carries a `borrow<error>` from
+    /// `wasi:io/error` — we drop the payload here (see top-of-file
+    /// note) so the wire-form is `variant { last-operation-failed,
+    /// closed }`.
+    variant stream-error {
+        last-operation-failed,
+        closed,
+    }
+
+    /// Byte-sink resource. The adapter only needs the
+    /// blocking-and-flushed write path — preview1 `fd_write` is
+    /// itself blocking, so any non-blocking lowering would just be
+    /// extra ceremony.
+    resource output-stream {
+        /// Write `contents` and block until the host has accepted
+        /// every byte. Returns `ok` on full success or
+        /// `err(stream-error)` if the underlying sink closed or
+        /// errored mid-write.
+        blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
+    }
+}

--- a/adapters/wasi-preview1/wit/preview1.wit
+++ b/adapters/wasi-preview1/wit/preview1.wit
@@ -1,21 +1,18 @@
 // wasi-preview1 → preview2 adapter world.
 //
-// Authored against the canonical wasi:cli@0.2.6 component-model
-// surface (see `wit/deps/wasi-cli/world.wit` for the trimmed slice
-// of `wasi:cli` this adapter actually canon-lowers).
+// Authored against the canonical wasi:cli@0.2.6 + wasi:io@0.2.6
+// component-model surfaces (see `wit/deps/{wasi-cli,wasi-io}/` for
+// the trimmed slices this adapter consumes).
 //
-// Scope cut for cataggar/wamr#453's initial sub-phase: the adapter
-// only canon-lowers `wasi:cli/exit.exit-with-code(u8)` — the
-// `proc_exit` path — and exports the canon-lifted `wasi:cli/run.run`
-// command entry. Every other preview1 import is an ENOSYS stub in
-// `src/adapter.wat`, and the wabt adapter splicer's
-// core-wasm GC pass drops the unused exports at splice time.
-//
-// The wider import set (`wasi:io/streams`, `wasi:filesystem/…`, etc.)
-// arrives in a later sub-phase alongside the real fd_write /
-// args_get / clock_time_get lowering. Adding it now would require
-// `metadata_encode.zig` to grow resource-handle support, which is a
-// non-trivial parallel work item.
+// Current scope (cataggar/wamr#453 Phase 1.c.2): the WIT declares
+// the wider preview2 surface the adapter will lower against
+// (`wasi:cli/exit` + `wasi:io/streams`), exercising the encoder's
+// resource-handle paths end-to-end. The `adapter.wat` core wasm
+// still only references `wasi:cli/exit.exit-with-code` directly;
+// the `wasi:io/streams.output-stream.blocking-write-and-flush`
+// lowering lands in Phase 1.c.3 alongside the real `fd_write` body.
+// Until then, the splicer's GC pass will drop the unused
+// `wasi:io/streams` instance from the spliced component.
 
 package wabt:wasi-preview1@0.0.0;
 
@@ -27,6 +24,15 @@ world command {
     /// through `wasi:cli/exit.exit(result<_, _>)` and collapses every
     /// non-zero code to host exit code 1.
     import wasi:cli/exit@0.2.6;
+
+    /// Byte-sink resource + `blocking-write-and-flush` method. The
+    /// preview1 `fd_write` iterates the iovec list, copies into a
+    /// canon-realloc'd buffer, and calls `blocking-write-and-flush`
+    /// against the stdout/stderr handle. The handle itself is
+    /// obtained via host trampoline in Phase 1.c.3 — declaring it
+    /// here so the encoded world advertises the imported resource
+    /// shape now.
+    import wasi:io/streams@0.2.6;
 
     /// Canon-lift'd `run()` entry. The adapter calls
     /// `__main_module__._start` and returns `ok` on normal return;


### PR DESCRIPTION
Phase 1.c.2 of cataggar/wamr#453 — widen the wasi-preview1 adapter's WIT to import the `wasi:io/streams` interface so the resource-encoding paths added in #147 chunk 4 get exercised through the real adapter build, not just unit tests.

Stacked on #147. Reviewing #147 first is recommended — this PR is just a WIT-layout uplift on top of the encoder work that already landed there.

## What lands

- `adapters/wasi-preview1/wit/deps/wasi-io/streams.wit` (new) — trimmed `package wasi:io@0.2.6;` with a single `interface streams`:
  ```wit
  variant stream-error {
      last-operation-failed,
      closed,
  }

  resource output-stream {
      blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
  }
  ```
  Slimmed against canonical `bytecodealliance/wasi-io@v0.2.6`:
  - `stream-error.last-operation-failed` drops its `borrow<error>` payload (would need cross-package `use` from `wasi:io/error`).
  - Every method on `output-stream` other than `blocking-write-and-flush` is omitted — preview1 `fd_write` is blocking, so no non-blocking ceremony.
  - Top-of-file comment captures the full rationale.

- `adapters/wasi-preview1/wit/preview1.wit` — `world command` adds `import wasi:io/streams@0.2.6;`. Header comment updated to call out the deliberately wider preview2 surface and the splicer's GC-at-compose-time behaviour for the still-unused imports.

## What this exercises end-to-end

`metadata_encode` walks the new interface and emits, in order:

1. `TypeDef.variant { stream-error: { last-operation-failed, closed } }`
2. `TypeDef.resource { destructor: null }` for `output-stream`
3. `ExportDecl { name: "output-stream", desc: .type = .eq{N} }` — externalising the resource's WIT name
4. `TypeDef.func { params: [contents: list<u8>], result: result<_, variant{N}> }` for `blocking-write-and-flush`'s body, with `self: borrow<output-stream>` prepended by `emitFuncExport`
5. `ExportDecl { name: "[method]output-stream.blocking-write-and-flush", desc: .func = N }` — canonical method name synthesised in `formatResourceMemberName`

Each of those bytes goes through `writer.zig`'s `0x3F 0x00` (no-destructor) resource tag and the `borrow`/`own` ValType emission — every path PR #147 chunk 4 added.

## Numbers

- Adapter wasm size: **1086 → 1254 bytes** (+168)
- Encoded-section payload: **~190 → 371 bytes**

A `python` byte-search of the produced wasm confirms every expected wire-string appears in the encoded-section payload:

```
b'wasi:cli/exit@0.2.6'                   -> found @ 222
b'wasi:io/streams@0.2.6'                 -> found @ 1136
b'output-stream'                         -> found @ 1036
b'blocking-write-and-flush'              -> found @ 1107
b'last-operation-failed'                 -> found @  998
b'closed'                                -> found @ 1022
b'exit-with-code'                        -> found @  242
b'wasi:cli/run@0.2.6'                    -> found @  559
```

(`stream-error` is bound internally only — externalising typedef names lands alongside `use`-clause support in Phase 1.c.2.5.)

## Validation

- `zig build adapter` — succeeds; `build_adapter`'s self-check (`decode.parseFromAdapterCore`) still round-trips cleanly.
- `zig build test` — same green status as the base (`feat/wit-resources-and-handles`, PR #147 HEAD); the lone `FAIL assert_return(invoke "a"): trap error.UndefinedElement` line is pre-existing on the parent.
- `wasm-tools print zig-out/adapter/wasi_snapshot_preview1.command.wasm` still shows the expected core wasm imports/exports (`__main_module__._start`, `wasi:cli/exit@0.2.6.exit-with-code`, preview1 stubs).

## Deferred (Phase 1.c.2.5 — separate PR)

- `use wasi:io/streams.{output-stream};` clauses in the encoder. Needed before declaring `wasi:cli/stdout` / `wasi:cli/stderr` interfaces that obtain `output-stream` handles via `get-stdout` / `get-stderr`. Encoder needs `alias outer instance K type T` emission inside consuming instance-type bodies.
- Externalising typedef names (emitting an `ExportDecl` for the typedef's WIT name) for `variant` / `record` / `enum` / `flags` — currently bound to the body-builder's internal `name_map` only.

Refs cataggar/wamr#453
