### PR TITLE
feat(adapter): wire fd_prestat_* to wasi:filesystem/preopens (#165 subphase a1)

### DIFF
--- a/adapters/wasi-preview1/src/adapter.wat
+++ b/adapters/wasi-preview1/src/adapter.wat
@@ -46,6 +46,12 @@
 ;;     the host writes strings directly into the caller's preview1
 ;;     argv_buf / env_buf (no main-heap allocation for any of these
 ;;     paths).
+;;   * `fd_prestat_get` / `fd_prestat_dir_name` — lifts
+;;     `wasi:filesystem/preopens.get-directories` once per call into
+;;     the bump arena (no permanent cache) and reads the i-th
+;;     preopen out for `wasi-libc`'s startup walk. The wider
+;;     filesystem surface (path_open, fd_read, stat, readdir) is
+;;     still pending under subphases (a2)/(b)/(c) of #165.
 ;;
 ;; Declared preview2 imports the adapter consumes today:
 ;;
@@ -68,13 +74,20 @@
 ;;     preview1 `random_get` import;
 ;;   * `wasi:clocks/wall-clock@0.2.6.{now, resolution}` +
 ;;     `wasi:clocks/monotonic-clock@0.2.6.{now, resolution}` —
-;;     backing for the preview1 `clock_*_get` imports.
+;;     backing for the preview1 `clock_*_get` imports;
+;;   * `wasi:filesystem/preopens@0.2.6.get-directories` — backing
+;;     for the preview1 `fd_prestat_*` walk;
+;;   * `wasi:filesystem/types@0.2.6` — only the bare `descriptor`
+;;     resource is declared for now (its `own<>` reference is the
+;;     payload of `preopens.get-directories`' return). Methods
+;;     arrive in subphases (a2)/(b)/(c) of #165.
 ;;
 ;; Still ENOSYS (tracked under cataggar/wabt#168):
 ;;
-;;   * `fd_read`, `fd_close`, `fd_prestat_get`, `fd_prestat_dir_name`,
-;;     plus the path_* surface — wait for filesystem read-side
-;;     (#165);
+;;   * `fd_read`, `fd_close`, `path_open`, plus the rest of the
+;;     filesystem surface (`fd_filestat_get`, `path_filestat_get`,
+;;     `fd_readdir`, the `path_*` write-side, sockets) — wait for
+;;     subphases (a2)/(b)/(c) of #165 and #166;
 ;;   * `fd_fdstat_set_flags` — no preview2 equivalent for the flags
 ;;     preview1 cares about.
 
@@ -160,6 +173,14 @@
   ;;   after running the host-side iteration.
   (type $get_arguments_sig   (func (param i32)))
   (type $get_environment_sig (func (param i32)))
+
+  ;; `wasi:filesystem/preopens.get-directories() ->
+  ;;   list<tuple<descriptor, string>>` — same shape as the
+  ;;   `wasi:cli/environment` calls above. The host writes
+  ;;   `(list_ptr, list_len)` at the ret_area; the list backing is
+  ;;   12-byte tuples of `(descriptor_handle: i32, name_ptr: i32,
+  ;;   name_len: i32)`.
+  (type $get_directories_sig (func (param i32)))
 
   ;; ── imports ──────────────────────────────────────────────────
   ;;
@@ -273,6 +294,15 @@
     (func $get_arguments (type $get_arguments_sig)))
   (import "wasi:cli/environment@0.2.6" "get-environment"
     (func $get_environment (type $get_environment_sig)))
+
+  ;; `wasi:filesystem/preopens.get-directories() ->
+  ;; list<tuple<descriptor, string>>` backing the preview1
+  ;; `fd_prestat_get` / `fd_prestat_dir_name` imports. Lifted on
+  ;; each preview1 call via mode 2 (count) of the import-alloc
+  ;; state machine — the canon list backing + each name lands in
+  ;; the bump arena and gets reset after the call.
+  (import "wasi:filesystem/preopens@0.2.6" "get-directories"
+    (func $get_directories (type $get_directories_sig)))
 
   ;; ── adapter state ────────────────────────────────────────────
   ;;
@@ -735,8 +765,157 @@
     i32.const 0)             ;; SUCCESS
 
   (func $fd_fdstat_set_flags (type $fd_fdstat_set_flags_sig) i32.const 52)
-  (func $fd_prestat_get (type $fd_prestat_get_sig) i32.const 52)
-  (func $fd_prestat_dir_name (type $fd_prestat_dir_name_sig) i32.const 52)
+
+  ;; preview1 `fd_prestat_get(fd, prestat_ptr) -> errno`.
+  ;;
+  ;; wasi-libc walks preopens at startup by calling
+  ;; `fd_prestat_get(fd)` for `fd = 3, 4, 5, …` until it returns
+  ;; `EBADF`. Each call lifts the full preopens list from the host
+  ;; via `wasi:filesystem/preopens.get-directories` into the bump
+  ;; arena (mode 2), looks up the `idx = fd - 3` entry, writes the
+  ;; preview1 `prestat` record, then resets the arena. No
+  ;; permanent allocation; each call is stateless.
+  ;;
+  ;; preview1 `prestat` layout (8 bytes, align 4):
+  ;;   offset 0: u8  tag (0 = PREOPENTYPE_DIR)
+  ;;   offset 1..3: pad
+  ;;   offset 4: u32 pr_name_len
+  ;;
+  ;; We `i32.store offset=0` a single zero to cover the tag + 3
+  ;; pad bytes in one write — `PREOPENTYPE_DIR` is 0.
+  ;;
+  ;; fd < 3 (stdio) returns `EBADF`; fd >= 3 + n_preopens also
+  ;; returns `EBADF`, matching wasmtime's reference adapter.
+  (func $fd_prestat_get (type $fd_prestat_get_sig)
+    (local $ra i32) (local $idx i32) (local $list_ptr i32)
+    (local $list_len i32) (local $entry i32) (local $name_len i32)
+    local.get 0
+    i32.const 3
+    i32.sub
+    local.tee $idx
+    i32.const 0
+    i32.lt_s
+    if
+      i32.const 8                ;; EBADF for stdio
+      return
+    end
+    ;; mode 2 (count) — the canon list backing + each per-name
+    ;; alloc land in the bump arena; nothing reaches the embed's
+    ;; heap.
+    i32.const 0  global.set $arena_cur
+    i32.const 0  global.set $strings_sz
+    i32.const 2  global.set $import_alloc_mode
+    call $ensure_ret_area
+    local.tee $ra
+    call $get_directories
+    i32.const 0  global.set $import_alloc_mode
+    local.get $ra
+    i32.load offset=0
+    local.set $list_ptr
+    local.get $ra
+    i32.load offset=4
+    local.set $list_len
+    local.get $idx
+    local.get $list_len
+    i32.ge_u
+    if
+      i32.const 0  global.set $arena_cur
+      i32.const 0  global.set $strings_sz
+      i32.const 8                ;; EBADF — past the last preopen
+      return
+    end
+    ;; entry = list_ptr + idx * 12 (tuple stride is 12 bytes:
+    ;; descriptor handle i32, name_ptr i32, name_len i32)
+    local.get $list_ptr
+    local.get $idx
+    i32.const 12
+    i32.mul
+    i32.add
+    local.tee $entry
+    i32.load offset=8
+    local.set $name_len
+    ;; Write prestat at prestat_ptr.
+    local.get 1
+    i32.const 0                  ;; tag + 3 pad bytes
+    i32.store offset=0
+    local.get 1
+    local.get $name_len
+    i32.store offset=4
+    ;; Cleanup.
+    i32.const 0  global.set $arena_cur
+    i32.const 0  global.set $strings_sz
+    i32.const 0)
+
+  ;; preview1 `fd_prestat_dir_name(fd, buf, buf_len) -> errno`.
+  ;; Same lift + lookup as `$fd_prestat_get`; instead of writing a
+  ;; prestat record we `memory.copy` up to `buf_len` bytes of the
+  ;; preopen's name into the caller's buffer. `buf_len` ≥ name_len
+  ;; is the normal wasi-libc flow (the caller sized the buffer from
+  ;; the preceding `fd_prestat_get`); we clamp defensively.
+  (func $fd_prestat_dir_name (type $fd_prestat_dir_name_sig)
+    (local $ra i32) (local $idx i32) (local $list_ptr i32)
+    (local $list_len i32) (local $entry i32)
+    (local $name_ptr i32) (local $name_len i32) (local $copy_len i32)
+    local.get 0
+    i32.const 3
+    i32.sub
+    local.tee $idx
+    i32.const 0
+    i32.lt_s
+    if
+      i32.const 8
+      return
+    end
+    i32.const 0  global.set $arena_cur
+    i32.const 0  global.set $strings_sz
+    i32.const 2  global.set $import_alloc_mode
+    call $ensure_ret_area
+    local.tee $ra
+    call $get_directories
+    i32.const 0  global.set $import_alloc_mode
+    local.get $ra
+    i32.load offset=0
+    local.set $list_ptr
+    local.get $ra
+    i32.load offset=4
+    local.set $list_len
+    local.get $idx
+    local.get $list_len
+    i32.ge_u
+    if
+      i32.const 0  global.set $arena_cur
+      i32.const 0  global.set $strings_sz
+      i32.const 8
+      return
+    end
+    local.get $list_ptr
+    local.get $idx
+    i32.const 12
+    i32.mul
+    i32.add
+    local.tee $entry
+    i32.load offset=4
+    local.set $name_ptr
+    local.get $entry
+    i32.load offset=8
+    local.set $name_len
+    ;; copy_len = min(buf_len, name_len)
+    local.get 2
+    local.get $name_len
+    i32.lt_u
+    if (result i32)
+      local.get 2
+    else
+      local.get $name_len
+    end
+    local.set $copy_len
+    local.get 1                  ;; buf
+    local.get $name_ptr
+    local.get $copy_len
+    memory.copy
+    i32.const 0  global.set $arena_cur
+    i32.const 0  global.set $strings_sz
+    i32.const 0)
 
   ;; ── args / environ ───────────────────────────────────────────
   ;;

--- a/adapters/wasi-preview1/wit/deps/wasi-filesystem/preopens.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-filesystem/preopens.wit
@@ -1,0 +1,40 @@
+// Trimmed slice of `wasi:filesystem@0.2.6.preopens`. Mirrors the
+// canonical `bytecodealliance/wasi-filesystem@v0.2.6/wit/preopens.wit`
+// shape but declares only the one func the preview1 → preview2
+// adapter calls: `get-directories`.
+//
+// Backs the preview1 `fd_prestat_get` / `fd_prestat_dir_name`
+// imports. `wasi-libc` walks preopens at startup by repeatedly
+// calling `fd_prestat_get(fd)` for `fd = 3, 4, 5, …` until
+// `EBADF`, then `fd_prestat_dir_name(fd, buf, buf_len)` to read
+// each name. Both route through `get-directories` on the host
+// side, which returns a `list<tuple<descriptor, string>>` of all
+// preopened directories.
+//
+// `use wasi:filesystem/types.{descriptor};` references the
+// `descriptor` resource declared in `types.wit`. The
+// `metadata_encode` encoder requires the source interface
+// (`types`) to also be imported by the world that consumes this
+// interface (see the test at
+// `src/component/wit/metadata_encode.zig:1525`), so the
+// preview1 world body imports both `wasi:filesystem/types@0.2.6`
+// and `wasi:filesystem/preopens@0.2.6`.
+//
+// This file holds the package declaration for the multi-file
+// `wasi:filesystem@0.2.6` slice — `resolver.readWitDir`
+// concatenates `.wit` files in lexicographic order, and
+// `preopens.wit` sorts before `types.wit` (`p` < `t`), so the
+// parser sees this file's `package wasi:filesystem@0.2.6;`
+// directive first.
+
+package wasi:filesystem@0.2.6;
+
+interface preopens {
+    use types.{descriptor};
+
+    /// Return the set of preopened directories made available to
+    /// the guest. Each entry is `(handle, name)` where `handle`
+    /// is the preview2 `descriptor` for the directory and `name`
+    /// is the path the guest sees the directory mounted under.
+    get-directories: func() -> list<tuple<descriptor, string>>;
+}

--- a/adapters/wasi-preview1/wit/deps/wasi-filesystem/types.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-filesystem/types.wit
@@ -1,0 +1,34 @@
+// Trimmed slice of `wasi:filesystem@0.2.6.types`. The canonical
+// `bytecodealliance/wasi-filesystem@v0.2.6/wit/types.wit` declares
+// the full `descriptor` surface (~30 methods) plus many auxiliary
+// types (`descriptor-type`, `descriptor-flags`, `open-flags`,
+// `path-flags`, `error-code`, `stat`, `new-timestamp`, …). For
+// subphase (a1) — preopens-only — we only need the opaque
+// `descriptor` resource itself so the encoded-world section can
+// carry `own<descriptor>` in `preopens.get-directories`' return
+// type.
+//
+// The wider surface arrives in subsequent subphases:
+//   * (a2) `path_open` + `fd_close` → `descriptor.open-at`,
+//     `[resource-drop]descriptor`, `descriptor-flags`,
+//     `open-flags`, `path-flags`, `error-code`.
+//   * (b)  `fd_read` + `fd_seek` → `descriptor.read-via-stream`,
+//     `descriptor.seek`, descriptor-type and a few flags.
+//   * (c)  `fd_filestat_get` / `path_filestat_get` / `fd_readdir`
+//     → `descriptor.stat`, `descriptor.stat-at`,
+//     `descriptor.read-directory`, plus the relevant record types.
+//
+// NOTE: the package declaration for this multi-file slice lives in
+// `preopens.wit` (which sorts before `types.wit` — `p` < `t`).
+// `resolver.readWitDir` concatenates files in order, so the
+// `package wasi:filesystem@0.2.6;` directive must appear in the
+// file that's parsed first.
+
+interface types {
+    /// Opaque handle to a filesystem object — directory, regular
+    /// file, symlink, character/block device, etc. The preview1
+    /// adapter only treats these as opaque indices into the host's
+    /// resource table; descriptor type / flag inspection arrives
+    /// in subphases (a2)/(b)/(c).
+    resource descriptor { }
+}

--- a/adapters/wasi-preview1/wit/preview1.wit
+++ b/adapters/wasi-preview1/wit/preview1.wit
@@ -62,6 +62,26 @@ world command {
     /// (no extra memcpy, no leaked main-heap allocation).
     import wasi:cli/environment@0.2.6;
 
+    /// Filesystem preopen list backing the preview1 `fd_prestat_get`
+    /// / `fd_prestat_dir_name` imports. wasi-libc walks the
+    /// preopen set at startup; each call routes through
+    /// `preopens.get-directories` on the host side. The
+    /// `descriptor` resource that `get-directories` returns is
+    /// declared in `wasi:filesystem/types`, which the
+    /// `metadata_encode` encoder requires to be imported by the
+    /// world even though the adapter doesn't call any of its
+    /// methods directly yet (see
+    /// `src/component/wit/metadata_encode.zig:1525` — "the source
+    /// interface of a `use` clause must also be reachable from the
+    /// world body").
+    ///
+    /// The wider `wasi:filesystem` surface (path_open, fd_read,
+    /// stat, readdir) arrives in subphases (a2)/(b)/(c) of
+    /// cataggar/wabt#165; this PR ships only the preopens lookup
+    /// path.
+    import wasi:filesystem/types@0.2.6;
+    import wasi:filesystem/preopens@0.2.6;
+
     /// Cryptographically-secure RNG backing the preview1 `random_get`
     /// import. wasi-libc's `getentropy`, Zig's `std.crypto.random`,
     /// Rust's `rand` wasi backend and Go's runtime RNG seed all


### PR DESCRIPTION
Refs #165 (subphase a1). Refs #168.

First chunk of cataggar/wabt#165 (filesystem read-side). The issue body recommends splitting into three subphases — **(a) preopens + path_open**, **(b) fd_read via streams**, **(c) fd_filestat / readdir**. Going one step finer, this PR ships **(a1) preopens-only**; the descriptor table + open-at flag dispatch land in **(a2)**. Keeping subphases small lets each design decision (mode 2 here; descriptor table in a2; stream caching in b; errno-mapping table in c) be reviewed independently.

## Why this matters

wasi-libc walks preopens at startup:

```
for fd in 3..: 
  if fd_prestat_get(fd) == EBADF: break
  fd_prestat_dir_name(fd, buf, name_len)
```

With both stubs returning `ENOSYS`, every guest saw zero preopens. `std::fs::File::open("/etc/hosts")` / `std.fs.cwd().openFile` / `fopen` failed at the path-resolution step before `path_open` was even attempted.

## Approach: stateless per-call lift

Re-uses the mode-2 (`count`) path of the import-alloc state machine landed in #172. Each preview1 call:

1. `arena_cur = 0; mode = 2;`
2. `$get_directories(ret_area)` — host writes list backing (12-byte tuples) + each name into the bump arena (offsets 32..65536 of the existing `$ret_area` page).
3. `mode = 0;`
4. `idx = fd - 3`; EBADF if out of range.
5. `fd_prestat_get`: read `name_len` from `list_ptr + idx*12 + 8`; write 8-byte prestat `{ tag=0 (PREOPENTYPE_DIR), name_len }` at `prestat_ptr`.
   `fd_prestat_dir_name`: `memory.copy(buf ← name_ptr, min(buf_len, name_len))`.
6. `arena_cur = 0` → state machine fully reset; no main-heap allocation occurred.

wasi-libc walks preopens once at startup, so the runtime cost is `2 * n_preopens` extra `get-directories` host calls per process — trivial for any realistic `n`.

## Changes

- `adapters/wasi-preview1/wit/deps/wasi-filesystem/preopens.wit` *(new)* — trimmed slice declaring just `get-directories`. Holds the `package wasi:filesystem@0.2.6;` directive because `preopens.wit` sorts before `types.wit` alphabetically.
- `adapters/wasi-preview1/wit/deps/wasi-filesystem/types.wit` *(new)* — trimmed slice declaring just the opaque `resource descriptor { }`. **No methods yet** — those arrive in subphases (a2)/(b)/(c). Required because `metadata_encode` enforces "the source interface of a `use` clause must also be reachable from the world body" ([test](https://github.com/cataggar/wabt/blob/main/src/component/wit/metadata_encode.zig#L1525)).
- `adapters/wasi-preview1/wit/preview1.wit` — new imports for `wasi:filesystem/types@0.2.6` + `wasi:filesystem/preopens@0.2.6`.
- `adapters/wasi-preview1/src/adapter.wat`:
  - new `$get_directories_sig (func (param i32))` type (canon-lowered `list<tuple<descriptor, string>>` return);
  - new `wasi:filesystem/preopens@0.2.6 get-directories` import;
  - reworked `$fd_prestat_get` + `$fd_prestat_dir_name` bodies;
  - header status block + section banner refresh.

## Verification

- `zig build adapter` ✓ (parses + validates + decode self-check)
- `zig build` ✓
- `zig build test` ✓ (exit 0)

Behavioral acceptance (Zig fixture iterating preopens under `wamr run --preopen=/=/tmp` returns the mapped path) is exercised out-of-tree against cataggar/wamr fixtures.

## What does *not* change

- No splicer / encoder changes — cross-interface `use { descriptor }` between two interfaces in the same package is already exercised by `wasi:io/streams` using `wasi:io/error`.
- No descriptor handle leak in the wasm linear-memory sense: each lift writes into the bump arena which is reset after every call.

## Notes

- **Host-side resource handle accumulation:** each `get-directories` call bumps the runtime's resource table by `n_preopens` handles which we don't `[resource-drop]` (the drop import isn't declared yet — it lands in (a2) when we open user descriptors). For startup-scan use this is bounded; if a fixture stress-tests it, (a2) addresses it.
- **What still ENOSYSes:** `fd_read`, `fd_close`, `path_open`, `fd_seek` (for fd ≥ 3), `fd_filestat_get`, `path_filestat_get`, `fd_readdir`, and the entire `path_*` write-side. They land in subphases (a2)/(b)/(c) of #165 and in #166.