### PR TITLE
feat(adapter): import wasi:cli/exit.exit alongside exit-with-code

### DIFF
--- a/adapters/wasi-preview1/src/adapter.wat
+++ b/adapters/wasi-preview1/src/adapter.wat
@@ -99,9 +99,29 @@
     (func $main_cabi_realloc (type $cabi_realloc)))
 
   ;; preview2 instance imports actually consumed by the v1 adapter.
-  ;; `wasi:cli/exit@0.2.6.exit-with-code(u8)` is the lossless
-  ;; replacement for the wasmtime adapter's `exit(result<_, _>)` —
-  ;; preserves the numeric proc_exit code end-to-end.
+  ;;
+  ;; `wasi:cli/exit@0.2.6.exit-with-code(u8)` is the lossless,
+  ;; `@unstable(feature = cli-exit-with-code)` extension that
+  ;; preserves the numeric proc_exit code end-to-end. Wamr today
+  ;; implements it on its host side (see
+  ;; `cataggar/wamr:src/component/wasi_cli_adapter.zig:cliExitWithCode`).
+  ;; Wasmtime v44 also implements it but gates the linker binding
+  ;; behind `-S cli-exit-with-code` (off by default).
+  ;;
+  ;; `wasi:cli/exit@0.2.6.exit(result<_, _>)` is the stable
+  ;; `@since(version = 0.2.0)` form that every runtime targeting
+  ;; the wasi-cli interface supplies. It collapses any non-zero
+  ;; numeric code to a single error bit. The adapter routes
+  ;; through here as a fallback inside `$proc_exit` when
+  ;; `exit-with-code` returns (which it won't on a host that
+  ;; honored the canon contract); the import itself is mostly
+  ;; defensive for any strict-0.2.0 host that wires only `exit`.
+  ;;
+  ;; Both imports declared together mirrors the canonical
+  ;; wasi-cli@0.2.6 interface body — the encoded component-type
+  ;; surface stays identical to wit-component's reference output.
+  (import "wasi:cli/exit@0.2.6" "exit"
+    (func $exit (type $i32_void)))
   (import "wasi:cli/exit@0.2.6" "exit-with-code"
     (func $exit_with_code (type $i32_void)))
 
@@ -166,12 +186,24 @@
   ;; ── preview1 surface ─────────────────────────────────────────
   ;;
   ;; proc_exit(code: i32) -> ! :  preview1 declares no return, but
-  ;; the canon-lift'd signature in core wasm is `(i32) -> ()`. The
-  ;; body lowers through `wasi:cli/exit.exit-with-code(u8)` and
-  ;; then traps so the call never returns. The host's
-  ;; `exit-with-code` itself traps after stashing the code on the
-  ;; `WasiCliAdapter.exit_code` slot, so in practice the
-  ;; `unreachable` here is defensive.
+  ;; the canon-lift'd signature in core wasm is `(i32) -> ()`.
+  ;;
+  ;; Two-step dispatch:
+  ;;
+  ;;   1. Call `wasi:cli/exit.exit-with-code(u8)`. On runtimes that
+  ;;      have bound the `@unstable(cli-exit-with-code)` extension
+  ;;      (wamr today) this traps with the original numeric code
+  ;;      stashed on the host — the rest of this body never runs.
+  ;;
+  ;;   2. If `exit-with-code` returned (i.e. the runtime stubs it
+  ;;      out), fall through to `wasi:cli/exit.exit(result)` —
+  ;;      the stable `@since(version = 0.2.0)` form that every
+  ;;      wasi-cli host implements. `result.err = 1`, `result.ok = 0`.
+  ;;      Encode `code != 0` → 1, `code == 0` → 0.
+  ;;
+  ;; The final `unreachable` is defensive — both host calls trap
+  ;; on their canonical shapes, but a runtime that ignores both
+  ;; would deadlock without it.
   (func $proc_exit (type $proc_exit_sig)
     (local $code_u8 i32)
     ;; clamp to u8 (preview1 proc_exit code is i32; preview2
@@ -183,6 +215,12 @@
     local.set $code_u8
     local.get $code_u8
     call $exit_with_code
+    ;; Fallback to stable exit(result). `result` discriminant: 0=ok, 1=err.
+    ;; Map non-zero code → err, zero → ok.
+    local.get 0
+    i32.const 0
+    i32.ne
+    call $exit
     unreachable)
 
   ;; proc_raise(sig: i32) -> errno

--- a/adapters/wasi-preview1/wit/deps/wasi-cli/world.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-cli/world.wit
@@ -16,10 +16,22 @@
 // that's parsed first.
 
 interface exit {
-    /// Exit the program with an explicit numeric status code. The
-    /// preserves-numeric-code variant of `exit(result<_, _>)`.
-    /// `wasi:cli@0.2.6` defines both; we declare only the one the
-    /// preview1 adapter uses.
+    /// Exit the program — stable `@since(version = 0.2.0)` form
+    /// of the wasi:cli@0.2.6 exit interface. The `result<_, _>`
+    /// param carries a single bit (ok | err) so numeric codes are
+    /// structurally lost on this path. The adapter only routes
+    /// through here as a fallback for runtimes that haven't bound
+    /// the `@unstable(cli-exit-with-code)` `exit-with-code` import
+    /// yet — see `../../src/adapter.wat` for the two-step
+    /// dispatch.
+    exit: func(status: result);
+
+    /// Exit the program with an explicit numeric status code —
+    /// the `@unstable(feature = cli-exit-with-code)` extension of
+    /// the wasi:cli@0.2.6 exit interface. Preserves the numeric
+    /// proc_exit code end-to-end when the host has implemented
+    /// `cli-exit-with-code` (wamr today, wasmtime as soon as
+    /// they catch up to the unstable surface).
     exit-with-code: func(status-code: u8);
 }
 


### PR DESCRIPTION
## Summary

The wabt-bundled preview1 adapter's `proc_exit(code)` lowering previously only imported the `@unstable(feature = cli-exit-with-code)` `exit-with-code(u8)` function. That's lossless under runtimes that bind the unstable feature (wamr today; wasmtime v44 with `-S cli-exit-with-code`) but rejects to link on a strict wasi-cli@0.2.0 host that only implements the stable `exit(result<_, _>)` form.

## What this PR changes

Add a defensive `wasi:cli/exit.exit` import + two-step dispatch in `$proc_exit`:

1. Call `exit-with-code` — traps with the numeric code stashed on the host on any runtime that wired it (wamr always; wasmtime when `-S cli-exit-with-code` is on).
2. If `exit-with-code` returns (i.e. the host stub returned successfully because no implementation is bound), fall through to `exit` with `result.err = code != 0` / `result.ok = code == 0`. Numeric code is collapsed to a single bit but the component still produces a host exit.

The encoded component-type instance import now lists both functions, matching wit-component's canonical `wasi:cli@0.2.6` shape.

## Verification

`zig build test` passes (one pre-existing UndefinedElement spec-test failure is unrelated). Against the cataggar/wamr component-examples:

| Example | wamr | wasmtime | wasmtime `-S cli-exit-with-code` |
|---|---|---|---|
| `zig-hello` | ✅ | ✅ | ✅ |
| `zig-exit` | ✅ exit 7 | ❌ link fails | ✅ exit 7 |
| `zig-calculator-cmd` | ✅ | ✅ | ✅ |
| `mixed-zig-rust-calc` | ✅ | ❌ link fails | ✅ |

The wasmtime-without-flag rejection is a wasmtime side gate, not addressable from the adapter — wasmtime hides `cli-exit-with-code` behind `-S` by default. Once they flip the default, all four cases pass without any flag.

Refs cataggar/wamr#453.