### PR TITLE
adapter WIT: revert explicit own<R> workarounds now that #184 auto-wraps (#189)

### DIFF
--- a/adapters/wasi-preview1/wit/deps/wasi-filesystem/types.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-filesystem/types.wit
@@ -218,9 +218,11 @@ interface types {
     /// splicer-synthesised `[resource-drop]directory-entry-stream`.
     ///
     /// Declared BEFORE `descriptor` because `descriptor.read-directory`
-    /// references `own<directory-entry-stream>` in its return type;
-    /// the encoder binds resource names lazily as it walks the
+    /// references `directory-entry-stream` in its return type; the
+    /// encoder binds resource names lazily as it walks the
     /// interface body, so the referent must precede the reference.
+    /// The bare resource ref auto-wraps as
+    /// `own<directory-entry-stream>` per cataggar/wabt#182.
     resource directory-entry-stream {
         read-directory-entry: func() -> result<option<directory-entry>, error-code>;
     }
@@ -239,7 +241,7 @@ interface types {
             path: string,
             open-flags: open-flags,
             %flags: descriptor-flags
-        ) -> result<own<descriptor>, error-code>;
+        ) -> result<descriptor, error-code>;
 
         /// Open an `input-stream` reading from `offset`. Backs
         /// preview1 `fd_read` for regular files. The adapter opens
@@ -247,7 +249,7 @@ interface types {
         /// adapter-tracked file position), reads via
         /// `input-stream.blocking-read`, drops the stream, and
         /// advances its tracked position by the bytes returned.
-        read-via-stream: func(offset: u64) -> result<own<input-stream>, error-code>;
+        read-via-stream: func(offset: u64) -> result<input-stream, error-code>;
 
         /// Open an `output-stream` writing at `offset`. Backs
         /// preview1 `fd_write` for fd ≥ 3 and `fd_pwrite`. The
@@ -255,7 +257,7 @@ interface types {
         /// `blocking-write-and-flush` returns; for `fd_write` the
         /// tracked position is advanced by total bytes written, for
         /// `fd_pwrite` it is left untouched (POSIX semantics).
-        write-via-stream: func(offset: u64) -> result<own<output-stream>, error-code>;
+        write-via-stream: func(offset: u64) -> result<output-stream, error-code>;
 
         /// Open an append-mode `output-stream`. Used by the adapter
         /// only when `descriptor-flags::append` was requested at
@@ -263,7 +265,7 @@ interface types {
         /// adapter routes ordinary `fd_write` through this when the
         /// fd was opened with `FDFLAGS_APPEND` (deferred — current
         /// adapter always uses `write-via-stream`).
-        append-via-stream: func() -> result<own<output-stream>, error-code>;
+        append-via-stream: func() -> result<output-stream, error-code>;
 
         /// Backs preview1 `fd_filestat_set_size`.
         set-size: func(size: u64) -> result<_, error-code>;
@@ -386,7 +388,7 @@ interface types {
         /// listing each call (wasi-libc's `readdir(3)` then
         /// continues by re-reading from the start, matching the
         /// behaviour of the wasmtime reference adapter).
-        read-directory: func() -> result<own<directory-entry-stream>, error-code>;
+        read-directory: func() -> result<directory-entry-stream, error-code>;
     }
 }
 

--- a/adapters/wasi-preview1/wit/deps/wasi-io/streams.wit
+++ b/adapters/wasi-preview1/wit/deps/wasi-io/streams.wit
@@ -5,9 +5,10 @@
 //   * `stream-error` variant — the canonical version's
 //     `last-operation-failed` case carries an `error` resource
 //     payload from `wasi:io/error`. We mirror that shape via
-//     `use error.{error};` + `last-operation-failed(own<error>)`
+//     `use error.{error};` + `last-operation-failed(error)`
 //     so the encoded `component-type:` section is byte-identical
-//     to wasmtime's reference adapter for this case.
+//     to wasmtime's reference adapter for this case. Bare
+//     `error` auto-wraps as `own<error>` per cataggar/wabt#182.
 //
 //   * `output-stream` resource with `blocking-write-and-flush` —
 //     the single method the preview1 → preview2 adapter calls in
@@ -29,12 +30,14 @@ interface streams {
 
     /// Failure modes for `output-stream` writes. Matches the
     /// canonical wasi:io@0.2.6 variant shape: the
-    /// `last-operation-failed` case carries an `own<error>` payload
-    /// from `wasi:io/error`. The adapter discards the payload —
-    /// preview1 `fd_write` is itself blocking, so any non-`ok`
-    /// outcome traps before the host sees the resource.
+    /// `last-operation-failed` case carries an owned `error`
+    /// resource payload from `wasi:io/error` (the bare `error`
+    /// ref auto-wraps as `own<error>` per cataggar/wabt#182).
+    /// The adapter discards the payload — preview1 `fd_write` is
+    /// itself blocking, so any non-`ok` outcome traps before the
+    /// host sees the resource.
     variant stream-error {
-        last-operation-failed(own<error>),
+        last-operation-failed(error),
         closed,
     }
 


### PR DESCRIPTION
Closes #189.

Cosmetic / upstream-fidelity cleanup. #184 taught the encoder
to auto-wrap bare resource references with `own<>` in
value-type positions; the six explicit `own<R>` wrappings left
in the adapter WIT slices can now revert to the canonical bare
form, matching upstream `bytecodealliance/wasi-{io,filesystem}@v0.2.6/wit/*.wit`
line-for-line.

## Reverts

| File / line | from | to |
|---|---|---|
| `wit/deps/wasi-io/streams.wit:37` | `last-operation-failed(own<error>)` | `last-operation-failed(error)` |
| `wit/deps/wasi-filesystem/types.wit:242` | `result<own<descriptor>, error-code>` | `result<descriptor, error-code>` |
| `wit/deps/wasi-filesystem/types.wit:250` | `result<own<input-stream>, error-code>` | `result<input-stream, error-code>` |
| `wit/deps/wasi-filesystem/types.wit:258` | `result<own<output-stream>, error-code>` | `result<output-stream, error-code>` |
| `wit/deps/wasi-filesystem/types.wit:266` | `result<own<output-stream>, error-code>` | `result<output-stream, error-code>` |
| `wit/deps/wasi-filesystem/types.wit:391` | `result<own<directory-entry-stream>, error-code>` | `result<directory-entry-stream, error-code>` |

Plus 3 doc-comment tweaks crediting #182's auto-wrap as the
reason the bare form is legal.

## Byte-identity (the strict pass)

```
$ sha256sum zig-out/adapter/*.wasm  # pre-revert
663c60913fea263f5c098027621c925759644ba3fb531e74a7ad18f88bfbad76  wasi_snapshot_preview1.command.wasm
ef2e22743e97778c31b98d3e4b456cc0b1889ce3bf73c0faca431065a632e01b  wasi_snapshot_preview1.reactor.wasm

$ sha256sum zig-out/adapter/*.wasm  # post-revert (after rm -rf zig-out)
663c60913fea263f5c098027621c925759644ba3fb531e74a7ad18f88bfbad76  wasi_snapshot_preview1.command.wasm
ef2e22743e97778c31b98d3e4b456cc0b1889ce3bf73c0faca431065a632e01b  wasi_snapshot_preview1.reactor.wasm
```

Exact match. #184's "auto-wrap is byte-identical to explicit
own<>" promise holds end-to-end.

## Additional validation

* `wasm-tools validate --features all` passes on both rebuilt
  adapter shapes.
* The #182 hello fixture (`_start` core importing
  `fd_prestat_get`) composes via `wabt component new`,
  validates under wasm-tools 1.220.0, and runs under wasmtime
  44.0.1 exit 0.
* `zig build test` stays green.