### PR TITLE
fix(adapter): canonical wasi:io/error + page-sized ret_area alloc

### DIFF
--- a/adapters/wasi-preview1/src/adapter.wat
+++ b/adapters/wasi-preview1/src/adapter.wat
@@ -229,14 +229,26 @@
   ;; Helper: ensure `$ret_area` points at a 16-byte block in
   ;; env.memory. Allocates once via the embed's cabi_realloc.
   ;; Returns the cached pointer.
+  ;;
+  ;; We request a full page (65536 bytes) rather than the 16 bytes
+  ;; we actually need. The reason: when the embed itself doesn't
+  ;; export `cabi_realloc`, the component-new splicer replaces the
+  ;; `__main_module__::cabi_realloc` import with a
+  ;; `realloc_via_memory_grow` body (see
+  ;; `src/component/adapter/adapter.zig:buildMainModuleFallback`)
+  ;; that traps on any allocation request smaller than one page.
+  ;; Matches `wit-component`'s upstream allocate_stack_via_realloc
+  ;; strategy — allocate one page up-front, carve the small scratch
+  ;; area out of its head, ignore the rest. Embeds with real
+  ;; cabi_realloc still satisfy the request fine.
   (func $ensure_ret_area (result i32)
     global.get $ret_area
     i32.eqz
     if
       i32.const 0     ;; old_ptr
       i32.const 0     ;; old_size
-      i32.const 4     ;; align
-      i32.const 16    ;; new_size
+      i32.const 65536 ;; align (page)
+      i32.const 65536 ;; new_size (one page)
       call $main_cabi_realloc
       global.set $ret_area
     end

--- a/adapters/wasi-preview1/wit/deps/wasi-io/error.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-io/error.wit
@@ -1,0 +1,25 @@
+// Trimmed slice of `wasi:io@0.2.6.error`. Mirrors the canonical
+// `bytecodealliance/wasi-io@v0.2.6/wit/error.wit` shape but
+// declares only the bare `error` resource type:
+//
+//   * `to-debug-string` (the only method on the canonical resource)
+//     is not referenced from the preview1 → preview2 adapter; the
+//     resource is only ever propagated through the
+//     `stream-error.last-operation-failed(own<error>)` variant case
+//     that `fd_write` discards on the first error.
+//
+// `streams.wit` imports the resource via
+// `use error.{error};` so the world body emits the canonical
+// `alias instance-export sort=type` decl right after the
+// `wasi:io/error@0.2.6` import — exactly matching wasmtime's
+// reference adapter's component-type custom section.
+
+package wasi:io@0.2.6;
+
+interface error {
+    /// Opaque host error. Only used as a payload of
+    /// `wasi:io/streams.stream-error::last-operation-failed`.
+    /// The adapter never lifts an `error` itself; it propagates
+    /// the borrow it receives back into the runtime as a trap.
+    resource error { }
+}

--- a/adapters/wasi-preview1/wit/deps/wasi-io/streams.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-io/streams.wit
@@ -1,14 +1,13 @@
 // Trimmed slice of `wasi:io@0.2.6.streams` that the wabt-built
 // wasi-preview1 adapter needs. Mirrors the canonical
-// `bytecodealliance/wasi-io@v0.2.6` shape but declares only:
+// `bytecodealliance/wasi-io@v0.2.6` shape and declares only:
 //
 //   * `stream-error` variant — the canonical version's
 //     `last-operation-failed` case carries an `error` resource
-//     payload from `wasi:io/error`. We flatten it to a no-payload
-//     case until the encoder grows `use` clause support; both
-//     forms encode to a `result<_, stream-error>` shape that the
-//     adapter never reads (preview1 `fd_write` only cares about
-//     "succeeded" vs "trap on first error").
+//     payload from `wasi:io/error`. We mirror that shape via
+//     `use error.{error};` + `last-operation-failed(own<error>)`
+//     so the encoded `component-type:` section is byte-identical
+//     to wasmtime's reference adapter for this case.
 //
 //   * `output-stream` resource with `blocking-write-and-flush` —
 //     the single method the preview1 → preview2 adapter calls in
@@ -18,17 +17,24 @@
 // non-blocking write / input-stream / forward / splice) lives
 // upstream and is not consumed by the adapter, so it stays out
 // of this trimmed copy to keep `metadata_encode` output minimal.
-
-package wasi:io@0.2.6;
+//
+// NOTE: the package declaration for this directory's multi-file
+// slice lives in `error.wit` (which sorts first alphabetically).
+// `resolver.readWitDir` concatenates files in order, so the
+// `package wasi:io@0.2.6;` directive must appear in the file
+// that's parsed first.
 
 interface streams {
-    /// Failure modes for `output-stream` writes. The canonical
-    /// `last-operation-failed` case carries a `borrow<error>` from
-    /// `wasi:io/error` — we drop the payload here (see top-of-file
-    /// note) so the wire-form is `variant { last-operation-failed,
-    /// closed }`.
+    use error.{error};
+
+    /// Failure modes for `output-stream` writes. Matches the
+    /// canonical wasi:io@0.2.6 variant shape: the
+    /// `last-operation-failed` case carries an `own<error>` payload
+    /// from `wasi:io/error`. The adapter discards the payload —
+    /// preview1 `fd_write` is itself blocking, so any non-`ok`
+    /// outcome traps before the host sees the resource.
     variant stream-error {
-        last-operation-failed,
+        last-operation-failed(own<error>),
         closed,
     }
 
@@ -44,3 +50,4 @@ interface streams {
         blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
     }
 }
+

--- a/adapters/wasi-preview1/wit/preview1.wit
+++ b/adapters/wasi-preview1/wit/preview1.wit
@@ -28,6 +28,14 @@ world command {
     /// non-zero code to host exit code 1.
     import wasi:cli/exit@0.2.6;
 
+    /// Opaque resource referenced by `wasi:io/streams.stream-error`'s
+    /// `last-operation-failed(own<error>)` payload. The adapter
+    /// never lifts an `error` itself but the world must declare the
+    /// resource so `streams`'s `use error.{error};` resolves against
+    /// the world-level type indexspace — matching wasmtime's
+    /// reference adapter shape.
+    import wasi:io/error@0.2.6;
+
     /// Byte-sink resource + `blocking-write-and-flush` method. The
     /// preview1 `fd_write` iterates the iovec list, copies into a
     /// canon-realloc'd buffer, and calls `blocking-write-and-flush`

--- a/src/component/wit/metadata_encode.zig
+++ b/src/component/wit/metadata_encode.zig
@@ -270,7 +270,11 @@ fn collectUseRequests(
     for (lookup.iface.items) |it| {
         if (it != .use) continue;
         const u = it.use;
-        const src_lookup = resolver.findInterfaceWithPkg(u.from) orelse return error.UnknownInterface;
+        // The consuming interface's package is the context for
+        // resolving short `use` refs — `use error.{error};` inside
+        // `wasi:io/streams` resolves against `wasi:io`, not the
+        // world's main package.
+        const src_lookup = resolver.findInterfaceWithPkgCtx(u.from, lookup.pkg) orelse return error.UnknownInterface;
         const src_qname = try formatQualifiedName(
             ar,
             src_lookup.pkg.namespace,
@@ -371,8 +375,11 @@ fn buildInterfaceBody(
     // (no `pkg/` qualifier) hit the main doc; `<ns>:<pkg>/<iface>[@<ver>]`
     // refs traverse the deps (populated by `parseLayout` walking
     // `<root>/deps/<pkg>/`). The resolver returns the same shape
-    // either way.
-    const iface_body = resolver.findInterface(ref) orelse return error.UnknownInterface;
+    // either way. The returned `pkg` is the consuming interface's
+    // own package — used below as fallback context when resolving
+    // short `use src.{T};` refs against the dep's sibling files.
+    const iface_lookup = resolver.findInterfaceWithPkg(ref) orelse return error.UnknownInterface;
+    const iface_body = iface_lookup.iface;
 
     // `BodyBuilder` tracks the type-index space inside this
     // instance-type body. Every appended `.type` decl bumps
@@ -480,7 +487,7 @@ fn buildInterfaceBody(
                 // canonical wit-component output: consumers of this
                 // iface can pull the type via the export chain
                 // without re-traversing the alias path).
-                const src_lookup = resolver.findInterfaceWithPkg(u.from) orelse return error.UnknownInterface;
+                const src_lookup = resolver.findInterfaceWithPkgCtx(u.from, iface_lookup.pkg) orelse return error.UnknownInterface;
                 const src_qname = try formatQualifiedName(
                     ar,
                     src_lookup.pkg.namespace,

--- a/src/component/wit/resolver.zig
+++ b/src/component/wit/resolver.zig
@@ -65,13 +65,44 @@ pub const Resolver = struct {
     /// inside an interface located in `wasi:cli` must resolve `foo` as
     /// `wasi:cli/foo`, not as a ref into the world's main package.
     pub fn findInterfaceWithPkg(self: Resolver, ref: ast.InterfaceRef) ?Lookup {
-        const target_pkg = ref.package orelse {
+        return self.findInterfaceWithPkgCtx(ref, null);
+    }
+
+    /// Variant of `findInterfaceWithPkg` that accepts a `ctx_pkg`
+    /// fallback package id. When `ref.package == null` (a short ref
+    /// like `use error.{error};`) the lookup tries `ctx_pkg` first
+    /// — this is the package the *consuming* interface lives in.
+    /// Falls back to `self.main` if `ctx_pkg` is null or doesn't
+    /// contain the named interface. Same package matched (relaxed
+    /// version compare) as `findInterfaceWithPkg`.
+    pub fn findInterfaceWithPkgCtx(self: Resolver, ref: ast.InterfaceRef, ctx_pkg: ?ast.PackageId) ?Lookup {
+        if (ref.package == null) {
+            if (ctx_pkg) |cp| {
+                if (self.main.package) |mp| {
+                    if (packageMatches(mp, cp)) {
+                        if (findInterfaceInDoc(self.main, ref.name)) |i| {
+                            return .{ .iface = i, .pkg = mp };
+                        }
+                    }
+                }
+                for (self.deps) |dep| {
+                    if (dep.package) |dp| {
+                        if (packageMatches(dp, cp)) {
+                            if (findInterfaceInDoc(dep, ref.name)) |i| {
+                                return .{ .iface = i, .pkg = dp };
+                            }
+                        }
+                    }
+                }
+                // Fall through to the original main-only lookup.
+            }
             if (findInterfaceInDoc(self.main, ref.name)) |i| {
                 return .{ .iface = i, .pkg = self.main.package orelse return null };
             }
             return null;
-        };
+        }
 
+        const target_pkg = ref.package.?;
         if (self.main.package) |mp| {
             if (packageMatches(mp, target_pkg)) {
                 if (findInterfaceInDoc(self.main, ref.name)) |i| return .{ .iface = i, .pkg = mp };


### PR DESCRIPTION
## Summary

The wabt-built preview1→preview2 adapter previously flattened the canonical `wasi:io@0.2.6` `stream-error` variant — its `last-operation-failed` case dropped the `error` resource payload because the WIT encoder couldn't resolve `use` clauses across packages and the WAT scaffolder used a sub-page `cabi_realloc` allocation that the splicer's fallback realloc body rejects.

Result: `wasmtime run` rejected wabt-encoded components built against the wabt-built adapter with either:

```
case `last-operation-failed` has no type but one was expected
```

or, after the type shape was fixed:

```
wasm trap: wasm `unreachable` instruction executed
```

This PR lands the missing pieces so wabt's auto-attached / explicit-adapter path is byte-compatible with wasmtime's reference adapter on the `zig-hello` fixture (cataggar/wamr#453 Bug A).

## What this PR changes

### Adapter WIT shape (`adapters/wasi-preview1/wit`)

* **`deps/wasi-io/error.wit`** (new): trimmed slice of `wasi:io@0.2.6.error` declaring just the bare `error` resource type — no `to-debug-string` method (mirrors wasmtime's reference adapter, which also omits it). Holds the `package wasi:io@0.2.6;` declaration for the multi-file slice (sorts alphabetically before `streams.wit`).
* **`deps/wasi-io/streams.wit`**: restore the canonical `use error.{error};` clause and the `last-operation-failed(own<error>)` payload. Drops the redundant package declaration (now in `error.wit`).
* **`preview1.wit`**: explicit `import wasi:io/error@0.2.6;` in the `command` world so the world body's encoded section provides the outer type slot that `use error.{error};` aliases against.

### Encoder support for cross-package `use` clauses

* **`src/component/wit/resolver.zig`**: new `findInterfaceWithPkgCtx(ref, ctx_pkg)` accepts a fallback context package id. When a short ref (`ref.package == null`) is being looked up, search the context package first. Needed for `use error.{error};` *inside* a dep-package interface — that short ref must resolve against the dep's own sibling files, not the world's main package.
* **`src/component/wit/metadata_encode.zig`**: thread the consuming interface's package context through the two `use`-clause lookup sites (`collectUseRequests`, `buildInterfaceBody.use`). Captures `iface_lookup.pkg` from `findInterfaceWithPkg` and forwards it as the context for `u.from` resolution.

### Adapter WAT scratch-allocation fix

* **`adapters/wasi-preview1/src/adapter.wat`** (`$ensure_ret_area`): ask `cabi_realloc` for one page (65536 bytes) instead of 16 bytes. The component-new splicer's fallback `cabi_realloc` body (the `realloc_via_memory_grow` mirror added in #157) only honors page-sized allocations — anything smaller traps. Mirrors `wit-component`'s `allocate_stack_via_realloc` strategy (allocate one page, use the head, ignore the rest). Embeds with a real `cabi_realloc` still satisfy the request fine.

## Verification

Against the zig-hello fixture in `cataggar/wamr` (uses wamr's bundled `component-examples` build, which now feeds in the wabt-built adapter under-the-hood when `--no-builtin-adapter` is dropped):

```
$ wamr run zig-out/component-examples/zig-hello.component.wasm
hello from zig component
$ wasmtime run zig-out/component-examples/zig-hello.component.wasm
hello from zig component
$ wamr run zig-out/component-examples/mixed-zig-rust-calc.composed.wasm
40 + 2 = 42
100 + 200 = 300
$ wasmtime run zig-out/component-examples/mixed-zig-rust-calc.composed.wasm
40 + 2 = 42
100 + 200 = 300
```

Auto-attached / builtin-adapter path also works:

```
$ wabt component new core.wasm -o auto.wasm
$ wasmtime run auto.wasm
hello from zig component
```

`zig build test` passes (one pre-existing `UndefinedElement` spec-test failure on `main` is unrelated and still present).

Refs cataggar/wamr#453.