### PR TITLE
fix(build): resolve adapter tool target via resolveTargetQuery({})

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -85,17 +85,31 @@ pub fn build(b: *std.Build) void {
     // `adapters/wasi-preview1/README.md` for the surface coverage, the
     // current scaffold status, and the roadmap up to the embedded-default
     // adapter for `wabt component new` (tracked under cataggar/wamr#453).
+    // Build the tool for the actual host machine (NOT the user's
+    // `-Dtarget`): the tool runs at build time on the build platform
+    // to produce the adapter wasm. `b.graph.host` in Zig 0.16 returns
+    // the user-selected `-Dtarget` when one is set (verified failing
+    // on the `wasi`/`riscv64` release matrix entries), so we resolve
+    // the native query explicitly here.
+    const native_host = b.resolveTargetQuery(.{});
+
+    // The wabt module itself is compiled for the user's target; the
+    // tool needs a separate copy compiled for the host so the
+    // build-time `build-wasi-preview1-adapter` exe is executable on
+    // the CI runner.
+    const wabt_host_mod = b.createModule(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = native_host,
+        .optimize = optimize,
+    });
+    wabt_host_mod.addOptions("build_options", options);
+
     const adapter_tool_mod = b.createModule(.{
         .root_source_file = b.path("adapters/wasi-preview1/tools/build_adapter.zig"),
-        // Build the tool for the host so we can run it; the adapter
-        // artifact it emits is the wasm target itself.
-        .target = b.graph.host,
+        .target = native_host,
         .optimize = optimize,
-        .strip = if (strip) true else null,
-        .stack_protector = if (stack_protector) true else null,
-        .link_libc = if (link_libc) true else null,
         .imports = &.{
-            .{ .name = "wabt", .module = wabt_mod },
+            .{ .name = "wabt", .module = wabt_host_mod },
         },
     });
     const adapter_tool_exe = b.addExecutable(.{


### PR DESCRIPTION
## Summary

`b.graph.host` in Zig 0.16 returns the user's `-Dtarget` when one is set (rather than the actual build host), so the `build-wasi-preview1-adapter` tool was being cross-compiled to e.g. `wasm32-wasi` / `riscv64-linux` and then attempted to run on the CI runner. Both the `wasi` and `linux-riscv64` release matrix entries failed for v3.0.0-dev.5 with:

```
LLVM ERROR: 64-bit code requested on a subtarget that doesn't support it!
'+a' is not a recognized feature for this target (ignoring feature)
```

## What this PR changes

Resolve the native host explicitly via `b.resolveTargetQuery(.{})`, then build a host-targeted copy of the wabt module (needed by the tool's `@import("wabt")`) alongside the tool itself. The user-targeted wabt CLI build still depends on the host-built tool to produce the embedded adapter wasm.

## Verification

Verified locally on aarch64-linux:

```
$ zig build -Doptimize=ReleaseSafe -Dtarget=wasm32-wasi -Dstrip=true -Dstack-protector=true -Dversion=3.0.0-dev.5-test
$ file zig-out/bin/wabt.wasm
zig-out/bin/wabt.wasm: WebAssembly (wasm) binary module version 0x1 (MVP)

$ zig build -Doptimize=ReleaseSafe -Dtarget=riscv64-linux -Dstrip=true -Dstack-protector=true -Dversion=3.0.0-dev.5-test
(succeeds)
```

Re-tagging `v3.0.0-dev.5` after this merges will unblock the release.