### PR TITLE
fix(adapter): explicit own<descriptor> in preopens.get-directories tuple

### DIFF
--- a/adapters/wasi-preview1/wit/deps/wasi-filesystem/preopens.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-filesystem/preopens.wit
@@ -8,8 +8,8 @@
 // calling `fd_prestat_get(fd)` for `fd = 3, 4, 5, …` until
 // `EBADF`, then `fd_prestat_dir_name(fd, buf, buf_len)` to read
 // each name. Both route through `get-directories` on the host
-// side, which returns a `list<tuple<descriptor, string>>` of all
-// preopened directories.
+// side, which returns a `list<tuple<own<descriptor>, string>>` of
+// all preopened directories.
 //
 // `use wasi:filesystem/types.{descriptor};` references the
 // `descriptor` resource declared in `types.wit`. The
@@ -19,6 +19,18 @@
 // `src/component/wit/metadata_encode.zig:1525`), so the
 // preview1 world body imports both `wasi:filesystem/types@0.2.6`
 // and `wasi:filesystem/preopens@0.2.6`.
+//
+// NOTE: the tuple element is written as the explicit `own<descriptor>`
+// form rather than canonical bare `descriptor`. The canonical
+// WIT semantics auto-wrap a bare resource ref with `own<>` when
+// it appears in a value-type position (tuple, list, record), but
+// wabt's `metadata_encode` does not yet apply that sugar — so
+// bare `descriptor` inside `tuple<…>` would lower to a
+// `Defined(Tuple([Type(N), String]))` whose first element is a
+// type alias rather than `Defined(Own(N))`. Wasmtime rejects that
+// component with `type index 1 is not a defined type` at parse
+// time. Explicit `own<>` produces the wire bytes wit-component
+// emits canonically. Tracked as a wabt-side encoder follow-up.
 //
 // This file holds the package declaration for the multi-file
 // `wasi:filesystem@0.2.6` slice — `resolver.readWitDir`
@@ -36,5 +48,5 @@ interface preopens {
     /// the guest. Each entry is `(handle, name)` where `handle`
     /// is the preview2 `descriptor` for the directory and `name`
     /// is the path the guest sees the directory mounted under.
-    get-directories: func() -> list<tuple<descriptor, string>>;
+    get-directories: func() -> list<tuple<own<descriptor>, string>>;
 }


### PR DESCRIPTION
## Summary

The wabt-bundled wasi-preview1 → preview2 adapter's `wasi:filesystem/preopens.get-directories` lowering uses bare `descriptor` as a tuple element. Canonical WIT semantics auto-wrap a bare resource ref with `own<>` when it appears in a value-type position (tuple / list / record), but wabt's `metadata_encode` does not yet apply that sugar — bare `descriptor` inside `tuple<…>` lowered to `Defined(Tuple([Type(N), String]))` whose first element is a type alias rather than `Defined(Own(N))`. Wasmtime parses the component-type custom section before instantiation and rejects this with:

```
error: type index 1 is not a defined type (at offset 0x433)
```

…breaking cross-runtime validation for every command-style component that lifts the wabt adapter (verified locally against all four cataggar/wamr component-examples — every component fails at the same offset inside the `wasi:filesystem/preopens` instance type).

## What this PR changes

Use explicit `own<descriptor>` in the trimmed slice at `adapters/wasi-preview1/wit/deps/wasi-filesystem/preopens.wit`. Produces the same wire bytes as wit-component's canonical encoding and unblocks `wasmtime run -S cli-exit-with-code`. Stays consistent with `deps/wasi-cli/world.wit`'s explicit `own<output-stream>` return-type form (same workaround for the same encoder gap).

## Verification

End-to-end against cataggar/wamr@1188580e (full `zig build install component-examples`):

| fixture | `validate` | `wamr` | `wasmtime -S cli-exit-with-code` |
|---|---|---|---|
| `zig-hello.component` | OK | 0 | 0 |
| `zig-exit.component` | OK | 7 | 7 |
| `zig-calculator-cmd.composed` | OK | 0 | 0 |
| `mixed-zig-rust-calc.composed` | OK | 0 | 0 |

Stdout text is byte-identical between wamr and wasmtime in all four cases. Full `zig build test` on the wabt side passes (only the two intentional bad-subcommand exit-code checks log; exit 0).

## Follow-up

The underlying encoder gap — auto-wrap a bare resource ref with `own<>` when it appears in a value-type position — is worth tracking as a separate `metadata_encode` enhancement. Until then any new WIT slice we add needs to remember the explicit form (existing comments in `deps/wasi-cli/stdio.wit` document the same caveat for return types).

Blocks the v3.0.0-dev.6 tag.