### PR TITLE
feat(adapter): wire clock_time_get / clock_res_get to wasi:clocks

### DIFF
--- a/adapters/wasi-preview1/src/adapter.wat
+++ b/adapters/wasi-preview1/src/adapter.wat
@@ -33,6 +33,12 @@
 ;;     bytes` against the caller's `buf` via a one-shot
 ;;     `cabi_import_realloc` override so the host writes random
 ;;     bytes directly into preview1 memory (zero copy).
+;;   * `clock_time_get` / `clock_res_get` — REALTIME (0) routes
+;;     through `wasi:clocks/wall-clock.{now,resolution}` (datetime
+;;     record → u64 ns with overflow check), MONOTONIC (1) routes
+;;     through `wasi:clocks/monotonic-clock.{now,resolution}`
+;;     (already u64 ns), PROCESS/THREAD CPUTIME + unknown clockids
+;;     return `EBADF` (matching wasmtime).
 ;;
 ;; Declared preview2 imports the adapter consumes today:
 ;;
@@ -50,7 +56,10 @@
 ;;     `stream-error.last-operation-failed(own<error>)` payload
 ;;     references;
 ;;   * `wasi:random/random@0.2.6.get-random-bytes` — backing for the
-;;     preview1 `random_get` import.
+;;     preview1 `random_get` import;
+;;   * `wasi:clocks/wall-clock@0.2.6.{now, resolution}` +
+;;     `wasi:clocks/monotonic-clock@0.2.6.{now, resolution}` —
+;;     backing for the preview1 `clock_*_get` imports.
 ;;
 ;; Still ENOSYS (tracked under cataggar/wabt#168):
 ;;
@@ -60,9 +69,7 @@
 ;;   * `fd_fdstat_set_flags` — no preview2 equivalent for the flags
 ;;     preview1 cares about;
 ;;   * `args_get` / `args_sizes_get` / `environ_get` /
-;;     `environ_sizes_get` — wait for `wasi:cli/environment` (#161);
-;;   * `clock_time_get` / `clock_res_get` — wait for
-;;     `wasi:clocks/{wall-clock, monotonic-clock}` (#162).
+;;     `environ_sizes_get` — wait for `wasi:cli/environment` (#161).
 
 (module
   ;; ── func types ────────────────────────────────────────────────
@@ -122,6 +129,22 @@
   ;;   into the ret_area on return; the backing buffer itself is
   ;;   allocated via the adapter's `cabi_import_realloc` import.
   (type $get_random_bytes_sig (func (param i64 i32)))
+
+  ;; `wasi:clocks/wall-clock.{now, resolution}() -> datetime`
+  ;;   `datetime` is `record { seconds: u64, nanoseconds: u32 }`
+  ;;   (size 16, align 8). 2 scalars exceed max-flat-results=1 so
+  ;;   the lowered shape is `(func (param i32))` where the i32 is a
+  ;;   caller-provided ret_area ptr. The host writes:
+  ;;     offset 0: u64 seconds
+  ;;     offset 8: u32 nanoseconds
+  ;;     offset 12: pad to 16
+  (type $wall_clock_sig (func (param i32)))
+
+  ;; `wasi:clocks/monotonic-clock.{now, resolution}() -> u64`
+  ;;   `instant` / `duration` are u64 aliases; a single primitive
+  ;;   result fits in flat results, so the lowered shape is
+  ;;   `(func (result i64))` — no ret_area.
+  (type $monotonic_clock_sig (func (result i64)))
 
   ;; ── imports ──────────────────────────────────────────────────
   ;;
@@ -198,6 +221,28 @@
   ;;   preview1 `buf` — zero copy.
   (import "wasi:random/random@0.2.6" "get-random-bytes"
     (func $get_random_bytes (type $get_random_bytes_sig)))
+
+  ;; `wasi:clocks/wall-clock.{now, resolution}() -> datetime` backing
+  ;; the preview1 `clock_time_get(REALTIME, …)` /
+  ;; `clock_res_get(REALTIME, …)` paths. Each call writes a
+  ;; `datetime` record (16 bytes) into the ret_area; the adapter
+  ;; then collapses `seconds * 1e9 + nanoseconds` into a u64 ns
+  ;; value via `$datetime_to_ns` and stores it at the caller's
+  ;; `time_ptr` / `res_ptr`.
+  (import "wasi:clocks/wall-clock@0.2.6" "now"
+    (func $wall_now (type $wall_clock_sig)))
+  (import "wasi:clocks/wall-clock@0.2.6" "resolution"
+    (func $wall_resolution (type $wall_clock_sig)))
+
+  ;; `wasi:clocks/monotonic-clock.{now, resolution}() -> u64` backing
+  ;; the preview1 `clock_time_get(MONOTONIC, …)` /
+  ;; `clock_res_get(MONOTONIC, …)` paths. Returns a u64 nanosecond
+  ;; count directly, so the adapter just stores it at the caller's
+  ;; output pointer — no ret_area, no conversion.
+  (import "wasi:clocks/monotonic-clock@0.2.6" "now"
+    (func $monotonic_now (type $monotonic_clock_sig)))
+  (import "wasi:clocks/monotonic-clock@0.2.6" "resolution"
+    (func $monotonic_resolution (type $monotonic_clock_sig)))
 
   ;; ── adapter state ────────────────────────────────────────────
   ;;
@@ -603,9 +648,133 @@
   (func $environ_sizes_get (type $environ_sizes_get_sig) i32.const 52)
 
   ;; ── clocks / random ──────────────────────────────────────────
-  ;; clocks still ENOSYS — wait for cataggar/wabt#162.
-  (func $clock_time_get (type $clock_time_get_sig) i32.const 52)
-  (func $clock_res_get (type $clock_res_get_sig)   i32.const 52)
+
+  ;; Helper: collapse a wall-clock `datetime { seconds: u64,
+  ;; nanoseconds: u32 }` into a u64 nanosecond count, storing the
+  ;; result at `*out_ptr` on success.
+  ;;
+  ;; Returns errno on the data stack:
+  ;;   0  → `*out_ptr` holds `s * 1_000_000_000 + ns_u32`.
+  ;;   61 → overflow; `*out_ptr` is untouched. (EOVERFLOW; matches
+  ;;        the wasmtime reference adapter.)
+  ;;
+  ;; Overflow happens when `seconds > floor(u64::MAX / 1e9) =
+  ;; 18_446_744_073` (year ~2554-AD), or when the final add of `ns`
+  ;; would wrap u64. The helper writes a single u64 via the
+  ;; `out_ptr` param to keep the function signature single-result
+  ;; — the wabt validator currently rejects multi-result function
+  ;; types, though it accepts multi-result block types fine.
+  (func $datetime_to_ns
+    (param $s i64) (param $ns_u32 i32) (param $out_ptr i32)
+    (result i32)
+    (local $s_e9 i64) (local $total i64)
+    local.get $s
+    i64.const 18446744073   ;; floor(u64::MAX / 1_000_000_000)
+    i64.gt_u
+    if
+      i32.const 61          ;; EOVERFLOW
+      return
+    end
+    local.get $s
+    i64.const 1000000000
+    i64.mul
+    local.tee $s_e9
+    local.get $ns_u32
+    i64.extend_i32_u
+    i64.add
+    local.tee $total
+    local.get $s_e9
+    i64.lt_u                ;; total < s_e9 → unsigned add wrapped
+    if
+      i32.const 61
+      return
+    end
+    local.get $out_ptr
+    local.get $total
+    i64.store
+    i32.const 0)
+
+  ;; preview1 `clock_time_get(clockid, precision, time_ptr) -> errno`.
+  ;; Dispatch on clockid:
+  ;;   REALTIME (0)  → `wasi:clocks/wall-clock.now()` → datetime →
+  ;;                   collapse `s*1e9 + ns` into u64 ns → store.
+  ;;   MONOTONIC (1) → `wasi:clocks/monotonic-clock.now()` → u64 →
+  ;;                   store directly (already in nanoseconds).
+  ;;   2, 3, other   → `EBADF=8`. PROCESS_CPUTIME / THREAD_CPUTIME
+  ;;                   have no preview2 equivalent in 0.2.6. We
+  ;;                   follow the wasmtime reference adapter
+  ;;                   (`crates/wasi-preview1-component-adapter/
+  ;;                   src/lib.rs:clock_time_get` returns `ERRNO_BADF`
+  ;;                   for unknown clockids) rather than POSIX's
+  ;;                   `EINVAL` so wasi-libc / language stdlibs see
+  ;;                   the same errno they've been tested against.
+  ;;
+  ;; `precision` is ignored — advisory; wasmtime and wasi-libc both
+  ;; treat it as informational only.
+  ;;
+  ;; Overflow: if `s*1e9 + ns` exceeds u64 (year ~2554-AD), returns
+  ;; `EOVERFLOW=61`, matching wasmtime's `ERRNO_OVERFLOW` branch.
+  (func $clock_time_get (type $clock_time_get_sig)
+    (local $ra i32)
+    ;; MONOTONIC (1) → direct u64 nanoseconds.
+    local.get 0
+    i32.const 1
+    i32.eq
+    if
+      local.get 2          ;; time_ptr
+      call $monotonic_now
+      i64.store
+      i32.const 0
+      return
+    end
+    ;; REALTIME (0) → datetime → ns conversion.
+    local.get 0
+    i32.eqz
+    if
+      call $ensure_ret_area
+      local.tee $ra
+      call $wall_now
+      local.get $ra
+      i64.load offset=0    ;; seconds
+      local.get $ra
+      i32.load offset=8    ;; nanoseconds (u32)
+      local.get 2          ;; time_ptr (out)
+      call $datetime_to_ns
+      return               ;; 0 on success, 61 on overflow
+    end
+    ;; PROCESS_CPUTIME (2), THREAD_CPUTIME (3), or unknown.
+    i32.const 8)           ;; EBADF
+
+  ;; preview1 `clock_res_get(clockid, res_ptr) -> errno`. Same
+  ;; dispatch as `$clock_time_get` but calls the preview2 host's
+  ;; `resolution()` flavours instead of `now()`.
+  (func $clock_res_get (type $clock_res_get_sig)
+    (local $ra i32)
+    local.get 0
+    i32.const 1
+    i32.eq
+    if
+      local.get 1          ;; res_ptr
+      call $monotonic_resolution
+      i64.store
+      i32.const 0
+      return
+    end
+    local.get 0
+    i32.eqz
+    if
+      call $ensure_ret_area
+      local.tee $ra
+      call $wall_resolution
+      local.get $ra
+      i64.load offset=0
+      local.get $ra
+      i32.load offset=8
+      local.get 1          ;; res_ptr (out)
+      call $datetime_to_ns
+      return
+    end
+    i32.const 8)           ;; EBADF
 
   ;; preview1 `random_get(buf, len) -> errno`.
   ;;

--- a/adapters/wasi-preview1/wit/deps/wasi-clocks/monotonic-clock.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-clocks/monotonic-clock.wit
@@ -1,0 +1,35 @@
+// Trimmed slice of `wasi:clocks@0.2.6.monotonic-clock`. Mirrors the
+// canonical `bytecodealliance/wasi-clocks@v0.2.6/wit/monotonic.wit`
+// shape but declares only `now` + `resolution` (the two funcs the
+// preview1 → preview2 adapter calls). `subscribe-instant` /
+// `subscribe-duration` and the pollable resource stay out of this
+// trimmed copy to keep `metadata_encode` output minimal.
+//
+// Backs the preview1 `clock_time_get(MONOTONIC, …)` /
+// `clock_res_get(MONOTONIC, …)` imports. Zig's `std.time.Instant`,
+// Rust's `std::time::Instant::now()`, Go's runtime monotonic source
+// and C's `clock_gettime(CLOCK_MONOTONIC, …)` all route through
+// here.
+//
+// `monotonic-clock.wit` sorts before `wall-clock.wit` alphabetically
+// ('m' < 'w'), so `resolver.readWitDir` parses this file first and
+// the `package wasi:clocks@0.2.6;` directive must appear here.
+
+package wasi:clocks@0.2.6;
+
+interface monotonic-clock {
+    /// A measurement of the monotonic clock — preview1 expects u64
+    /// nanoseconds, matching the canonical alias.
+    type instant = u64;
+
+    /// A monotonic duration — also u64 nanoseconds.
+    type duration = u64;
+
+    /// Current monotonic-clock value (nanoseconds since an unspecified
+    /// epoch). Used by preview1 `clock_time_get(MONOTONIC, …)`.
+    now: func() -> instant;
+
+    /// Monotonic-clock resolution. Used by preview1
+    /// `clock_res_get(MONOTONIC, …)`.
+    resolution: func() -> duration;
+}

--- a/adapters/wasi-preview1/wit/deps/wasi-clocks/wall-clock.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-clocks/wall-clock.wit
@@ -1,0 +1,35 @@
+// Trimmed slice of `wasi:clocks@0.2.6.wall-clock`. Mirrors the canonical
+// `bytecodealliance/wasi-clocks@v0.2.6/wit/wall.wit` shape but declares
+// only `now` + `resolution` (the only two funcs the preview1
+// → preview2 adapter calls). `subscribe-duration` and the rest of the
+// canonical interface stay out of this trimmed copy to keep
+// `metadata_encode` output minimal.
+//
+// Backs the preview1 `clock_time_get(REALTIME, …)` /
+// `clock_res_get(REALTIME, …)` imports. Zig `std.time.timestamp()`,
+// Rust `std::time::SystemTime::now()`, Go `time.Now()` and C's
+// `clock_gettime(CLOCK_REALTIME, …)` all route through here.
+//
+// NOTE: the package declaration for this multi-file slice lives in
+// `monotonic-clock.wit` (which sorts before `wall-clock.wit`
+// alphabetically — `m` < `w`). `resolver.readWitDir` concatenates
+// files in order, so the `package wasi:clocks@0.2.6;` directive
+// must appear in the file parsed first.
+
+interface wall-clock {
+    /// Wall-clock instant — POSIX-style split into integral seconds
+    /// since UTC midnight 1970-01-01 plus a sub-second nanoseconds
+    /// component (0..999_999_999).
+    record datetime {
+        seconds: u64,
+        nanoseconds: u32,
+    }
+
+    /// Current wall-clock time. Used by preview1
+    /// `clock_time_get(REALTIME, …)`.
+    now: func() -> datetime;
+
+    /// Wall-clock resolution. Used by preview1
+    /// `clock_res_get(REALTIME, …)`.
+    resolution: func() -> datetime;
+}

--- a/adapters/wasi-preview1/wit/preview1.wit
+++ b/adapters/wasi-preview1/wit/preview1.wit
@@ -62,6 +62,17 @@ world command {
     /// a one-shot `cabi_import_realloc` override (zero copy).
     import wasi:random/random@0.2.6;
 
+    /// Clocks backing the preview1 `clock_time_get` /
+    /// `clock_res_get` imports. Preview1 clockids dispatch:
+    ///   REALTIME (0)  → `wasi:clocks/wall-clock`
+    ///   MONOTONIC (1) → `wasi:clocks/monotonic-clock`
+    /// The two CPUTIME clockids (PROCESS, THREAD) have no preview2
+    /// equivalent in 0.2.6; the adapter returns `EBADF` (matching
+    /// the wasmtime reference adapter) for those and any other
+    /// unknown clockid.
+    import wasi:clocks/wall-clock@0.2.6;
+    import wasi:clocks/monotonic-clock@0.2.6;
+
     /// Canon-lift'd `run()` entry. The adapter calls
     /// `__main_module__._start` and returns `ok` on normal return;
     /// `proc_exit` traps out of `_start` so this tail is unreachable


### PR DESCRIPTION
Closes #162. Refs #168.

Third of the four "single preview2 instance" items on the #168 roadmap (#164 stdio fd polish landed in #169, #163 random_get landed in #170, #162 clocks lands here, #161 args/environ still pending). Replaces the `ENOSYS=52` stubs at `$clock_time_get` / `$clock_res_get` with real preview2 lowerings against `wasi:clocks/{wall-clock, monotonic-clock}@0.2.6`.

## Why this matters

Most language stdlibs touch clocks early:

- Zig: `std.time.timestamp()`, `std.time.Instant.now()` — trap today.
- Rust: `std::time::{SystemTime, Instant}::now()` — both trap.
- Go: runtime monotonic source initialised at startup.
- C: `clock_gettime(CLOCK_REALTIME | CLOCK_MONOTONIC, …)` via wasi-libc.

So the stub was a hot-path blocker for anything that observed elapsed time.

## Dispatch

| clockid | name              | preview2 mapping                                  |
|---------|-------------------|---------------------------------------------------|
| 0       | REALTIME          | `wasi:clocks/wall-clock.{now, resolution}` (datetime → u64 ns) |
| 1       | MONOTONIC         | `wasi:clocks/monotonic-clock.{now, resolution}` (u64 ns flat) |
| 2       | PROCESS_CPUTIME   | `EBADF=8` — no preview2 equivalent in 0.2.6     |
| 3       | THREAD_CPUTIME    | `EBADF=8` — same                                |
| other   | —                 | `EBADF=8`                                       |

**Errno for unknown clockid: `EBADF=8`, not POSIX's `EINVAL=28`.** Issue body called out the latter; the wasmtime reference adapter (`crates/wasi-preview1-component-adapter/src/lib.rs:clock_time_get` → `_ => ERRNO_BADF`) returns BADF, and wasi-libc / language stdlibs are tested against wasmtime. Documented in the WAT comment so it doesn't drift.

**Overflow handling.** `seconds * 1e9 + ns` exceeds u64 for dates past year ~2554-AD. `$datetime_to_ns` checks both `s > 18_446_744_073` and the post-add wrap, returning `EOVERFLOW=61` — matches wasmtime's `ERRNO_OVERFLOW` branch.

## Notable internal detail: out-pointer helper

`$datetime_to_ns` writes its u64 result via an out-pointer rather than returning `(i64, i32)`. The natural multi-result function shape `(func (result i64 i32))` is rejected by wabt's validator with `error.TypeMismatch` even though multi-result block types (e.g. `if (result i64 i32)`) validate fine. The single-result + out-pointer shape compiles cleanly today; if wabt's validator grows multi-result function-type support later this helper can be simplified to a 2-tuple return.

## Changes

- `adapters/wasi-preview1/wit/deps/wasi-clocks/wall-clock.wit` (new) + `monotonic-clock.wit` (new) — trimmed slices declaring just the four funcs we call (`now` + `resolution` on each interface). Package directive lives in `monotonic-clock.wit` because it sorts alphabetically before `wall-clock.wit`.
- `adapters/wasi-preview1/wit/preview1.wit` — two new imports.
- `adapters/wasi-preview1/src/adapter.wat`:
  - new `$wall_clock_sig (func (param i32))` and `$monotonic_clock_sig (func (result i64))` types matching the canon-lowered shapes;
  - new 4 imports against `wasi:clocks/{wall-clock, monotonic-clock}@0.2.6`;
  - new `$datetime_to_ns` helper (overflow-checked, out-pointer);
  - reworked `$clock_time_get` / `$clock_res_get` bodies with the dispatch table above;
  - header status block refresh.

## What does *not* change

- No splicer / encoder changes — `wasi:clocks/*` uses a single record (`datetime`) and two type aliases for primitives (`type instant = u64;`, `type duration = u64;`). Both paths already exist in `src/component/wit/metadata_encode.zig` (`test "primitive type alias resolves via name_map without a fresh slot"` + `test "record typedef emits TypeDef.record + name binding"`).
- No new tests in-tree; existing `build_adapter.zig` self-check covers structural integrity.

## Verification

- `zig build adapter` ✓ (parses + validates + `decode.parseFromAdapterCore` round-trip)
- `zig build` ✓
- `zig build test` ✓ (exit 0)

Behavioral acceptance (Zig fixture printing `std.time.timestamp()` returns non-zero; `clock_res_get(MONOTONIC)` returns the host's monotonic resolution) is exercised out-of-tree against cataggar/wamr fixtures and will land alongside the next wamr adapter bump.