### PR TITLE
feat: canonical wasi-http@0.2.6 end-to-end (#195 phases 2-5)

### DIFF
--- a/src/component/wit/metadata_encode.zig
+++ b/src/component/wit/metadata_encode.zig
@@ -79,6 +79,7 @@ pub const EncodeError = error{
     UnknownInterface,
     UnsupportedWitFeature,
     InvalidWit,
+    IncludeCycle,
 } || writer.EncodeError;
 
 /// Encode the named world from `doc` as a `component-type:<world>`
@@ -111,6 +112,26 @@ pub fn encodeWorldFromResolver(
     const world = findWorld(resolver.main, world_name) orelse return error.UnknownWorld;
     const pkg_id = resolver.main.package orelse return error.InvalidWit;
 
+    // Expand `include` items in the world body. Walks the world's
+    // items recursively, splicing in the contents of each included
+    // world (applying any `with { N as A }` renames) and detecting
+    // cycles. World-level `.use` items are dropped (no-op for
+    // emission); `.type` items still surface as
+    // `error.UnsupportedWitFeature` for now (Phase 4 work).
+    var expanded_items = std.ArrayListUnmanaged(ast.WorldItem).empty;
+    var include_stack = std.StringHashMapUnmanaged(void).empty;
+    try expandWorldItems(ar, resolver, world, pkg_id, &include_stack, &expanded_items);
+
+    // Implicit imports: every interface in the (expanded) world body
+    // may `use types.{...}` from a sibling interface that isn't
+    // otherwise present in the world. The component-model wire
+    // format requires those types to be reachable, so the encoder
+    // synthesises a matching `.import` for every transitively-used
+    // source interface not already imported or exported. This
+    // mirrors `wit-component`'s behaviour and is what makes the
+    // canonical `wasi-http/proxy` world encode end-to-end.
+    try addImplicitImports(ar, resolver, pkg_id, &expanded_items);
+
     // Build the world's body component-type decls.
     var world_decls = std.ArrayListUnmanaged(ctypes.Decl).empty;
 
@@ -139,18 +160,19 @@ pub fn encodeWorldFromResolver(
     // can emit alias-export decls right after each import without
     // having to re-walk every other interface.
     var alias_requests = std.StringHashMapUnmanaged(std.ArrayListUnmanaged([]const u8)).empty;
-    for (world.items) |item| {
+    for (expanded_items.items) |item| {
         switch (item) {
             .@"export", .import => |we| {
                 try collectUseRequests(ar, resolver, we, &alias_requests);
             },
-            .use, .include, .type => return error.UnsupportedWitFeature,
+            .use => {},
+            .include, .type => return error.UnsupportedWitFeature,
         }
     }
 
     // Each `export <iface>;` / `import <ns>:<pkg>/<iface>;` becomes a
     // type=instance-type decl followed by an export/import decl.
-    for (world.items) |item| {
+    for (expanded_items.items) |item| {
         switch (item) {
             .@"export", .import => |we| {
                 const is_export = item == .@"export";
@@ -200,7 +222,8 @@ pub fn encodeWorldFromResolver(
                     }
                 }
             },
-            .use, .include, .type => return error.UnsupportedWitFeature,
+            .use => {},
+            .include, .type => return error.UnsupportedWitFeature,
         }
     }
 
@@ -321,6 +344,285 @@ fn findWorld(doc: ast.Document, name: []const u8) ?ast.World {
     return null;
 }
 
+/// Reorder interface items so type defs come out in dependency order.
+/// `use` items are emitted first (they bind use-imported names);
+/// type defs are then emitted such that any type referenced by another
+/// type appears first; funcs come last (they may reference any name
+/// bound by this point).
+///
+/// Canonical wasi-* files routinely forward-reference named types
+/// within an interface (e.g. `variant error-code` referencing a
+/// `record DNS-error-payload` declared later in the same file).
+fn sortIfaceItemsForEncoding(
+    ar: Allocator,
+    items: []const ast.InterfaceItem,
+) EncodeError![]const ast.InterfaceItem {
+    var uses = std.ArrayListUnmanaged(ast.InterfaceItem).empty;
+    var types = std.ArrayListUnmanaged(ast.InterfaceItem).empty;
+    var funcs = std.ArrayListUnmanaged(ast.InterfaceItem).empty;
+    for (items) |it| {
+        switch (it) {
+            .use => try uses.append(ar, it),
+            .type => try types.append(ar, it),
+            .func => try funcs.append(ar, it),
+        }
+    }
+
+    // Worklist topo-sort over types. A type is emittable when every
+    // named reference inside it either (a) is a primitive, (b) was
+    // already emitted in this pass, or (c) is bound via a `use`
+    // (collected upfront below).
+    var bound = std.StringHashMapUnmanaged(void).empty;
+    for (uses.items) |u_it| for (u_it.use.names) |un| {
+        const visible = un.rename orelse un.name;
+        try bound.put(ar, visible, {});
+    };
+
+    var sorted_types = std.ArrayListUnmanaged(ast.InterfaceItem).empty;
+    while (types.items.len > 0) {
+        var made_progress = false;
+        var i: usize = 0;
+        while (i < types.items.len) {
+            const t_item = types.items[i];
+            const td = t_item.type;
+            if (typeKindAllDepsBound(td.kind, bound, td.name)) {
+                try sorted_types.append(ar, t_item);
+                try bound.put(ar, td.name, {});
+                // Remove from types by swapping with the last element.
+                types.items[i] = types.items[types.items.len - 1];
+                types.items.len -= 1;
+                made_progress = true;
+            } else {
+                i += 1;
+            }
+        }
+        if (!made_progress) {
+            // Circular reference or unresolved name — fall back to
+            // declaration order and let the encoder error out at the
+            // real reference site with a more useful diagnostic.
+            for (types.items) |t_item| try sorted_types.append(ar, t_item);
+            break;
+        }
+    }
+
+    var out = std.ArrayListUnmanaged(ast.InterfaceItem).empty;
+    try out.appendSlice(ar, uses.items);
+    try out.appendSlice(ar, sorted_types.items);
+    try out.appendSlice(ar, funcs.items);
+    return try out.toOwnedSlice(ar);
+}
+
+fn typeKindAllDepsBound(
+    kind: ast.TypeDefKind,
+    bound: std.StringHashMapUnmanaged(void),
+    self_name: []const u8,
+) bool {
+    return switch (kind) {
+        .alias => |t| typeAllDepsBound(t, bound, self_name),
+        .record => |fields| blk: {
+            for (fields) |f| if (!typeAllDepsBound(f.type, bound, self_name)) break :blk false;
+            break :blk true;
+        },
+        .variant => |cases| blk: {
+            for (cases) |c| if (c.type) |t| if (!typeAllDepsBound(t, bound, self_name)) break :blk false;
+            break :blk true;
+        },
+        .@"enum", .flags => true,
+        .resource => |methods| blk: {
+            // Resources bind their own name BEFORE processing their
+            // method bodies, so self-references inside method sigs
+            // are always resolvable. Pass `self_name` so the inner
+            // type walker can treat it as bound.
+            for (methods) |m| {
+                for (m.func.params) |p| if (!typeAllDepsBound(p.type, bound, self_name)) break :blk false;
+                if (m.func.result) |r| if (!typeAllDepsBound(r, bound, self_name)) break :blk false;
+            }
+            break :blk true;
+        },
+    };
+}
+
+fn typeAllDepsBound(t: ast.Type, bound: std.StringHashMapUnmanaged(void), self_name: []const u8) bool {
+    return switch (t) {
+        .bool, .u8, .u16, .u32, .u64, .s8, .s16, .s32, .s64, .f32, .f64, .char, .string => true,
+        .list => |inner| typeAllDepsBound(inner.*, bound, self_name),
+        .option => |inner| typeAllDepsBound(inner.*, bound, self_name),
+        .result => |r| blk: {
+            if (r.ok) |t2| if (!typeAllDepsBound(t2.*, bound, self_name)) break :blk false;
+            if (r.err) |t2| if (!typeAllDepsBound(t2.*, bound, self_name)) break :blk false;
+            break :blk true;
+        },
+        .tuple => |ts| blk: {
+            for (ts) |t2| if (!typeAllDepsBound(t2, bound, self_name)) break :blk false;
+            break :blk true;
+        },
+        .name, .borrow, .own => |n| (self_name.len > 0 and std.mem.eql(u8, n, self_name)) or bound.contains(n),
+    };
+}
+
+/// Recursively expand `world.items`, splicing in the contents of any
+/// `.include` items into `out`. World-level `.use` items are dropped
+/// (they bind types into the world's name scope, which the encoder
+/// resolves lazily). `.include` cycles surface as `error.IncludeCycle`.
+///
+/// `ctx_pkg` is the consuming world's package, used as the fallback
+/// when an `include` target ref has no explicit package qualifier
+/// (`include foo;` resolves first in the consuming world's package).
+fn expandWorldItems(
+    ar: Allocator,
+    resolver: wit_resolver.Resolver,
+    world: ast.World,
+    ctx_pkg: ast.PackageId,
+    visited: *std.StringHashMapUnmanaged(void),
+    out: *std.ArrayListUnmanaged(ast.WorldItem),
+) EncodeError!void {
+    for (world.items) |item| {
+        switch (item) {
+            .import, .@"export", .type => try out.append(ar, item),
+            .use => {},
+            .include => |inc| {
+                const target = resolver.findWorldCtx(inc.target, ctx_pkg) orelse return error.UnknownWorld;
+                const ns = if (target.pkg.namespace.len > 0) target.pkg.namespace else "<anon>";
+                const pn = target.pkg.name;
+                const key = try std.fmt.allocPrint(ar, "{s}:{s}/{s}", .{ ns, pn, target.world.name });
+                const gop = try visited.getOrPut(ar, key);
+                if (gop.found_existing) return error.IncludeCycle;
+
+                var inner = std.ArrayListUnmanaged(ast.WorldItem).empty;
+                try expandWorldItems(ar, resolver, target.world, target.pkg, visited, &inner);
+                _ = visited.remove(key);
+
+                for (inner.items) |inner_item| {
+                    const renamed = applyWithRenames(inner_item, inc.with);
+                    try out.append(ar, renamed);
+                }
+            },
+        }
+    }
+}
+
+fn applyWithRenames(item: ast.WorldItem, mapping: []const ast.UseName) ast.WorldItem {
+    if (mapping.len == 0) return item;
+    return switch (item) {
+        .import => |we| .{ .import = renameExtern(we, mapping) },
+        .@"export" => |we| .{ .@"export" = renameExtern(we, mapping) },
+        else => item,
+    };
+}
+
+fn renameExtern(we: ast.WorldExtern, mapping: []const ast.UseName) ast.WorldExtern {
+    const old = externShortName(we) orelse return we;
+    for (mapping) |m| {
+        if (std.mem.eql(u8, m.name, old)) {
+            const new = m.rename orelse return we;
+            return setExternShortName(we, new);
+        }
+    }
+    return we;
+}
+
+fn externShortName(we: ast.WorldExtern) ?[]const u8 {
+    return switch (we) {
+        .named_func => |nf| nf.name,
+        .named_interface => |ni| ni.name,
+        .interface_ref => |ir| if (ir.ref.package == null) ir.ref.name else null,
+    };
+}
+
+fn setExternShortName(we: ast.WorldExtern, new_name: []const u8) ast.WorldExtern {
+    return switch (we) {
+        .named_func => |nf| .{ .named_func = .{ .docs = nf.docs, .name = new_name, .func = nf.func } },
+        .named_interface => |ni| .{ .named_interface = .{ .docs = ni.docs, .name = new_name, .items = ni.items } },
+        .interface_ref => |ir| .{ .interface_ref = .{ .docs = ir.docs, .ref = .{ .package = ir.ref.package, .name = new_name } } },
+    };
+}
+
+/// For every interface in `items`, walk its `use` clauses and
+/// ensure the source interface is reachable in the world. Synthesises
+/// an `.import` for each source interface not already present.
+/// Mirrors `wit-component`'s implicit-import behaviour: the spec
+/// requires types referenced via `use` to be reachable via the
+/// world's import/export surface.
+///
+/// The result list is topologically ordered — every source interface
+/// appears BEFORE any interface that consumes it via `use`. This
+/// matters because the encoder builds `world_alias_map` import-by-
+/// import in declaration order; a consumer that references an alias
+/// not-yet-populated trips `error.InvalidWit`.
+fn addImplicitImports(
+    ar: Allocator,
+    resolver: wit_resolver.Resolver,
+    ctx_pkg: ast.PackageId,
+    items: *std.ArrayListUnmanaged(ast.WorldItem),
+) EncodeError!void {
+    const original = try items.toOwnedSlice(ar);
+    items.* = .empty;
+
+    var seen = std.StringHashMapUnmanaged(void).empty;
+
+    const Helper = struct {
+        fn visit(
+            arena: Allocator,
+            res: wit_resolver.Resolver,
+            ctx: ast.PackageId,
+            out: *std.ArrayListUnmanaged(ast.WorldItem),
+            visited: *std.StringHashMapUnmanaged(void),
+            item: ast.WorldItem,
+        ) EncodeError!void {
+            const we = switch (item) {
+                .import, .@"export" => |w| w,
+                else => {
+                    try out.append(arena, item);
+                    return;
+                },
+            };
+            const ref = switch (we) {
+                .interface_ref => |ir| ir.ref,
+                else => {
+                    try out.append(arena, item);
+                    return;
+                },
+            };
+            const qn = qualifiedName(arena, we, ctx) catch return error.InvalidWit;
+            if (visited.contains(qn)) return;
+            try visited.put(arena, qn, {});
+
+            // Recurse on the iface's `use` source ifaces first.
+            const lookup = res.findInterfaceWithPkgCtx(ref, ctx) orelse return error.UnknownInterface;
+            for (lookup.iface.items) |iface_item| {
+                if (iface_item != .use) continue;
+                const u = iface_item.use;
+                const src_lookup = res.findInterfaceWithPkgCtx(u.from, lookup.pkg) orelse return error.UnknownInterface;
+                const src_qn = try formatQualifiedName(
+                    arena,
+                    src_lookup.pkg.namespace,
+                    src_lookup.pkg.name,
+                    u.from.name,
+                    src_lookup.pkg.version,
+                );
+                if (visited.contains(src_qn)) continue;
+                const synth: ast.WorldExtern = .{ .interface_ref = .{
+                    .docs = "",
+                    .ref = .{
+                        .package = .{
+                            .namespace = src_lookup.pkg.namespace,
+                            .name = src_lookup.pkg.name,
+                            .version = src_lookup.pkg.version,
+                        },
+                        .name = u.from.name,
+                    },
+                } };
+                try visit(arena, res, ctx, out, visited, .{ .import = synth });
+            }
+            try out.append(arena, item);
+        }
+    };
+
+    for (original) |it| {
+        try Helper.visit(ar, resolver, ctx_pkg, items, &seen, it);
+    }
+}
+
 /// Compute the qualified name to advertise on the wire for a world's
 /// extern. `<id>;` and `<id>@<ver>;` get prefixed by the document's
 /// package; `<ns>:<pkg>/<iface>[@<ver>];` is used as-is.
@@ -394,7 +696,17 @@ fn buildInterfaceBody(
         .type_idx = 0,
         .name_map = .empty,
     };
-    for (iface_body.items) |it| {
+    // Reorder iface items so type defs come out in dependency order
+    // (forward references between named types are common in canonical
+    // wasi-* files — `variant error-code` references `record
+    // DNS-error-payload` which is defined later in the same file).
+    // `use` items must come first to bind use-imported names; types
+    // are then emitted in topological order (each type's name-deps
+    // are emitted before it); funcs come last (they may reference
+    // any name).
+    const sorted_items = try sortIfaceItemsForEncoding(ar, iface_body.items);
+
+    for (sorted_items) |it| {
         switch (it) {
             .func => |f| try builder.emitFuncExport(f.name, f.func, null),
             .type => |td| switch (td.kind) {
@@ -1567,20 +1879,47 @@ test "metadata_encode: use of an unknown type in source iface reports InvalidWit
     defer testing.allocator.free(bytes);
 }
 
-test "metadata_encode: rejects use whose source iface is not in the world" {
-    // The source interface of a `use` clause must also be reachable
-    // from the world body (as an import or export). Without that,
-    // the world body has no instance to alias from, and the
-    // pre-pass key won't be populated — leaving the consuming-iface
-    // body looking up a slot that doesn't exist.
+test "metadata_encode: implicit-imports source iface used by an iface in the world (#195 phase 4)" {
+    // Before #195 phase 4, the source interface of a `use` clause
+    // had to be explicitly imported/exported by the world; without
+    // that, the encoder returned `error.InvalidWit`. Now the
+    // encoder auto-imports the source — mirroring wit-component's
+    // implicit-import behaviour — so worlds like `wasi-http/proxy`
+    // (which only includes `imports`, not the underlying
+    // `wasi:http/types` interface that its exports `use`) encode
+    // cleanly.
     const source =
         \\package docs:demo@0.1.0;
         \\interface streams { resource output-stream { } }
-        \\interface stdout { use streams.{output-stream}; }
+        \\interface stdout { use streams.{output-stream}; get-stdout: func() -> own<output-stream>; }
         \\world cmd { import stdout; }
     ;
-    const r = encodeWorldFromSource(testing.allocator, source, "cmd");
-    try testing.expectError(error.InvalidWit, r);
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "cmd");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const comp = try loader.load(bytes, arena.allocator());
+
+    // The world body should contain TWO imports — `stdout`
+    // (explicitly declared) and `streams` (auto-imported because
+    // `stdout` uses it).
+    const wb = comp.types[0].component.decls[0].type.component;
+    var import_names = std.ArrayListUnmanaged([]const u8).empty;
+    for (wb.decls) |d| switch (d) {
+        .import => |im| try import_names.append(arena.allocator(), im.name),
+        else => {},
+    };
+    try testing.expectEqual(@as(usize, 2), import_names.items.len);
+    var saw_streams = false;
+    var saw_stdout = false;
+    for (import_names.items) |n| {
+        if (std.mem.endsWith(u8, n, "/streams@0.1.0")) saw_streams = true;
+        if (std.mem.endsWith(u8, n, "/stdout@0.1.0")) saw_stdout = true;
+    }
+    try testing.expect(saw_streams);
+    try testing.expect(saw_stdout);
 }
 
 test "metadata_encode: use clause from qualified versioned source ref" {
@@ -1894,3 +2233,113 @@ test "metadata_encode #182: explicit borrow<R> on use-introduced resource still 
     try testing.expect(ops_body.decls[2].type.val == .borrow);
     try testing.expectEqual(@as(u32, 1), ops_body.decls[2].type.val.borrow);
 }
+
+test "metadata_encode #195p3: include splices base world's items" {
+    // Synthetic include test mirroring wasi-http's
+    // `world proxy { include imports; export incoming-handler; }`
+    // pattern. The consumer world should encode as if `base`'s
+    // items were inlined.
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface a { f: func(); }
+        \\interface b { g: func(); }
+        \\world base {
+        \\    import a;
+        \\}
+        \\world consumer {
+        \\    include base;
+        \\    export b;
+        \\}
+    ;
+    const ct = try encodeWorldFromSource(testing.allocator, source, "consumer");
+    defer testing.allocator.free(ct);
+
+    const loader = @import("../loader.zig");
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const comp = try loader.load(ct, arena.allocator());
+
+    // World body: import a (instance) + export b (instance) — 4 decls.
+    const wb = comp.types[0].component.decls[0].type.component;
+    var imports: usize = 0;
+    var exports: usize = 0;
+    for (wb.decls) |d| switch (d) {
+        .import => imports += 1,
+        .@"export" => exports += 1,
+        else => {},
+    };
+    try testing.expectEqual(@as(usize, 1), imports);
+    try testing.expectEqual(@as(usize, 1), exports);
+}
+
+test "metadata_encode #195p3: transitive include (3 deep)" {
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface a { f: func(); }
+        \\interface b { g: func(); }
+        \\interface c { h: func(); }
+        \\world inner { import a; }
+        \\world middle { include inner; import b; }
+        \\world outer { include middle; export c; }
+    ;
+    const ct = try encodeWorldFromSource(testing.allocator, source, "outer");
+    defer testing.allocator.free(ct);
+
+    const loader = @import("../loader.zig");
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const comp = try loader.load(ct, arena.allocator());
+
+    const wb = comp.types[0].component.decls[0].type.component;
+    var imports: usize = 0;
+    var exports: usize = 0;
+    for (wb.decls) |d| switch (d) {
+        .import => imports += 1,
+        .@"export" => exports += 1,
+        else => {},
+    };
+    try testing.expectEqual(@as(usize, 2), imports); // a + b
+    try testing.expectEqual(@as(usize, 1), exports); // c
+}
+
+test "metadata_encode #195p3: include cycle is detected" {
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface a { f: func(); }
+        \\world w1 { include w2; }
+        \\world w2 { include w1; }
+    ;
+    const r = encodeWorldFromSource(testing.allocator, source, "w1");
+    try testing.expectError(error.IncludeCycle, r);
+}
+
+test "metadata_encode #195p3: include with { N as A } rename" {
+    const source =
+        \\package docs:demo@0.1.0;
+        \\interface a { f: func(); }
+        \\interface a-renamed { f: func(); }
+        \\world base { import a; }
+        \\world consumer { include base with { a as a-renamed }; }
+    ;
+    // The rename should rebind the imported name `a` to `a-renamed`.
+    // Since both interfaces exist in the package, the encoder uses
+    // the renamed local name to look up the interface body. Both
+    // should encode without error.
+    const ct = try encodeWorldFromSource(testing.allocator, source, "consumer");
+    defer testing.allocator.free(ct);
+
+    const loader = @import("../loader.zig");
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const comp = try loader.load(ct, arena.allocator());
+    const wb = comp.types[0].component.decls[0].type.component;
+    var found_renamed = false;
+    for (wb.decls) |d| switch (d) {
+        .import => |im| {
+            if (std.mem.indexOf(u8, im.name, "/a-renamed@") != null) found_renamed = true;
+        },
+        else => {},
+    };
+    try testing.expect(found_renamed);
+}
+

--- a/src/component/wit/resolver.zig
+++ b/src/component/wit/resolver.zig
@@ -199,7 +199,63 @@ pub const Resolver = struct {
         iface: ast.Interface,
         pkg: ast.PackageId,
     };
+
+    /// Look up a world by reference. Same package-matching rules as
+    /// `findInterfaceWithPkg`. Used by `metadata_encode` to expand
+    /// `include` items.
+    pub fn findWorld(self: Resolver, ref: ast.InterfaceRef) ?WorldLookup {
+        return self.findWorldCtx(ref, null);
+    }
+
+    pub fn findWorldCtx(self: Resolver, ref: ast.InterfaceRef, ctx_pkg: ?ast.PackageId) ?WorldLookup {
+        if (ref.package == null) {
+            if (ctx_pkg) |cp| {
+                if (self.main.package) |mp| {
+                    if (packageMatches(mp, cp)) {
+                        if (findWorldInDoc(self.main, ref.name)) |w| return .{ .world = w, .pkg = mp };
+                    }
+                }
+                for (self.deps) |dep| {
+                    if (dep.package) |dp| {
+                        if (packageMatches(dp, cp)) {
+                            if (findWorldInDoc(dep, ref.name)) |w| return .{ .world = w, .pkg = dp };
+                        }
+                    }
+                }
+            }
+            if (findWorldInDoc(self.main, ref.name)) |w| {
+                return .{ .world = w, .pkg = self.main.package orelse return null };
+            }
+            return null;
+        }
+        const target_pkg = ref.package.?;
+        if (self.main.package) |mp| {
+            if (packageMatches(mp, target_pkg)) {
+                if (findWorldInDoc(self.main, ref.name)) |w| return .{ .world = w, .pkg = mp };
+            }
+        }
+        for (self.deps) |dep| {
+            if (dep.package) |dp| {
+                if (packageMatches(dp, target_pkg)) {
+                    if (findWorldInDoc(dep, ref.name)) |w| return .{ .world = w, .pkg = dp };
+                }
+            }
+        }
+        return null;
+    }
+
+    pub const WorldLookup = struct {
+        world: ast.World,
+        pkg: ast.PackageId,
+    };
 };
+
+fn findWorldInDoc(doc: ast.Document, name: []const u8) ?ast.World {
+    for (doc.items) |it| {
+        if (it == .world and std.mem.eql(u8, it.world.name, name)) return it.world;
+    }
+    return null;
+}
 
 fn findInterfaceInDoc(doc: ast.Document, name: []const u8) ?ast.Interface {
     for (doc.items) |it| {

--- a/src/component/wit/resolver.zig
+++ b/src/component/wit/resolver.zig
@@ -36,7 +36,84 @@ pub const ResolveError = parser.ParseError || error{
     InvalidLayout,
     /// A `*.wit` file under `<root>` was empty.
     EmptyWit,
+    /// Two or more files in the same directory carry differing
+    /// `package <ns>:<name>[@<ver>];` declarations.
+    PackageDeclConflict,
+    /// No file in the directory carries a `package <ns>:<name>;`
+    /// declaration — qualified-name resolution would fail.
+    NoPackageDeclInDirectory,
 };
+
+/// Optional diagnostic populated by the resolver on errors that
+/// have a path-level explanation. Mirrors `parser.ParseDiagnostic`
+/// but uses file paths instead of byte spans.
+pub const ResolveDiagnostic = struct {
+    msg: []const u8 = "",
+    path: []const u8 = "",
+    path2: []const u8 = "",
+};
+
+/// Lightweight scanner: returns the byte range `[start, end)` of
+/// the first `package <ns>:<name>[@<ver>];` declaration in `buf`,
+/// skipping only leading whitespace, `//` / `///` line comments,
+/// `/* … */` block comments, and `@<id>(<args>?)` annotations
+/// before the decl. Returns null if no leading decl is found
+/// (the file may still contain `package` mid-stream, but that's
+/// not a top-level decl).
+pub fn scanForPackageDecl(buf: []const u8) ?struct { start: usize, end: usize } {
+    var i: usize = 0;
+    while (i < buf.len) {
+        const c = buf[i];
+        switch (c) {
+            ' ', '\t', '\r', '\n' => i += 1,
+            '/' => {
+                if (i + 1 >= buf.len) return null;
+                if (buf[i + 1] == '/') {
+                    while (i < buf.len and buf[i] != '\n') i += 1;
+                } else if (buf[i + 1] == '*') {
+                    i += 2;
+                    while (i + 1 < buf.len and !(buf[i] == '*' and buf[i + 1] == '/')) i += 1;
+                    if (i + 1 < buf.len) i += 2;
+                } else {
+                    return null;
+                }
+            },
+            '@' => {
+                // Skip annotation: `@` <id> `(<balanced parens>)`?
+                i += 1;
+                // skip id chars
+                while (i < buf.len and isIdentChar(buf[i])) i += 1;
+                // skip optional `( ... )`
+                while (i < buf.len and (buf[i] == ' ' or buf[i] == '\t' or buf[i] == '\r' or buf[i] == '\n')) i += 1;
+                if (i < buf.len and buf[i] == '(') {
+                    var depth: usize = 1;
+                    i += 1;
+                    while (i < buf.len and depth > 0) : (i += 1) {
+                        if (buf[i] == '(') depth += 1;
+                        if (buf[i] == ')') depth -= 1;
+                    }
+                }
+            },
+            'p' => {
+                // Look for `package ` literal.
+                if (i + 8 <= buf.len and std.mem.eql(u8, buf[i .. i + 8], "package ")) {
+                    const decl_start = i;
+                    // Advance until the next `;` or end of buf.
+                    while (i < buf.len and buf[i] != ';') i += 1;
+                    if (i >= buf.len) return null;
+                    return .{ .start = decl_start, .end = i + 1 };
+                }
+                return null;
+            },
+            else => return null,
+        }
+    }
+    return null;
+}
+
+fn isIdentChar(c: u8) bool {
+    return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or (c >= '0' and c <= '9') or c == '-' or c == '_';
+}
 
 pub const Resolver = struct {
     /// The "main" parsed doc — the package the world being embedded
@@ -161,13 +238,36 @@ pub const WitSource = struct {
 /// and concatenate them, separated by '\n'. Returns the concatenated
 /// buffer (caller frees) and the list of file paths included.
 ///
-/// Empty result → no `.wit` files found.
+/// Read every top-level `*.wit` file under `dir` (sorted, non-recursive)
+/// and concatenate them into a single source buffer, separated by '\n'.
+///
+/// Canonical WIT directories often have a single `package <id>;`
+/// declaration that's inherited by every other file in the same
+/// directory (e.g. `wasi-http/wit/proxy.wit` carries the package
+/// decl; `types.wit` and `handler.wit` don't). To produce a parser-
+/// digestible buffer we:
+///
+///   1. Scan each file for a leading `package` decl.
+///   2. Require the directory contain exactly one DISTINCT decl
+///      (multiple files may carry it as long as they match); error
+///      with `PackageDeclConflict` on a mismatch and
+///      `NoPackageDeclInDirectory` if none has one.
+///   3. Concat the canonical decl-bearing file FIRST (with its
+///      decl intact), then other files alphabetically afterwards
+///      with any duplicate decl stripped.
+///
+/// Returns the concatenated buffer (caller frees) and the list of
+/// file paths included (in concat order).
+///
+/// Empty result (no `.wit` files found) → returns `text.len == 0`.
 pub fn readWitDir(
     alloc: Allocator,
     io: std.Io,
     dir_path: []const u8,
-) !struct { text: []u8, paths: [][]const u8 } {
-    var dir = try std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true });
+    diag: ?*ResolveDiagnostic,
+) ResolveError!struct { text: []u8, paths: [][]const u8 } {
+    var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch
+        return error.FileSystemError;
     defer dir.close(io);
 
     var entries: std.ArrayListUnmanaged([]const u8) = .empty;
@@ -176,7 +276,7 @@ pub fn readWitDir(
         entries.deinit(alloc);
     }
     var it = dir.iterate();
-    while (try it.next(io)) |entry| {
+    while ((it.next(io) catch return error.FileSystemError)) |entry| {
         if (entry.kind != .file) continue;
         if (!std.mem.endsWith(u8, entry.name, ".wit")) continue;
         try entries.append(alloc, try alloc.dupe(u8, entry.name));
@@ -187,6 +287,77 @@ pub fn readWitDir(
         }
     }.lt);
 
+    if (entries.items.len == 0) {
+        return .{ .text = try alloc.alloc(u8, 0), .paths = try alloc.alloc([]const u8, 0) };
+    }
+
+    // Read every file into memory, scan each for its leading package
+    // decl, and validate consistency.
+    const FileEntry = struct {
+        name: []const u8,
+        full_path: []const u8,
+        buf: []u8,
+        pkg_start: usize,
+        pkg_end: usize,
+        has_pkg: bool,
+    };
+    var files = try alloc.alloc(FileEntry, entries.items.len);
+    defer {
+        for (files) |f| {
+            alloc.free(f.full_path);
+            alloc.free(f.buf);
+        }
+        alloc.free(files);
+    }
+    var canonical_decl: ?[]const u8 = null;
+    var canonical_path: []const u8 = "";
+    var first_decl_idx: ?usize = null;
+    for (entries.items, 0..) |name, i| {
+        const full = std.fs.path.join(alloc, &.{ dir_path, name }) catch return error.FileSystemError;
+        const buf = std.Io.Dir.cwd().readFileAlloc(
+            io,
+            full,
+            alloc,
+            std.Io.Limit.limited(1 << 20),
+        ) catch return error.FileSystemError;
+        files[i] = .{
+            .name = name,
+            .full_path = full,
+            .buf = buf,
+            .pkg_start = 0,
+            .pkg_end = 0,
+            .has_pkg = false,
+        };
+        if (scanForPackageDecl(buf)) |range| {
+            files[i].pkg_start = range.start;
+            files[i].pkg_end = range.end;
+            files[i].has_pkg = true;
+            const decl_text = std.mem.trim(u8, buf[range.start..range.end], " \t\r\n");
+            if (canonical_decl) |canon| {
+                if (!std.mem.eql(u8, canon, decl_text)) {
+                    if (diag) |d| d.* = .{
+                        .msg = "files in the same WIT directory have differing `package` decls",
+                        .path = canonical_path,
+                        .path2 = full,
+                    };
+                    return error.PackageDeclConflict;
+                }
+            } else {
+                canonical_decl = decl_text;
+                canonical_path = full;
+                first_decl_idx = i;
+            }
+        }
+    }
+
+    if (first_decl_idx == null) {
+        if (diag) |d| d.* = .{
+            .msg = "no `package <ns>:<name>[@<ver>];` decl found in any file under this directory",
+            .path = dir_path,
+        };
+        return error.NoPackageDeclInDirectory;
+    }
+
     var combined: std.ArrayListUnmanaged(u8) = .empty;
     errdefer combined.deinit(alloc);
     var paths: std.ArrayListUnmanaged([]const u8) = .empty;
@@ -195,19 +366,29 @@ pub fn readWitDir(
         paths.deinit(alloc);
     }
 
-    for (entries.items) |name| {
-        const full = try std.fs.path.join(alloc, &.{ dir_path, name });
-        const buf = try std.Io.Dir.cwd().readFileAlloc(
-            io,
-            full,
-            alloc,
-            std.Io.Limit.limited(1 << 20),
-        );
-        defer alloc.free(buf);
-        try combined.appendSlice(alloc, buf);
+    // Emit order: the package-bearing file first (decl intact), then
+    // every other file in alphabetical order with any duplicate decl
+    // stripped.
+    const first = first_decl_idx.?;
+    {
+        const f = files[first];
+        try combined.appendSlice(alloc, f.buf);
         try combined.append(alloc, '\n');
-        try paths.append(alloc, full);
+        try paths.append(alloc, try alloc.dupe(u8, f.full_path));
     }
+    for (files, 0..) |f, i| {
+        if (i == first) continue;
+        try paths.append(alloc, try alloc.dupe(u8, f.full_path));
+        if (f.has_pkg) {
+            // Strip the duplicate decl; keep surrounding content.
+            try combined.appendSlice(alloc, f.buf[0..f.pkg_start]);
+            try combined.appendSlice(alloc, f.buf[f.pkg_end..]);
+        } else {
+            try combined.appendSlice(alloc, f.buf);
+        }
+        try combined.append(alloc, '\n');
+    }
+
     return .{
         .text = try combined.toOwnedSlice(alloc),
         .paths = try paths.toOwnedSlice(alloc),
@@ -228,6 +409,18 @@ pub fn parseLayout(
     io: std.Io,
     root: []const u8,
 ) ResolveError!Resolver {
+    return parseLayoutWithDiag(arena, io, root, null);
+}
+
+/// Like `parseLayout` but also populates `diag` on errors that have
+/// a file-path-level explanation (`PackageDeclConflict`,
+/// `NoPackageDeclInDirectory`).
+pub fn parseLayoutWithDiag(
+    arena: Allocator,
+    io: std.Io,
+    root: []const u8,
+    diag: ?*ResolveDiagnostic,
+) ResolveError!Resolver {
     const stat = std.Io.Dir.cwd().statFile(io, root, .{}) catch return error.InvalidLayout;
 
     if (stat.kind != .directory) {
@@ -243,7 +436,7 @@ pub fn parseLayout(
     }
 
     // Read main package.
-    const main_combined = readWitDir(arena, io, root) catch return error.FileSystemError;
+    const main_combined = try readWitDir(arena, io, root, diag);
     if (main_combined.text.len == 0) return error.EmptyWit;
     const main = try parser.parse(arena, main_combined.text, null);
 
@@ -282,7 +475,7 @@ pub fn parseLayout(
         const entry_path = try std.fs.path.join(arena, &.{ deps_path, name });
         switch (kind) {
             .directory => {
-                const combined = readWitDir(arena, io, entry_path) catch return error.FileSystemError;
+                const combined = try readWitDir(arena, io, entry_path, diag);
                 if (combined.text.len == 0) continue;
                 const doc = try parser.parse(arena, combined.text, null);
                 try dep_docs.append(arena, doc);
@@ -400,4 +593,243 @@ test "resolver: package missing version on either side matches" {
     };
     const iface = res.findInterface(ref);
     try std.testing.expect(iface != null);
+}
+
+test "scanForPackageDecl: finds leading decl past whitespace/comments/annotations" {
+    // Plain package decl at the very start.
+    {
+        const buf = "package wasi:http@0.2.6;\ninterface i { f: func(); }";
+        const r = scanForPackageDecl(buf).?;
+        try std.testing.expectEqualStrings("package wasi:http@0.2.6;", buf[r.start..r.end]);
+    }
+    // Leading line + block comments.
+    {
+        const buf =
+            \\// header comment
+            \\/* block */
+            \\package wasi:http@0.2.6;
+        ;
+        const r = scanForPackageDecl(buf).?;
+        try std.testing.expectEqualStrings("package wasi:http@0.2.6;", buf[r.start..r.end]);
+    }
+    // Leading doc comments + annotations.
+    {
+        const buf =
+            \\/// doc
+            \\@since(version = 0.2.0)
+            \\package wasi:http@0.2.6;
+        ;
+        const r = scanForPackageDecl(buf).?;
+        try std.testing.expectEqualStrings("package wasi:http@0.2.6;", buf[r.start..r.end]);
+    }
+    // No leading decl — returns null.
+    {
+        const buf = "interface i { f: func(); }";
+        try std.testing.expect(scanForPackageDecl(buf) == null);
+    }
+    // `package` appearing mid-stream is NOT a leading decl.
+    {
+        const buf = "interface i { f: func(); }\npackage wasi:http@0.2.6;";
+        try std.testing.expect(scanForPackageDecl(buf) == null);
+    }
+}
+
+test "resolver #195p2: multi-file primary package — decl in non-first file" {
+    // Repro mirrors wasi-http/wit/: handler.wit (no pkg decl),
+    // proxy.wit (carries the decl), types.wit (no pkg decl).
+    // Alphabetical concat → decl mid-stream → parse fails pre-fix.
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var ar = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer ar.deinit();
+    const allocator = ar.allocator();
+
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "a-handler.wit",
+        .data = "interface handler { handle: func(); }",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "b-proxy.wit",
+        .data = "package wasi:http@0.2.6;\nworld w { import handler; }",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "c-types.wit",
+        .data = "interface types { t: func(); }",
+    });
+
+    const tmp_root = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    const res = try parseLayoutWithDiag(allocator, std.testing.io, tmp_root, null);
+    try std.testing.expect(res.main.package != null);
+    try std.testing.expectEqualStrings("wasi", res.main.package.?.namespace);
+    try std.testing.expectEqualStrings("http", res.main.package.?.name);
+    try std.testing.expectEqualStrings("0.2.6", res.main.package.?.version.?);
+    // All three files' items should be merged into one document.
+    // Order: items from the decl-bearing file first (just `world w`),
+    // then alphabetical others (`handler` then `types`).
+    try std.testing.expectEqual(@as(usize, 3), res.main.items.len);
+}
+
+test "resolver #195p2: package decl conflict between files" {
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var ar = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer ar.deinit();
+    const allocator = ar.allocator();
+
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "a.wit",
+        .data = "package wasi:http@0.2.6;\ninterface i { f: func(); }",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "b.wit",
+        .data = "package wasi:http@0.2.5;\ninterface j { f: func(); }",
+    });
+
+    const tmp_root = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    var diag: ResolveDiagnostic = .{};
+    const got = parseLayoutWithDiag(allocator, std.testing.io, tmp_root, &diag);
+    try std.testing.expectError(error.PackageDeclConflict, got);
+    try std.testing.expect(diag.msg.len > 0);
+    try std.testing.expect(diag.path.len > 0);
+    try std.testing.expect(diag.path2.len > 0);
+}
+
+test "resolver #195p2: no package decl in directory" {
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var ar = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer ar.deinit();
+    const allocator = ar.allocator();
+
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "a.wit",
+        .data = "interface i { f: func(); }",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "b.wit",
+        .data = "interface j { f: func(); }",
+    });
+
+    const tmp_root = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    var diag: ResolveDiagnostic = .{};
+    const got = parseLayoutWithDiag(allocator, std.testing.io, tmp_root, &diag);
+    try std.testing.expectError(error.NoPackageDeclInDirectory, got);
+    try std.testing.expect(diag.msg.len > 0);
+}
+
+test "resolver #195p2: duplicate-but-matching package decls are deduped" {
+    // wasi-http does NOT actually do this (only one file carries the
+    // decl), but other multi-file packages might. Verify the resolver
+    // accepts duplicated identical decls.
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var ar = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer ar.deinit();
+    const allocator = ar.allocator();
+
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "a.wit",
+        .data = "package ex:p@1.0.0;\ninterface ia { f: func(); }",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "b.wit",
+        .data = "package ex:p@1.0.0;\ninterface ib { f: func(); }",
+    });
+
+    const tmp_root = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    const res = try parseLayoutWithDiag(allocator, std.testing.io, tmp_root, null);
+    try std.testing.expect(res.main.package != null);
+    try std.testing.expectEqualStrings("ex", res.main.package.?.namespace);
+    try std.testing.expectEqualStrings("p", res.main.package.?.name);
+    try std.testing.expectEqual(@as(usize, 2), res.main.items.len);
+}
+
+test "resolver #195p2: canonical wasi-http proxy world resolves through the layout" {
+    // Phase 2 acceptance for #195. Assembles a temp WIT tree that
+    // mirrors the canonical wasi-http@0.2.6 layout (http/* as the
+    // main package, cli/clocks/filesystem/io/random/sockets under
+    // deps/) and asserts parseLayout resolves all packages.
+    //
+    // Source files are vendored at src/component/wit/wasi-canon/
+    // (added in #200 / Phase 1). We copy them out at test time
+    // using the runtime IO interface — simpler than @embedFile-ing
+    // 33 files a second time.
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var ar = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer ar.deinit();
+    const allocator = ar.allocator();
+    const io = std.testing.io;
+    const cwd = std.Io.Dir.cwd();
+
+    // Build the layout: <tmp>/wit/ (main = http) +
+    // <tmp>/wit/deps/{cli,clocks,filesystem,io,random,sockets}/.
+    try tmp.dir.createDirPath(io, "wit");
+    try tmp.dir.createDirPath(io, "wit/deps");
+
+    const pkgs = [_]struct { src_dir: []const u8, dst_rel: []const u8 }{
+        .{ .src_dir = "src/component/wit/wasi-canon/http", .dst_rel = "wit" },
+        .{ .src_dir = "src/component/wit/wasi-canon/cli", .dst_rel = "wit/deps/cli" },
+        .{ .src_dir = "src/component/wit/wasi-canon/clocks", .dst_rel = "wit/deps/clocks" },
+        .{ .src_dir = "src/component/wit/wasi-canon/filesystem", .dst_rel = "wit/deps/filesystem" },
+        .{ .src_dir = "src/component/wit/wasi-canon/io", .dst_rel = "wit/deps/io" },
+        .{ .src_dir = "src/component/wit/wasi-canon/random", .dst_rel = "wit/deps/random" },
+        .{ .src_dir = "src/component/wit/wasi-canon/sockets", .dst_rel = "wit/deps/sockets" },
+    };
+
+    for (pkgs) |pkg| {
+        try tmp.dir.createDirPath(io, pkg.dst_rel);
+        var src = try cwd.openDir(io, pkg.src_dir, .{ .iterate = true });
+        defer src.close(io);
+        var it = src.iterate();
+        while (try it.next(io)) |entry| {
+            if (entry.kind != .file) continue;
+            if (!std.mem.endsWith(u8, entry.name, ".wit")) continue;
+            const src_path = try std.fs.path.join(allocator, &.{ pkg.src_dir, entry.name });
+            const buf = try cwd.readFileAlloc(io, src_path, allocator, std.Io.Limit.limited(1 << 20));
+            const dst_path = try std.fs.path.join(allocator, &.{ pkg.dst_rel, entry.name });
+            try tmp.dir.writeFile(io, .{ .sub_path = dst_path, .data = buf });
+        }
+    }
+
+    const tmp_wit = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}/wit", .{tmp.sub_path});
+    var diag: ResolveDiagnostic = .{};
+    const res = parseLayoutWithDiag(allocator, io, tmp_wit, &diag) catch |err| {
+        std.debug.print(
+            "\nparseLayout failed: {s}\n  msg: {s}\n  path: {s}\n  path2: {s}\n",
+            .{ @errorName(err), diag.msg, diag.path, diag.path2 },
+        );
+        return err;
+    };
+
+    // Main package is wasi:http@0.2.6.
+    try std.testing.expect(res.main.package != null);
+    try std.testing.expectEqualStrings("wasi", res.main.package.?.namespace);
+    try std.testing.expectEqualStrings("http", res.main.package.?.name);
+    try std.testing.expectEqualStrings("0.2.6", res.main.package.?.version.?);
+
+    // All 6 dep packages are present and named.
+    try std.testing.expectEqual(@as(usize, 6), res.deps.len);
+    var saw_cli = false;
+    var saw_clocks = false;
+    var saw_filesystem = false;
+    var saw_io = false;
+    var saw_random = false;
+    var saw_sockets = false;
+    for (res.deps) |dep| {
+        try std.testing.expect(dep.package != null);
+        const n = dep.package.?.name;
+        if (std.mem.eql(u8, n, "cli")) saw_cli = true;
+        if (std.mem.eql(u8, n, "clocks")) saw_clocks = true;
+        if (std.mem.eql(u8, n, "filesystem")) saw_filesystem = true;
+        if (std.mem.eql(u8, n, "io")) saw_io = true;
+        if (std.mem.eql(u8, n, "random")) saw_random = true;
+        if (std.mem.eql(u8, n, "sockets")) saw_sockets = true;
+    }
+    try std.testing.expect(saw_cli);
+    try std.testing.expect(saw_clocks);
+    try std.testing.expect(saw_filesystem);
+    try std.testing.expect(saw_io);
+    try std.testing.expect(saw_random);
+    try std.testing.expect(saw_sockets);
 }

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -956,6 +956,117 @@ test "buildComponent #198: wraps cross-iface-use resources with import + alias +
     }
 }
 
+test "buildComponent #195p5: canonical wasi-http proxy world e2e" {
+    // Phase 5 acceptance for #195: pointing wabt at the canonical
+    // wasi-http@0.2.6 WIT layout + a Zig stub exporting
+    // `wasi:http/incoming-handler@0.2.6#handle` round-trips through
+    // metadata_encode (with include expansion + implicit imports +
+    // type topo-sort) and buildComponent (with resource hoisting,
+    // #199) into a binary whose component-level type indexspace is
+    // sound.
+    //
+    // The vendored canonical files live at src/component/wit/wasi-canon/
+    // (added in #200 / Phase 1). We assemble a temp WIT tree at test
+    // time and drive the embed + new pipeline against a synthesised
+    // core wasm exporting the proxy world's lifted func.
+    const wit_resolver = wabt.component.wit.resolver;
+    const wit_encode = wabt.component.wit.metadata_encode;
+
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var ar = std.heap.ArenaAllocator.init(testing.allocator);
+    defer ar.deinit();
+    const alloc = ar.allocator();
+    const io = std.testing.io;
+    const cwd = std.Io.Dir.cwd();
+
+    try tmp.dir.createDirPath(io, "wit");
+    try tmp.dir.createDirPath(io, "wit/deps");
+
+    const pkgs = [_]struct { src_dir: []const u8, dst_rel: []const u8 }{
+        .{ .src_dir = "src/component/wit/wasi-canon/http", .dst_rel = "wit" },
+        .{ .src_dir = "src/component/wit/wasi-canon/cli", .dst_rel = "wit/deps/cli" },
+        .{ .src_dir = "src/component/wit/wasi-canon/clocks", .dst_rel = "wit/deps/clocks" },
+        .{ .src_dir = "src/component/wit/wasi-canon/filesystem", .dst_rel = "wit/deps/filesystem" },
+        .{ .src_dir = "src/component/wit/wasi-canon/io", .dst_rel = "wit/deps/io" },
+        .{ .src_dir = "src/component/wit/wasi-canon/random", .dst_rel = "wit/deps/random" },
+        .{ .src_dir = "src/component/wit/wasi-canon/sockets", .dst_rel = "wit/deps/sockets" },
+    };
+    for (pkgs) |pkg| {
+        try tmp.dir.createDirPath(io, pkg.dst_rel);
+        var src = try cwd.openDir(io, pkg.src_dir, .{ .iterate = true });
+        defer src.close(io);
+        var it = src.iterate();
+        while (try it.next(io)) |entry| {
+            if (entry.kind != .file) continue;
+            if (!std.mem.endsWith(u8, entry.name, ".wit")) continue;
+            const src_path = try std.fs.path.join(alloc, &.{ pkg.src_dir, entry.name });
+            const buf = try cwd.readFileAlloc(io, src_path, alloc, std.Io.Limit.limited(1 << 20));
+            const dst_path = try std.fs.path.join(alloc, &.{ pkg.dst_rel, entry.name });
+            try tmp.dir.writeFile(io, .{ .sub_path = dst_path, .data = buf });
+        }
+    }
+
+    const tmp_wit = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/wit", .{tmp.sub_path});
+    const res = try wit_resolver.parseLayout(alloc, io, tmp_wit);
+
+    // Encode the proxy world's component-type metadata.
+    const ct_payload = try wit_encode.encodeWorldFromResolver(testing.allocator, res, "proxy");
+    defer testing.allocator.free(ct_payload);
+    try testing.expect(ct_payload.len > 0);
+
+    // Synthesise a core wasm exporting
+    // `wasi:http/incoming-handler@0.2.6#handle (i32, i32) -> ()`,
+    // matching the world's sole export, then attach the embedded
+    // component-type section.
+    const core_only = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x06, 0x01, 0x60, 0x02, 0x7f, 0x7f, 0x00,
+        0x03, 0x02, 0x01, 0x00,
+        0x07, 43, 0x01,
+        39, 'w', 'a', 's', 'i', ':', 'h', 't', 't', 'p',
+        '/', 'i', 'n', 'c', 'o', 'm', 'i', 'n', 'g', '-',
+        'h', 'a', 'n', 'd', 'l', 'e', 'r', '@', '0', '.',
+        '2', '.', '6', '#', 'h', 'a', 'n', 'd', 'l', 'e',
+        0x00, 0x00,
+        0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b,
+    };
+    var core_with_ct = std.ArrayListUnmanaged(u8).empty;
+    defer core_with_ct.deinit(testing.allocator);
+    try core_with_ct.appendSlice(testing.allocator, core_only[0..core_only.len]);
+    const cs_name = "component-type:proxy";
+    var cs_body = std.ArrayListUnmanaged(u8).empty;
+    defer cs_body.deinit(testing.allocator);
+    try writeU32Leb(testing.allocator, &cs_body, @intCast(cs_name.len));
+    try cs_body.appendSlice(testing.allocator, cs_name);
+    try cs_body.appendSlice(testing.allocator, ct_payload);
+    try core_with_ct.append(testing.allocator, 0);
+    try writeU32Leb(testing.allocator, &core_with_ct, @intCast(cs_body.items.len));
+    try core_with_ct.appendSlice(testing.allocator, cs_body.items);
+
+    const comp_bytes = try buildComponent(testing.allocator, core_with_ct.items);
+    defer testing.allocator.free(comp_bytes);
+    try testing.expect(comp_bytes.len > 0);
+
+    // The wrapping component must parse cleanly. Validators
+    // (wasm-tools) accept this binary in interactive runs; this
+    // in-process check uses the wabt loader as a smoke-test
+    // proxy to keep the test self-contained.
+    const loaded = try loader.load(comp_bytes, alloc);
+    try testing.expect(loaded.imports.len >= 1);
+    try testing.expect(loaded.exports.len >= 1);
+    // The exported instance must be the proxy world's
+    // incoming-handler export.
+    var saw_export = false;
+    for (loaded.exports) |e| {
+        if (std.mem.indexOf(u8, e.name, "wasi:http/incoming-handler@0.2.6") != null) {
+            saw_export = true;
+            break;
+        }
+    }
+    try testing.expect(saw_export);
+}
+
 test "buildComponent: rejects core wasm without component-type section" {
     const bare = [_]u8{
         0x00, 0x61, 0x73, 0x6d,


### PR DESCRIPTION
Closes #195. Final phase set; builds on #200 (Phase 1).

The canonical upstream `wasi-http@0.2.6` WIT layout now round-trips through:

```sh
wabt component embed --world proxy wit stub.wasm -o stub.embed.wasm
wabt component new   stub.embed.wasm                 -o stub.component.wasm
wasm-tools validate  stub.component.wasm
# exit 0
```

…with the upstream files copied verbatim into `wit/` + `wit/deps/{cli,clocks,filesystem,io,random,sockets}/` from the GitHub v0.2.6 SHAs.

## Commits in this PR

### Phase 2 — Resolver multi-file primary package

`wasi-http/wit/` carries the `package wasi:http@0.2.6;` decl only in `proxy.wit`; `handler.wit` and `types.wit` inherit it. The old resolver concatenated alphabetically, putting the decl mid-stream and tripping the parser.

`readWitDir` now scans each file for its leading `package` decl (skipping whitespace + line/block comments + `@<id>(args?)` annotations), validates all decls match (`PackageDeclConflict` otherwise), and reorders the concat so the decl-bearing file comes first with any duplicate decls in other files stripped. New errors: `PackageDeclConflict`, `NoPackageDeclInDirectory`. New diagnostic struct `ResolveDiagnostic` plus `parseLayoutWithDiag`. New `scanForPackageDecl` helper.

### Phase 3 — Encoder `include` expansion

`expandWorldItems` recursively walks `ast.World.items`, splicing in each `.include(<ref>)`'s target world items (with `with { N as A }` renames applied). Cycles → `error.IncludeCycle`. Resolver-side: new `findWorld` / `findWorldCtx` mirroring the interface lookups.

### Phase 4 — Full `wasi:http/types` body encodes

Two empirically-surfaced gaps fixed inline:

1. **Implicit imports.** `addImplicitImports` DFS-topological-walks the expanded items, synthesising an `.import` for every `use`-source iface not already reachable. Mirrors `wit-component`'s implicit-import behaviour — the canonical proxy world only references `wasi:http/types` via the `use types.{…}` clauses in its `incoming-handler` / `outgoing-handler` exports, never as an explicit world import.

2. **Type def topological sort.** `sortIfaceItemsForEncoding` reorders each interface body's type defs so any named type referenced by another type appears first in the wire output. Canonical `wasi:http/types` declares `variant error-code` (referencing `DNS-error-payload`) before `record DNS-error-payload`; the encoder previously walked items in declaration order and bailed on the forward reference. Worklist algorithm with self-reference allowance for resource decls.

### Phase 5 — End-to-end test

`buildComponent #195p5: canonical wasi-http proxy world e2e` (in `src/tools/component_new.zig`) assembles the canonical layout into a tmpDir at test time, drives `parseLayout` + `encodeWorldFromResolver` + `buildComponent`, and asserts the resulting binary loads cleanly with the expected import + export shape. Manually verified out-of-process against `wasm-tools validate 1.220.0` (exit 0).

## Verification

- `zig build test` → 462/462 pass (451 baseline post-#200 → +11: 6 Phase 2 + 4 Phase 3 + 1 Phase 4 rewrite + 1 Phase 5).
- One pre-existing test rewritten: `rejects use whose source iface is not in the world` is obsolete now that the encoder auto-imports; replaced with `implicit-imports source iface used by an iface in the world (#195 phase 4)` that asserts the new auto-import path.

## Out of scope / not implemented

- `stream<T>` / `future<T>` / `async` — unused in wasi-http 0.2.6.
- String-literal annotation args (`@deprecated("msg")`) — canonical wasi files don't use them; the WIT lexer doesn't tokenize strings.
- World-level `.type` items still surface as `UnsupportedWitFeature`. Not exercised by wasi-http.
- Multi-package resolver bug-for-bug parity with `wit-component` — out of scope unless a new fixture surfaces a gap.

Refs #200 (#195 Phase 1).
