### PR TITLE
wasi-preview1 adapter: export poll_oneoff as ENOSYS stub (#208)

### DIFF
--- a/adapters/wasi-preview1/src/fragments/body.wat
+++ b/adapters/wasi-preview1/src/fragments/body.wat
@@ -567,6 +567,44 @@
     ;; advisory.
     i32.const 0)
 
+  ;; preview1 `poll_oneoff(in_ptr, out_ptr, nsubscriptions,
+  ;;                        nevents_ptr) -> errno`.
+  ;;
+  ;; **MVP ENOSYS=52 stub** (cataggar/wabt#208). wasi-libc and
+  ;; Zig's stdlib pull `poll_oneoff` into standard startup imports
+  ;; (Zig declares it for `std.Io.Threaded` sleeps / I/O readiness),
+  ;; so embeds that don't actively call it would otherwise be
+  ;; blocked at `wabt component new` time with
+  ;; `MissingRequiredExport` from `gc.run`'s required-export
+  ;; seeding. A real lift would:
+  ;;
+  ;;   * Iterate `*in_ptr` reading 48-byte `subscription` records
+  ;;     (userdata: u64; u.tag: u8 + 7 pad; u.payload: 40 bytes —
+  ;;     clock: clockid u32, timeout u64, precision u64, flags
+  ;;     u16; fd_read/fd_write: fd u32).
+  ;;   * Translate CLOCK entries to pollables via
+  ;;     `wasi:clocks/monotonic-clock.subscribe-{duration,instant}`
+  ;;     (clockid ∈ {MONOTONIC=1, REALTIME=0}; abs flag selects
+  ;;     `subscribe-instant`; otherwise relative `subscribe-duration`).
+  ;;   * Translate FD entries to pollables via
+  ;;     `wasi:io/streams.subscribe` on the descriptor's
+  ;;     input-stream / output-stream.
+  ;;   * `wasi:io/poll.poll([pollables])` to block on the union.
+  ;;   * Write back one 32-byte `event` per ready index into
+  ;;     `*out_ptr`, set `*nevents_ptr` to the count.
+  ;;
+  ;; Returning ENOSYS lets the program decide — wasi-libc / Zig
+  ;; std typically surface it as `EAGAIN`/`EINTR` callers or as a
+  ;; sleep-call failure. Defensively writes 0 to `*nevents_ptr`
+  ;; so callers reading it after an error see a defined value.
+  (func $poll_oneoff (type $poll_oneoff_sig)
+    ;; *nevents_ptr = 0
+    local.get 3
+    i32.const 0
+    i32.store
+    ;; ENOSYS=52
+    i32.const 52)
+
   ;; ── fd_* (mostly ENOSYS stubs until subsequent commits) ──────
 
   ;; Helper: return cached stdout handle, populating it on first

--- a/adapters/wasi-preview1/src/fragments/exports.wat
+++ b/adapters/wasi-preview1/src/fragments/exports.wat
@@ -7,6 +7,7 @@
   (export "proc_exit"                  (func $proc_exit))
   (export "proc_raise"                 (func $proc_raise))
   (export "sched_yield"                (func $sched_yield))
+  (export "poll_oneoff"                (func $poll_oneoff))
   (export "fd_write"                   (func $fd_write))
   (export "fd_pwrite"                  (func $fd_pwrite))
   (export "fd_read"                    (func $fd_read))

--- a/adapters/wasi-preview1/src/fragments/prelude.wat
+++ b/adapters/wasi-preview1/src/fragments/prelude.wat
@@ -159,6 +159,17 @@
 ;;     lift not pursued — preview1 v3 has no socket-creation
 ;;     primitives, so the lift would be functionally moot
 ;;     (cataggar/wabt#178 closed as won't-implement).
+;;   * `poll_oneoff` — exported as ENOSYS=52 stub. wasi-libc and
+;;     Zig's stdlib reference it as part of standard startup
+;;     imports (Zig's `std.Io.Threaded` cites it for sleep / I/O
+;;     readiness), so embeds that pull it in via linker startup
+;;     would otherwise fail at `wabt component new` time with
+;;     `MissingRequiredExport`. Programs that actually call
+;;     `poll_oneoff(2)` get the well-defined ENOSYS errno; a real
+;;     preview2 lift (CLOCK subscriptions through
+;;     `wasi:clocks/monotonic-clock.subscribe-{duration,instant}`
+;;     + `wasi:io/poll.poll`; FD subscriptions through
+;;     `wasi:io/streams.subscribe`) is deferred per cataggar/wabt#208.
 
 (module
   ;; ── func types ────────────────────────────────────────────────
@@ -259,6 +270,15 @@
   (type $proc_exit_sig        (func (param i32)))
   (type $proc_raise_sig       (func (param i32) (result i32)))
   (type $sched_yield_sig      (func (result i32)))
+
+  ;; preview1 poll_oneoff signature (cataggar/wabt#208).
+  ;; poll_oneoff(in_ptr, out_ptr, nsubscriptions, nevents_ptr) -> errno
+  ;; Currently implemented as an ENOSYS=52 stub — see $poll_oneoff in
+  ;; body.wat for the rationale and follow-up plan (proper preview2
+  ;; routing through `wasi:io/poll.poll` + `wasi:clocks/monotonic-
+  ;; clock.subscribe-{duration,instant}` + `wasi:io/streams.subscribe`
+  ;; tracked separately).
+  (type $poll_oneoff_sig      (func (param i32 i32 i32 i32) (result i32)))
 
   ;; preview2 import signatures (canon-lower'd by the wrapping
   ;; component; here they are plain core-wasm function types). The

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -2989,6 +2989,75 @@ test "builtin_adapter: reactor world imports the same preview2 surface as comman
     }
 }
 
+// ── #208: `poll_oneoff` export presence + GC-pass survival ─────────────────
+// wasi-libc + Zig stdlib pull `poll_oneoff` in via standard startup
+// imports; the adapter must export it (even as an ENOSYS stub) so
+// `gc.run`'s required-export seeding succeeds and `wabt component
+// new` doesn't bail out with `error.MissingRequiredExport`.
+
+test "builtin_adapter: command exports poll_oneoff with the canonical preview1 signature (#208)" {
+    var owned = try core_imports.extract(testing.allocator, builtin_adapter.wasi_preview1_command_wasm);
+    defer owned.deinit();
+
+    const e = owned.interface.findExport("poll_oneoff") orelse {
+        return error.PollOneoffMissingFromCommandAdapter;
+    };
+    try testing.expect(e.kind == .func);
+    const sig = e.sig.?;
+    // poll_oneoff(in_ptr, out_ptr, nsubscriptions, nevents_ptr) -> errno
+    // Core-wasm shape: (i32, i32, i32, i32) -> i32.
+    try testing.expectEqual(@as(usize, 4), sig.params.len);
+    for (sig.params) |p| try testing.expectEqual(wabt.types.ValType.i32, p);
+    try testing.expectEqual(@as(usize, 1), sig.results.len);
+    try testing.expectEqual(wabt.types.ValType.i32, sig.results[0]);
+}
+
+test "builtin_adapter: reactor exports poll_oneoff with the canonical preview1 signature (#208)" {
+    var owned = try core_imports.extract(testing.allocator, builtin_adapter.wasi_preview1_reactor_wasm);
+    defer owned.deinit();
+
+    const e = owned.interface.findExport("poll_oneoff") orelse {
+        return error.PollOneoffMissingFromReactorAdapter;
+    };
+    try testing.expect(e.kind == .func);
+    const sig = e.sig.?;
+    try testing.expectEqual(@as(usize, 4), sig.params.len);
+    for (sig.params) |p| try testing.expectEqual(wabt.types.ValType.i32, p);
+    try testing.expectEqual(@as(usize, 1), sig.results.len);
+    try testing.expectEqual(wabt.types.ValType.i32, sig.results[0]);
+}
+
+test "builtin_adapter: gc.run satisfies a poll_oneoff requirement (regression for #208)" {
+    // Concrete repro of issue #208's failing path: an embed that
+    // imports `wasi_snapshot_preview1.poll_oneoff` causes the
+    // splicer to seed `gc.run`'s required-export set with
+    // `"poll_oneoff"`. Before this fix the adapter had no
+    // `poll_oneoff` export and `gc.run` returned
+    // `error.MissingRequiredExport` immediately. With the ENOSYS
+    // stub in place gc.run must succeed AND the survival-set
+    // bytes must re-load cleanly.
+    const gc = wabt.component.adapter.gc;
+    const required = [_][]const u8{"poll_oneoff"};
+
+    const out_cmd = try gc.run(
+        testing.allocator,
+        builtin_adapter.wasi_preview1_command_wasm,
+        &required,
+    );
+    defer testing.allocator.free(out_cmd);
+    try testing.expect(out_cmd.len > 8);
+    try testing.expectEqualSlices(u8, "\x00asm", out_cmd[0..4]);
+
+    const out_rx = try gc.run(
+        testing.allocator,
+        builtin_adapter.wasi_preview1_reactor_wasm,
+        &required,
+    );
+    defer testing.allocator.free(out_rx);
+    try testing.expect(out_rx.len > 8);
+    try testing.expectEqualSlices(u8, "\x00asm", out_rx[0..4]);
+}
+
 test "probeStartExport: core with `_start` func export -> .yes" {
     // Hand-rolled core wasm:
     //   - type 0: (func)


### PR DESCRIPTION
Closes #208 (title-of-issue: "preview1 adapter missing poll_oneoff / Zig std hits MissingRequiredExport").

## Diagnosis

Of the three names listed in the issue title, only `poll_oneoff` was actually missing from the built-in preview1 adapter:

| name | exported by adapter? |
|---|---|
| `fd_pread` | ✅ already exported (\`body.wat:2105\`) |
| `path_readlink` | ✅ already exported (\`body.wat:2323\`) |
| `poll_oneoff` | ❌ **missing entirely** |

`wasi-libc` and Zig's stdlib pull `wasi_snapshot_preview1.poll_oneoff` into standard startup imports (Zig declares it at \`std/os/wasi.zig:70\` and references it from \`std/Io/Threaded.zig:11645\` for sleeps + I/O readiness). Without a `poll_oneoff` export, \`wabt component new\` aborts at \`gc.zig:92\` with \`error.MissingRequiredExport\` for any embed that imports it — verified with a minimal Zig stub.

The issue body proposed a different fix (relaxing \`metadata_decode\` to accept \`.alias\` / \`.@"export" type\` decls inside world / interface bodies). That fix is **already present** in the current codebase (\`src/component/wit/metadata_decode.zig:179-202\` for the world walk, \`:251-298\` for the interface walk). The remaining live actionable item is the title's claim about the missing adapter export.

## Fix

Adds `poll_oneoff` to the preview1 adapter as an **ENOSYS=52 stub**, matching the precedent established by \`proc_raise\`, \`fd_allocate\`, \`fd_renumber\`, and \`sock_*\` (\`prelude.wat:101-105, 146-161\`):

- \`prelude.wat\` — new \`\$poll_oneoff_sig\` type alias \`(i32 i32 i32 i32) -> i32\` mirroring preview1's \`(in_ptr, out_ptr, nsubscriptions, nevents_ptr) -> errno\`, plus a header doc-block entry.
- \`body.wat\` — \`\$poll_oneoff\` function that defensively writes \`0\` to \`*nevents_ptr\` and returns \`52\`. The accompanying comment lays out exactly what a real preview2 lift would do (CLOCK subscriptions through \`wasi:clocks/monotonic-clock.subscribe-{duration,instant}\`; FD subscriptions through \`wasi:io/streams.subscribe\`; union poll via \`wasi:io/poll.poll\`) — deferred as a follow-up issue once a real consumer demands working timed waits via this code path.
- \`exports.wat\` — \`(export "poll_oneoff" (func \$poll_oneoff))\`.

## Tests

- \`builtin_adapter: command exports poll_oneoff with the canonical preview1 signature (#208)\`
- \`builtin_adapter: reactor exports poll_oneoff with the canonical preview1 signature (#208)\`
- \`builtin_adapter: gc.run satisfies a poll_oneoff requirement (regression for #208)\` — directly reproduces the user's failing path: seeds \`gc.run\` with \`["poll_oneoff"]\` and asserts it returns valid module bytes rather than \`error.MissingRequiredExport\`.

## Manual end-to-end

```
\$ cat stub.zig
extern "wasi_snapshot_preview1" fn poll_oneoff(in: *const u8, out: *u8, nsubscriptions: usize, nevents: *usize) i32;
export fn @"wasi:http/incoming-handler@0.2.6#handle"(_: i32, _: i32) void {
    var nin: u8 = 0; var nout: u8 = 0; var nevents: usize = 0;
    _ = poll_oneoff(&nin, &nout, 1, &nevents);
}
\$ zig build-exe -target wasm32-freestanding -fno-entry --export="wasi:http/incoming-handler@0.2.6#handle" stub.zig
\$ wabt component embed --world http-hello wit stub.wasm -o stub.embed.wasm  # ✓
\$ wabt component new stub.embed.wasm -o stub.component.wasm                  # ✓ (was MissingRequiredExport)
```

The full \`zig build test\` suite passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>