### PR TITLE
docs(adapter): retarget #168 references to follow-ups #178/#179/#180

### DIFF
--- a/adapters/wasi-preview1/README.md
+++ b/adapters/wasi-preview1/README.md
@@ -56,7 +56,8 @@ This directory ships:
     * `sched_yield` → trivial success;
     * `proc_raise`, `fd_fdstat_set_flags`, `sock_*` → `ENOSYS=52`
       (no preview2 equivalent in 0.2.6 / deferred to
-      cataggar/wabt#168).
+      cataggar/wabt#178 [sockets] +
+      cataggar/wabt#179 [fdstat]).
   * **WIT world** (`wit/preview1.wit` + `wit/deps/{wasi-cli,
     wasi-clocks, wasi-filesystem, wasi-io, wasi-random}/`) —
     declares the full preview2 surface the adapter consumes.
@@ -177,7 +178,7 @@ adapters/wasi-preview1/
         `random_get`,
         `sock_accept`, `sock_recv`, `sock_send`, `sock_shutdown`
         (sockets are inline `ENOSYS=52` stubs; the preview2
-        `wasi:sockets/*` lift is deferred to cataggar/wabt#168).
+        `wasi:sockets/*` lift is deferred to cataggar/wabt#178).
         wabt's adapter-core-wasm GC pass
         ([`src/component/adapter/gc.zig`](../../src/component/adapter/gc.zig))
         drops any unused exports at splice time.

--- a/adapters/wasi-preview1/src/fragments/body.wat
+++ b/adapters/wasi-preview1/src/fragments/body.wat
@@ -1706,7 +1706,7 @@
   ;; and falls back to `FILETYPE_UNKNOWN` when stdio isn't actually
   ;; a tty. We unconditionally report `character_device` to keep
   ;; this change in the "no new preview2 imports" bucket of
-  ;; cataggar/wabt#168. The trade-off is that a guest redirected to
+  ;; cataggar/wabt#179. The trade-off is that a guest redirected to
   ;; a file/pipe still believes it's writing to a tty — acceptable
   ;; for the v3 scope (CLI fixtures); revisit alongside the
   ;; terminal-* imports if a fixture surfaces the mismatch.
@@ -1722,7 +1722,7 @@
   ;; fd >= 3 keeps the ENOSYS=52 stub — preview2 has
   ;; `descriptor.{get-flags, get-type}` we could lift here, but the
   ;; preview1 `fdstat` also needs `fs_rights_*` which has no
-  ;; preview2 equivalent. Tracked under cataggar/wabt#168.
+  ;; preview2 equivalent. Tracked under cataggar/wabt#179.
   (func $fd_fdstat_get (type $fd_fdstat_get_sig)
     (local $rights i64)
     local.get 0

--- a/adapters/wasi-preview1/src/fragments/prelude.wat
+++ b/adapters/wasi-preview1/src/fragments/prelude.wat
@@ -102,7 +102,7 @@
 ;;     — exported as ENOSYS=52 stubs so wasi-libc embeds that pull
 ;;     these in via the C runtime startup splice cleanly. Programs
 ;;     that actually call socket(2) get a well-defined errno
-;;     (deferred preview2 sockets → cataggar/wabt#168).
+;;     (deferred preview2 sockets → cataggar/wabt#178).
 ;;
 ;; Declared preview2 imports the adapter consumes:
 ;;
@@ -134,14 +134,15 @@
 ;;     `[method]directory-entry-stream.read-directory-entry` +
 ;;     `[resource-drop]directory-entry-stream`.
 ;;
-;; Still ENOSYS / not lifted (tracked under cataggar/wabt#168):
+;; Still ENOSYS / not lifted (sub-issues split out of #168):
 ;;
 ;;   * `fd_fdstat_set_flags` — no preview2 equivalent for the flags
-;;     preview1 cares about.
+;;     preview1 cares about (cataggar/wabt#179).
 ;;   * `fd_pread`, `fd_advise`, `fd_allocate`, `fd_renumber`,
-;;     `fd_tell`, `path_readlink` — out of v3 scope.
+;;     `fd_tell`, `path_readlink` — out of v3 scope
+;;     (cataggar/wabt#180).
 ;;   * `sock_*` — ENOSYS stubs only; preview2 `wasi:sockets/*`
-;;     surface deferred.
+;;     surface deferred (cataggar/wabt#178).
 
 (module
   ;; ── func types ────────────────────────────────────────────────


### PR DESCRIPTION
Closes #168 (umbrella tracker) once merged.

Issue #168 was the umbrella tracker for the wasi-preview1 adapter
surface still stubbed as ENOSYS=52 past v3.0.0-dev.5. All 7
sub-issues on its in-body checklist (#161 – #167) have shipped,
but six in-code / README comments still pointed at #168 as the
home for the remaining ENOSYS surface, which kept the umbrella
from closing.

Split the remaining work into three focused follow-up issues and
retarget every reference:

* **#178** — `sock_*` ENOSYS stubs → preview2 `wasi:sockets/*`
  lift (large; new namespace, per-fd socket handle table).
* **#179** — `fd_fdstat_*` refinements: lift
  `descriptor.{get-flags, get-type}` for fd ≥ 3,
  `wasi:cli/terminal-*` for stdio terminal detection,
  `fd_fdstat_set_flags` design decision.
* **#180** — out-of-v3-scope preview1 funcs (`fd_pread`,
  `fd_advise`, `fd_allocate`, `fd_renumber`, `fd_tell`,
  `path_readlink`).

This PR is a docs/comments-only change touching 6 lines across:

* `adapters/wasi-preview1/README.md` (2 refs)
* `adapters/wasi-preview1/src/fragments/prelude.wat` (2 refs in
  the file-level banner; one rewritten to enumerate the three
  follow-ups)
* `adapters/wasi-preview1/src/fragments/body.wat` (2 refs in
  `$fd_fdstat_get`)

The rebuilt adapter artifacts are byte-identical to their
post-#177 baseline:

```
7045036cc0d4a22b2ca0844c8526d422  wasi_snapshot_preview1.command.wasm
52342caaa5c05acd28a84787646253f7  wasi_snapshot_preview1.reactor.wasm
```

After this merges, I'll close #168 with a final summary comment
pointing readers at the three follow-ups.