### PR TITLE
cli: unify help via positional `help`; drop -h/--help everywhere (#185)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -308,6 +308,45 @@ pub fn build(b: *std.Build) void {
         wabt_unknown.addArg("not-a-real-subcommand");
         wabt_unknown.expectExitCode(1);
         test_step.dependOn(&wabt_unknown.step);
+
+        // ── #185: leaf `help` subword + rejected -h / --help flags ──
+        //
+        // One representative leaf per subject. The positional `help`
+        // form must exit 0; the legacy `-h` / `--help` flags must be
+        // rejected as unknown options (exit non-zero). Mirrors the
+        // top-level `parseSubcommand` test assertions in
+        // `src/tools/wabt.zig` at the verb tier.
+        const help_cases = [_][3][]const u8{
+            .{ "text", "parse", "<input.wat>" },
+            .{ "module", "validate", "<input.wasm>" },
+            .{ "component", "new", "<input.wasm>" },
+            .{ "spec", "run", "<input.wast>" },
+        };
+        inline for (help_cases) |c| {
+            const subject = c[0];
+            const verb = c[1];
+
+            // `wabt <subject> <verb> help` → exit 0.
+            const ok = b.addRunArtifact(wabt_exe);
+            ok.addArgs(&.{ subject, verb, "help" });
+            ok.expectExitCode(0);
+            test_step.dependOn(&ok.step);
+
+            // `wabt <subject> <verb> -h` → exit non-zero (the flag is
+            // no longer recognised; the leaf falls through to its
+            // existing unknown-option / missing-input error path).
+            const dash_h = b.addRunArtifact(wabt_exe);
+            dash_h.addArgs(&.{ subject, verb, "-h" });
+            dash_h.expectExitCode(1);
+            test_step.dependOn(&dash_h.step);
+
+            // `wabt <subject> <verb> --help` → exit non-zero, same
+            // reasoning as above.
+            const dash_help = b.addRunArtifact(wabt_exe);
+            dash_help.addArgs(&.{ subject, verb, "--help" });
+            dash_help.expectExitCode(1);
+            test_step.dependOn(&dash_help.step);
+        }
     }
 }
 

--- a/src/tools/component_compose.zig
+++ b/src/tools/component_compose.zig
@@ -42,11 +42,14 @@ pub const usage =
     \\  -d, --define <file>     Provider component (repeatable)
     \\  -o, --output <file>     Output file (default: <input>.composed.wasm)
     \\      --skip-validation   Skip post-encoding component validation
-    \\  -h, --help              Show this help
     \\
 ;
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var providers_paths = std.ArrayListUnmanaged([]const u8).empty;
@@ -58,10 +61,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else if (std.mem.eql(u8, arg, "-d") or std.mem.eql(u8, arg, "--define")) {
+        if (std.mem.eql(u8, arg, "-d") or std.mem.eql(u8, arg, "--define")) {
             i += 1;
             if (i >= sub_args.len) {
                 std.debug.print("error: {s} requires a path argument\n", .{arg});
@@ -78,7 +78,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
         } else if (std.mem.eql(u8, arg, "--skip-validation")) {
             skip_validation = true;
         } else if (std.mem.startsWith(u8, arg, "-")) {
-            std.debug.print("error: unknown option '{s}'. Use `wabt help component`.\n", .{arg});
+            std.debug.print("error: unknown option '{s}'. Use `wabt component compose help`.\n", .{arg});
             std.process.exit(1);
         } else {
             if (consumer_path != null) {
@@ -90,7 +90,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     }
 
     const cons_path = consumer_path orelse {
-        std.debug.print("error: component compose requires <consumer.wasm>. Use `wabt help component`.\n", .{});
+        std.debug.print("error: component compose requires <consumer.wasm>. Use `wabt component compose help`.\n", .{});
         std.process.exit(1);
     };
 

--- a/src/tools/component_embed.zig
+++ b/src/tools/component_embed.zig
@@ -41,11 +41,14 @@ pub const usage =
     \\  -w, --world <name>      World to embed (required if the WIT defines
     \\                          more than one world)
     \\  -o, --output <file>     Output file (default: <input>.embed.wasm)
-    \\  -h, --help              Show this help
     \\
 ;
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var world_arg: ?[]const u8 = null;
@@ -56,10 +59,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else if (std.mem.eql(u8, arg, "-w") or std.mem.eql(u8, arg, "--world")) {
+        if (std.mem.eql(u8, arg, "-w") or std.mem.eql(u8, arg, "--world")) {
             i += 1;
             if (i >= sub_args.len) {
                 std.debug.print("error: {s} requires an argument\n", .{arg});
@@ -74,11 +74,11 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
             }
             output_file = sub_args[i];
         } else if (std.mem.startsWith(u8, arg, "-")) {
-            std.debug.print("error: unknown option '{s}'. Use `wabt help component`.\n", .{arg});
+            std.debug.print("error: unknown option '{s}'. Use `wabt component embed help`.\n", .{arg});
             std.process.exit(1);
         } else {
             if (pos_count >= positionals.len) {
-                std.debug.print("error: unexpected positional argument '{s}'. Use `wabt help component`.\n", .{arg});
+                std.debug.print("error: unexpected positional argument '{s}'. Use `wabt component embed help`.\n", .{arg});
                 std.process.exit(1);
             }
             positionals[pos_count] = arg;
@@ -87,7 +87,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     }
 
     if (pos_count < 2) {
-        std.debug.print("error: component embed requires <wit-path> and <core.wasm>. Use `wabt help component`.\n", .{});
+        std.debug.print("error: component embed requires <wit-path> and <core.wasm>. Use `wabt component embed help`.\n", .{});
         std.process.exit(1);
     }
 

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -91,13 +91,16 @@ pub const usage =
     \\                          no `--adapt wasi_snapshot_preview1=...`
     \\                          was supplied, the CLI's embedded
     \\                          adapter is spliced in transparently.
-    \\  -h, --help              Show this help
     \\
 ;
 
 const AdapterSpec = struct { name: []const u8, file: []const u8 };
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var output_file: ?[]const u8 = null;
@@ -110,10 +113,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
+        if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
             i += 1;
             if (i >= sub_args.len) {
                 std.debug.print("error: {s} requires an argument\n", .{arg});
@@ -137,7 +137,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
             };
             try adapts.append(alloc, .{ .name = spec[0..eq], .file = spec[eq + 1 ..] });
         } else if (std.mem.startsWith(u8, arg, "-")) {
-            std.debug.print("error: unknown option '{s}'. Use `wabt help component`.\n", .{arg});
+            std.debug.print("error: unknown option '{s}'. Use `wabt component new help`.\n", .{arg});
             std.process.exit(1);
         } else {
             if (input_path != null) {
@@ -149,7 +149,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     }
 
     const in_path = input_path orelse {
-        std.debug.print("error: component new requires <input.wasm>. Use `wabt help component`.\n", .{});
+        std.debug.print("error: component new requires <input.wasm>. Use `wabt component new help`.\n", .{});
         std.process.exit(1);
     };
 

--- a/src/tools/compose.zig
+++ b/src/tools/compose.zig
@@ -2,7 +2,7 @@
 //!
 //! The `compose` subject covers the WAC composition language. It
 //! ships in phase 1 with **no verbs implemented**. The dispatcher
-//! exists for taxonomic uniformity — `wabt help compose` reports the
+//! exists for taxonomic uniformity — `wabt component compose help` reports the
 //! original planned verbs that were filed and closed as not planned
 //! (#138 – #142). Future WAC integration will require new issues.
 

--- a/src/tools/decompile.zig
+++ b/src/tools/decompile.zig
@@ -8,7 +8,6 @@ pub const usage =
     \\
     \\Options:
     \\  -o, --output <file>   Output file (default: stdout)
-    \\  -h, --help            Show this help
     \\
 ;
 
@@ -20,6 +19,10 @@ pub fn decompile(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 }
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var input_file: ?[]const u8 = null;
@@ -28,10 +31,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
+        if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
             i += 1;
             if (i >= sub_args.len) {
                 std.debug.print("error: {s} requires an argument\n", .{arg});
@@ -44,7 +44,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     }
 
     const in_path = input_file orelse {
-        std.debug.print("error: no input file. Use `wabt help decompile` for usage.\n", .{});
+        std.debug.print("error: no input file. Use `wabt module decompile help` for usage.\n", .{});
         std.process.exit(1);
     };
 

--- a/src/tools/desugar.zig
+++ b/src/tools/desugar.zig
@@ -8,7 +8,6 @@ pub const usage =
     \\
     \\Options:
     \\  -o, --output <file>   Output file (default: stdout)
-    \\  -h, --help            Show this help
     \\
 ;
 
@@ -20,6 +19,10 @@ pub fn desugar(allocator: std.mem.Allocator, wat_source: []const u8) ![]u8 {
 }
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var input_file: ?[]const u8 = null;
@@ -28,10 +31,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
+        if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
             i += 1;
             if (i >= sub_args.len) {
                 std.debug.print("error: {s} requires an argument\n", .{arg});
@@ -44,7 +44,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     }
 
     const in_path = input_file orelse {
-        std.debug.print("error: no input file. Use `wabt help desugar` for usage.\n", .{});
+        std.debug.print("error: no input file. Use `wabt text desugar help` for usage.\n", .{});
         std.process.exit(1);
     };
 

--- a/src/tools/json_from_wast.zig
+++ b/src/tools/json_from_wast.zig
@@ -12,7 +12,6 @@ pub const usage =
     \\
     \\Options:
     \\  -o, --output <file>   Output JSON file (default: output.json)
-    \\  -h, --help            Show this help
     \\
 ;
 
@@ -359,6 +358,10 @@ fn findModuleEnd(text: []const u8) ?usize {
 }
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var input_file: ?[]const u8 = null;
@@ -367,10 +370,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
+        if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
             i += 1;
             if (i >= sub_args.len) {
                 std.debug.print("error: {s} requires an argument\n", .{arg});
@@ -383,7 +383,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     }
 
     const in_path = input_file orelse {
-        std.debug.print("error: no input file. Use `wabt help json-from-wast` for usage.\n", .{});
+        std.debug.print("error: no input file. Use `wabt spec to-json help` for usage.\n", .{});
         std.process.exit(1);
     };
 

--- a/src/tools/objdump.zig
+++ b/src/tools/objdump.zig
@@ -8,7 +8,6 @@ pub const usage =
     \\
     \\Options:
     \\  -o, --output <file>   Output file (default: stdout)
-    \\  -h, --help            Show this help
     \\
 ;
 
@@ -44,6 +43,10 @@ pub fn dump(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 }
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var input_file: ?[]const u8 = null;
@@ -52,10 +55,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
+        if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
             i += 1;
             if (i >= sub_args.len) {
                 std.debug.print("error: {s} requires an argument\n", .{arg});
@@ -68,7 +68,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     }
 
     const in_path = input_file orelse {
-        std.debug.print("error: no input file. Use `wabt help objdump` for usage.\n", .{});
+        std.debug.print("error: no input file. Use `wabt module objdump help` for usage.\n", .{});
         std.process.exit(1);
     };
 

--- a/src/tools/parse.zig
+++ b/src/tools/parse.zig
@@ -8,7 +8,6 @@ pub const usage =
     \\
     \\Options:
     \\  -o, --output <file>   Output file (default: <input>.wasm)
-    \\  -h, --help            Show this help
     \\
 ;
 
@@ -24,6 +23,10 @@ pub fn convert(allocator: std.mem.Allocator, wat_source: []const u8) ![]u8 {
 }
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var input_file: ?[]const u8 = null;
@@ -32,10 +35,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
+        if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
             i += 1;
             if (i >= sub_args.len) {
                 std.debug.print("error: {s} requires an argument\n", .{arg});
@@ -48,7 +48,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     }
 
     const in_path = input_file orelse {
-        std.debug.print("error: no input file. Use `wabt help parse` for usage.\n", .{});
+        std.debug.print("error: no input file. Use `wabt text parse help` for usage.\n", .{});
         std.process.exit(1);
     };
 

--- a/src/tools/print.zig
+++ b/src/tools/print.zig
@@ -8,7 +8,6 @@ pub const usage =
     \\
     \\Options:
     \\  -o, --output <file>   Output file (default: stdout)
-    \\  -h, --help            Show this help
     \\
 ;
 
@@ -22,6 +21,10 @@ pub fn convert(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 }
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var input_file: ?[]const u8 = null;
@@ -30,10 +33,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
+        if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
             i += 1;
             if (i >= sub_args.len) {
                 std.debug.print("error: {s} requires an argument\n", .{arg});
@@ -46,7 +46,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     }
 
     const in_path = input_file orelse {
-        std.debug.print("error: no input file. Use `wabt help print` for usage.\n", .{});
+        std.debug.print("error: no input file. Use `wabt text print help` for usage.\n", .{});
         std.process.exit(1);
     };
 

--- a/src/tools/shrink.zig
+++ b/src/tools/shrink.zig
@@ -46,7 +46,6 @@ pub const usage =
     \\  -s, --seed <N>        Reserved for compatibility (currently unused;
     \\                        wabt's reductions are deterministic)
     \\      --allow-empty     Permit shrinking down to an empty module
-    \\  -h, --help            Show this help
     \\
 ;
 
@@ -345,6 +344,10 @@ pub fn shrinkBytes(
 // ── CLI entry point ─────────────────────────────────────────────────
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var output_file: ?[]const u8 = null;
@@ -357,10 +360,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
+        if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
             i += 1;
             if (i >= sub_args.len) {
                 std.debug.print("error: {s} requires an argument\n", .{arg});
@@ -392,7 +392,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
         } else {
             if (pos_count >= positionals.len) {
                 std.debug.print(
-                    "error: unexpected positional argument '{s}'. Use `wabt help shrink`.\n",
+                    "error: unexpected positional argument '{s}'. Use `wabt module shrink help`.\n",
                     .{arg},
                 );
                 std.process.exit(1);
@@ -404,7 +404,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
 
     if (pos_count < 2) {
         std.debug.print(
-            "error: shrink requires <predicate> and <input.wasm>. Use `wabt help shrink`.\n",
+            "error: shrink requires <predicate> and <input.wasm>. Use `wabt module shrink help`.\n",
             .{},
         );
         std.process.exit(1);

--- a/src/tools/spectest.zig
+++ b/src/tools/spectest.zig
@@ -7,7 +7,6 @@ pub const usage =
     \\Run a WebAssembly spec test (.wast file).
     \\
     \\Options:
-    \\  -h, --help   Show this help
     \\
 ;
 
@@ -25,6 +24,10 @@ pub fn runBinaryValidation(allocator: std.mem.Allocator, wasm_bytes: []const u8)
 }
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var input_file: ?[]const u8 = null;
@@ -32,16 +35,13 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else {
+        {
             input_file = arg;
         }
     }
 
     const in_path = input_file orelse {
-        std.debug.print("no input file specified. Use `wabt help spectest` for usage.\n", .{});
+        std.debug.print("no input file specified. Use `wabt spec run help` for usage.\n", .{});
         return;
     };
 

--- a/src/tools/stats.zig
+++ b/src/tools/stats.zig
@@ -7,7 +7,6 @@ pub const usage =
     \\Print module statistics for a WebAssembly binary.
     \\
     \\Options:
-    \\  -h, --help   Show this help
     \\
 ;
 
@@ -44,6 +43,10 @@ pub fn stats(allocator: std.mem.Allocator, wasm_bytes: []const u8) !Stats {
 }
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var input_file: ?[]const u8 = null;
@@ -51,16 +54,13 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else {
+        {
             input_file = arg;
         }
     }
 
     const in_path = input_file orelse {
-        std.debug.print("error: no input file. Use `wabt help stats` for usage.\n", .{});
+        std.debug.print("error: no input file. Use `wabt module stats help` for usage.\n", .{});
         std.process.exit(1);
     };
 

--- a/src/tools/strip.zig
+++ b/src/tools/strip.zig
@@ -8,7 +8,6 @@ pub const usage =
     \\
     \\Options:
     \\  -o, --output <file>   Output file (default: overwrite input)
-    \\  -h, --help            Show this help
     \\
 ;
 
@@ -21,6 +20,10 @@ pub fn strip(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
 }
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var input_file: ?[]const u8 = null;
@@ -29,10 +32,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
+        if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
             i += 1;
             if (i >= sub_args.len) {
                 std.debug.print("error: {s} requires an argument\n", .{arg});
@@ -45,7 +45,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     }
 
     const in_path = input_file orelse {
-        std.debug.print("error: no input file. Use `wabt help strip` for usage.\n", .{});
+        std.debug.print("error: no input file. Use `wabt module strip help` for usage.\n", .{});
         std.process.exit(1);
     };
 

--- a/src/tools/validate.zig
+++ b/src/tools/validate.zig
@@ -9,7 +9,6 @@ pub const usage =
     \\(preamble \0asm 0d 00 01 00) are accepted.
     \\
     \\Options:
-    \\  -h, --help   Show this help
     \\
 ;
 
@@ -44,6 +43,10 @@ pub fn validateBytes(allocator: std.mem.Allocator, wasm_bytes: []const u8) !void
 }
 
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     const alloc = init.gpa;
 
     var input_file: ?[]const u8 = null;
@@ -51,16 +54,13 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else {
+        {
             input_file = arg;
         }
     }
 
     const in_path = input_file orelse {
-        std.debug.print("error: no input file. Use `wabt help validate` for usage.\n", .{});
+        std.debug.print("error: no input file. Use `wabt module validate help` for usage.\n", .{});
         std.process.exit(1);
     };
 


### PR DESCRIPTION
Closes #185.

Mirrors [cataggar/ghr#71](https://github.com/cataggar/ghr/pull/71)
and the upstream Zig CLI convention (`zig ar help`, `zig build help`, …): every level of the wabt CLI recognises a positional `help` token, and `-h` / `--help` flags are no longer accepted.

## What changed

| Tier | Status before | Status after |
|---|---|---|
| **Top level** (`wabt help`, `wabt help <subject>`) | already conformant — rejects `-h` / `--help` per `src/tools/wabt.zig:172-173` | unchanged |
| **Subject dispatchers** (`wabt <subject> help [<verb>]`) | already conformant — routes `help <verb>` to leaf's `usage` | unchanged |
| **14 leaf verb handlers** (`src/tools/*.zig`) | declared `-h, --help` in `usage`; short-circuited on the flags | **now** accept positional `help` as first arg; `-h` / `--help` are unknown options |

## Per-leaf change (uniform across all 14)

```diff
 pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
+    if (sub_args.len > 0 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, usage);
+        return;
+    }
     ...
     while (i < sub_args.len) : (i += 1) {
         const arg = sub_args[i];
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            writeStdout(init.io, usage);
-            return;
-        } else if (...
+        if (...
```

Plus a one-line removal in each `usage` constant
(`-h, --help            Show this help`).

While touching each file, retarget pre-existing
`Use \`wabt help <leaf>\`` error-message hints (which pointed
at the non-existent top-level form like `wabt help shrink`) to
the verb-level `wabt <subject> <verb> help` form that actually
works after this PR. Affected: `parse`, `print`, `desugar`,
`validate`, `objdump`, `strip`, `stats`, `decompile`, `shrink`,
`spec/run`, `spec/to-json`, `component/{new,embed,compose}`,
plus a doc-comment in `compose.zig`.

## Tests

`build.zig` grows 12 new CLI smoke tests — one representative
leaf per subject × three invocations each:

* `wabt text parse help`         → exit 0
* `wabt text parse -h`           → exit non-zero
* `wabt text parse --help`       → exit non-zero
* `wabt module validate help`    → exit 0
* `wabt module validate -h`      → exit non-zero
* `wabt module validate --help`  → exit non-zero
* `wabt component new help`      → exit 0
* `wabt component new -h`        → exit non-zero
* `wabt component new --help`    → exit non-zero
* `wabt spec run help`           → exit 0
* `wabt spec run -h`             → exit non-zero
* `wabt spec run --help`         → exit non-zero

The existing top-level `parseSubcommand("--help") == null` /
`parseSubcommand("-h") == null` assertions
(`src/tools/wabt.zig:172-173`) remain unchanged.

## Acceptance check

```
$ rg -- '"-h"|"--help"|-h, --help' src/tools/
src/tools/wabt.zig:172:    try std.testing.expectEqual(@as(?Subcommand, null), parseSubcommand("--help"));
src/tools/wabt.zig:173:    try std.testing.expectEqual(@as(?Subcommand, null), parseSubcommand("-h"));
```

Only the top-level rejection-test assertions remain — every
leaf's `-h` / `--help` recognition is gone.