### PR TITLE
feat(wit): declare wasi:cli/stdout + wasi:cli/stderr in preview1 world

### DIFF
--- a/adapters/wasi-preview1/wit/deps/wasi-cli/stdio.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-cli/stdio.wit
@@ -1,0 +1,49 @@
+// Trimmed slice of `wasi:cli@0.2.6.{stdout,stderr}`. Mirrors the
+// canonical `bytecodealliance/wasi-cli@v0.2.6/wit/stdio.wit` shape,
+// but:
+//
+//   * declares only the two interfaces the preview1 adapter actually
+//     calls (`stdout` + `stderr`; `stdin` is not on the preview1
+//     `fd_read` path yet and stays out of the trimmed copy);
+//
+//   * uses an explicit `own<output-stream>` return type rather than
+//     the canonical bare `output-stream` form. Both encode to the
+//     same on-wire shape via wit-component's implicit-`own<>` sugar,
+//     but our encoder's `lowerType` does not yet auto-wrap bare
+//     resource references — explicit `own<>` produces the same wire
+//     bytes without depending on that sugar.
+//
+// `use wasi:io/streams@0.2.6.{output-stream};` exercises the
+// interface-level `use` encoder path landed in PR #149 (Phase
+// 1.c.2.5): each interface body emits an `alias outer (type 1 K)`
+// + `export "output-stream" (type (eq L))` pair, and the world
+// body emits a matching `alias instance-export sort=type` decl
+// right after the `wasi:io/streams@0.2.6` import.
+//
+// This file holds the package declaration for the multi-file
+// `wasi:cli@0.2.6` slice — `resolver.readWitDir` concatenates
+// `*.wit` files in alphabetical order, and `stdio.wit` sorts
+// before `world.wit`, so the parser sees this `package` directive
+// first.
+
+package wasi:cli@0.2.6;
+
+interface stdout {
+    use wasi:io/streams@0.2.6.{output-stream};
+
+    /// Obtain a handle to the standard output stream. The handle is
+    /// owned: the adapter must `[resource-drop]output-stream` it on
+    /// teardown to release the underlying sink. In practice we cache
+    /// a single handle per process and never drop it — preview1
+    /// doesn't expose `fd_close` for fd 1/2.
+    get-stdout: func() -> own<output-stream>;
+}
+
+interface stderr {
+    use wasi:io/streams@0.2.6.{output-stream};
+
+    /// Same shape as `stdout.get-stdout`, against fd 2. The two
+    /// interfaces are split upstream so a guest can drop one
+    /// without losing the other; the adapter consumes both.
+    get-stderr: func() -> own<output-stream>;
+}

--- a/adapters/wasi-preview1/wit/deps/wasi-cli/world.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-cli/world.wit
@@ -8,8 +8,12 @@
 // `cataggar/wamr:src/component/wasi_cli_adapter.zig` and the
 // `wasi:cli@0.2.6` upstream WIT in
 // `bytecodealliance/wasi-cli@v0.2.6`.
-
-package wasi:cli@0.2.6;
+//
+// NOTE: the package declaration for this directory's multi-file
+// slice lives in `stdio.wit` (which sorts first alphabetically).
+// `resolver.readWitDir` concatenates files in order, so the
+// `package wasi:cli@0.2.6;` directive must appear in the file
+// that's parsed first.
 
 interface exit {
     /// Exit the program with an explicit numeric status code. The

--- a/adapters/wasi-preview1/wit/preview1.wit
+++ b/adapters/wasi-preview1/wit/preview1.wit
@@ -4,15 +4,18 @@
 // component-model surfaces (see `wit/deps/{wasi-cli,wasi-io}/` for
 // the trimmed slices this adapter consumes).
 //
-// Current scope (cataggar/wamr#453 Phase 1.c.2): the WIT declares
+// Current scope (cataggar/wamr#453 Phase 1.c.3a): the WIT declares
 // the wider preview2 surface the adapter will lower against
-// (`wasi:cli/exit` + `wasi:io/streams`), exercising the encoder's
-// resource-handle paths end-to-end. The `adapter.wat` core wasm
-// still only references `wasi:cli/exit.exit-with-code` directly;
-// the `wasi:io/streams.output-stream.blocking-write-and-flush`
-// lowering lands in Phase 1.c.3 alongside the real `fd_write` body.
+// (`wasi:cli/exit` + `wasi:io/streams` + `wasi:cli/stdout` +
+// `wasi:cli/stderr`), exercising the encoder's resource-handle +
+// `use`-clause paths end-to-end. The `adapter.wat` core wasm still
+// only references `wasi:cli/exit.exit-with-code` directly; the
+// `wasi:cli/stdout.get-stdout` / `wasi:cli/stderr.get-stderr` and
+// `wasi:io/streams.output-stream.blocking-write-and-flush`
+// lowerings land in Phase 1.c.3 alongside the real `fd_write` body.
 // Until then, the splicer's GC pass will drop the unused
-// `wasi:io/streams` instance from the spliced component.
+// `wasi:io/streams` + `wasi:cli/stdout` + `wasi:cli/stderr`
+// instances from the spliced component.
 
 package wabt:wasi-preview1@0.0.0;
 
@@ -29,10 +32,19 @@ world command {
     /// preview1 `fd_write` iterates the iovec list, copies into a
     /// canon-realloc'd buffer, and calls `blocking-write-and-flush`
     /// against the stdout/stderr handle. The handle itself is
-    /// obtained via host trampoline in Phase 1.c.3 — declaring it
-    /// here so the encoded world advertises the imported resource
-    /// shape now.
+    /// obtained via `wasi:cli/stdout.get-stdout` /
+    /// `wasi:cli/stderr.get-stderr` in Phase 1.c.3 — declared here
+    /// so the encoded world advertises the imported resource shape
+    /// now.
     import wasi:io/streams@0.2.6;
+
+    /// Owned `output-stream` handle factories. The two interfaces
+    /// re-export `output-stream` from `wasi:io/streams@0.2.6` via
+    /// `use` clauses, so the world body's encoded section gains
+    /// alias-instance-export decls that surface the type at the
+    /// world level. Preview1 fds 1 and 2 map to these handles.
+    import wasi:cli/stdout@0.2.6;
+    import wasi:cli/stderr@0.2.6;
 
     /// Canon-lift'd `run()` entry. The adapter calls
     /// `__main_module__._start` and returns `ok` on normal return;

--- a/src/component/wit/metadata_encode.zig
+++ b/src/component/wit/metadata_encode.zig
@@ -1425,3 +1425,33 @@ test "metadata_encode: rejects use whose source iface is not in the world" {
     const r = encodeWorldFromSource(testing.allocator, source, "cmd");
     try testing.expectError(error.InvalidWit, r);
 }
+
+test "metadata_encode: use clause from qualified versioned source ref" {
+    // `use wasi:io/streams@0.2.6.{output-stream};` exercises
+    // `parseSemverText`'s lookahead so the `.` before `{` is not
+    // greedily swallowed as a semver continuation. Regression
+    // pin for the bug discovered while wiring Phase 1.c.3a
+    // (preview1.wit declaring `wasi:cli/stdout` + `wasi:cli/stderr`).
+    const source =
+        \\package wabt:demo@0.0.0;
+        \\interface streams { resource output-stream { } }
+        \\interface stdout {
+        \\    use wabt:demo/streams@0.0.0.{output-stream};
+        \\    get-stdout: func() -> own<output-stream>;
+        \\}
+        \\world cmd { import streams; import stdout; }
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "cmd");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const world_body = comp.types[0].component.decls[0].type.component;
+    // Same shape as the short-ref version: 5 world-body decls, with
+    // the alias-instance-export decl between `streams` and `stdout`.
+    try testing.expectEqual(@as(usize, 5), world_body.decls.len);
+    try testing.expectEqualStrings("output-stream", world_body.decls[2].alias.instance_export.name);
+}

--- a/src/component/wit/parser.zig
+++ b/src/component/wit/parser.zig
@@ -226,24 +226,34 @@ const Parser = struct {
     /// We don't validate the structure — the encoder treats it as
     /// opaque text. Just consume tokens that could appear inside a
     /// semver string until we hit a delimiter (`;` or `/` or `.`+id).
+    ///
+    /// `.`, `-`, `+` are only consumed when followed by an id or
+    /// integer; otherwise they're left for the caller. This matters
+    /// for `use wasi:io/streams@0.2.6.{output-stream};` where the
+    /// `.` between the version and `{` is a use-clause delimiter,
+    /// not a semver continuation. We save and restore lexer/lookahead
+    /// state so we can speculatively peek past the separator.
     fn parseSemverText(self: *Parser) ParseError![]const u8 {
         const first = try self.expect(.integer);
         const start = first.span.start;
         var end = first.span.end;
-        // Greedily consume `.<n>` and `-<id-or-int>` and `+<id-or-int>`
-        // sequences.
         while (true) {
             const t = try self.peekTok();
             switch (t.tag) {
                 .period, .minus, .plus => {
-                    _ = try self.nextTok();
-                    end = t.span.end;
+                    const saved_pos = self.lex.pos;
+                    const saved_lookahead = self.lookahead;
+                    _ = try self.nextTok(); // consume sep
                     const after = try self.nextTok();
-                    end = after.span.end;
-                    // `after` should be an id or integer; accept both.
                     if (after.tag != .id and after.tag != .integer) {
-                        return self.fail(after.span, "invalid semver token");
+                        // Not a semver continuation — rewind so the
+                        // caller sees `t` (the separator) as the
+                        // next token.
+                        self.lex.pos = saved_pos;
+                        self.lookahead = saved_lookahead;
+                        break;
                     }
+                    end = after.span.end;
                 },
                 else => break,
             }


### PR DESCRIPTION
Phase 1.c.3a (cataggar/wamr#453): widen the wasi-preview1 adapter's WIT so the encoded `component-type:` section advertises the preview2 stdio surface the upcoming `fd_write` lowering will consume. Stacked on #149.

## Changes

* **wit/deps/wasi-cli/stdio.wit (new)** — declares `interface stdout` + `interface stderr` mirroring the upstream `bytecodealliance/wasi-cli@v0.2.6` shape, trimmed to the two funcs the adapter actually calls. Each interface uses `use wasi:io/streams@0.2.6.{output-stream};` to pull in the byte-sink resource via the encoder paths from #149. Uses explicit `-> own<output-stream>` rather than the canonical bare `-> output-stream` form (the latter depends on wit-component's implicit-`own<>` sugar, which this encoder does not yet provide).
* **wit/deps/wasi-cli/world.wit** — drops the `package wasi:cli@0.2.6;` directive (now lives in `stdio.wit`, which sorts first alphabetically and is parsed first by `resolver.readWitDir`).
* **wit/preview1.wit** — `world command` adds `import wasi:cli/stdout@0.2.6;` + `import wasi:cli/stderr@0.2.6;`. Header comment updated to phase 1.c.3a wording.

## Parser fix (drive-by)

`parseSemverText` greedily consumed `.<token>` sequences and emitted *"invalid semver token"* on `use wasi:io/streams@0.2.6.{output-stream};` because the `.` separating the version from `{` got eaten as a semver continuation. Fixed by saving lexer position + lookahead before the speculative consume and rewinding when the next-next token isn't an id or integer. New regression test `use clause from qualified versioned source ref` covers it.

## Validation

* `zig build test --summary all`: 409/409 tests pass (pre-existing spec test passes too — was a stale-cache artefact).
* `zig build adapter`: `wasi_snapshot_preview1.command.wasm` 1254 → 1420 bytes, encoded section 371 → 537 bytes. `build_adapter`'s `parseFromAdapterCore` self-check still round-trips. Byte-search confirms `wasi:cli/stdout`, `wasi:cli/stderr`, `get-stdout`, `get-stderr`, `output-stream`, and `blocking-write-and-flush` all appear in the encoded wire bytes.