### PR TITLE
wabt component new: preserve embed-declared methods through adapter-driven world GC (#222)

### DIFF
--- a/src/component/adapter/adapter.zig
+++ b/src/component/adapter/adapter.zig
@@ -148,7 +148,8 @@ pub fn splice(
     defer pristine_iface.deinit();
 
     const live_namespaces = try collectLiveNamespaces(a, pristine_iface.interface);
-    const live_methods_by_namespace = try collectLiveMethodsByNamespace(a, pristine_iface.interface);
+    const live_methods_adapter = try collectLiveMethodsByNamespace(a, pristine_iface.interface);
+    const live_methods_by_namespace = try augmentLiveMethodsByNamespaceWithEmbed(a, live_methods_adapter, embed_bytes);
     const live_export_names = try collectLiveExportNames(a, pristine_world);
 
     const gc_world_result = try world_gc.gcWorld(a, pristine_world, live_namespaces, live_methods_by_namespace, live_export_names);
@@ -258,7 +259,8 @@ fn spliceN(gpa: Allocator, embed_bytes: []const u8, adapters: []const Adapter) !
     defer pristine_iface.deinit();
 
     const live_namespaces = try collectLiveNamespaces(a, pristine_iface.interface);
-    const live_methods_by_namespace = try collectLiveMethodsByNamespace(a, pristine_iface.interface);
+    const live_methods_adapter = try collectLiveMethodsByNamespace(a, pristine_iface.interface);
+    const live_methods_by_namespace = try augmentLiveMethodsByNamespaceWithEmbed(a, live_methods_adapter, embed_bytes);
     const live_export_names = try collectLiveExportNames(a, pristine_world);
 
     const gc_world_result = try world_gc.gcWorld(a, pristine_world, live_namespaces, live_methods_by_namespace, live_export_names);
@@ -524,6 +526,120 @@ fn collectLiveMethodsByNamespace(
         }
     }
 
+    var out = try arena.alloc(world_gc.LiveMethodSet, by_ns.count());
+    var i: usize = 0;
+    var it = by_ns.iterator();
+    while (it.next()) |entry| : (i += 1) {
+        out[i] = .{
+            .namespace = entry.value_ptr.namespace,
+            .methods = try entry.value_ptr.methods.toOwnedSlice(arena),
+            .type_exports = try entry.value_ptr.type_exports.toOwnedSlice(arena),
+        };
+    }
+    return out;
+}
+
+/// Augment a `live_methods_by_namespace` set with methods + type
+/// exports declared by the embed's `component-type:<world>` custom
+/// section. Mirrors `wit-component`'s policy: every iface the user's
+/// WIT names as an import is kept verbatim in the wrapping
+/// component's instance-type body — its declared methods are the
+/// contract the user wrote and must survive the adapter-driven GC
+/// regardless of which lowered names the adapter happened to need
+/// (cataggar/wabt#222).
+///
+/// Returns `base` unchanged when the embed has no component-type
+/// section, or when decoding it fails (we fall back to the adapter-
+/// derived view rather than failing the splice).
+fn augmentLiveMethodsByNamespaceWithEmbed(
+    arena: Allocator,
+    base: []const world_gc.LiveMethodSet,
+    embed_bytes: []const u8,
+) SpliceError![]const world_gc.LiveMethodSet {
+    const NamespaceBuilder = struct {
+        namespace: []const u8,
+        methods: std.ArrayListUnmanaged([]const u8),
+        method_seen: std.StringHashMapUnmanaged(void),
+        type_exports: std.ArrayListUnmanaged([]const u8),
+        type_export_seen: std.StringHashMapUnmanaged(void),
+    };
+
+    var by_ns = std.StringArrayHashMapUnmanaged(NamespaceBuilder).empty;
+    defer by_ns.deinit(arena);
+
+    // Seed from the adapter-derived view.
+    for (base) |s| {
+        const gop = try by_ns.getOrPut(arena, s.namespace);
+        if (!gop.found_existing) gop.value_ptr.* = .{
+            .namespace = s.namespace,
+            .methods = .empty,
+            .method_seen = .empty,
+            .type_exports = .empty,
+            .type_export_seen = .empty,
+        };
+        const b = gop.value_ptr;
+        for (s.methods) |m| {
+            const mg = try b.method_seen.getOrPut(arena, m);
+            if (!mg.found_existing) try b.methods.append(arena, m);
+        }
+        for (s.type_exports) |t| {
+            const tg = try b.type_export_seen.getOrPut(arena, t);
+            if (!tg.found_existing) try b.type_exports.append(arena, t);
+        }
+    }
+
+    // Decode the embed's component-type. Absent / malformed → fall
+    // back to the adapter-derived view unchanged.
+    const found = metadata_decode.extractFromCoreWasm(embed_bytes) catch
+        return finalizeLiveSet(arena, &by_ns);
+    const ct = found orelse return finalizeLiveSet(arena, &by_ns);
+
+    const decoded = metadata_decode.decode(arena, ct.payload) catch
+        return finalizeLiveSet(arena, &by_ns);
+
+    // For each embed-declared import, add every `.@"export"` name
+    // its instance-type body declares. Methods (`.@"export" func`)
+    // contribute to `methods`; type exports (`.@"export" type`)
+    // contribute to `type_exports`. The encoded names match the
+    // canonical lowered form (e.g. `[method]pollable.ready`,
+    // `pollable`), so they line up 1:1 with `gcInstanceBody`'s
+    // name-match seeding.
+    for (decoded.externs) |ext| {
+        if (ext.is_export) continue;
+
+        const gop = try by_ns.getOrPut(arena, ext.qualified_name);
+        if (!gop.found_existing) gop.value_ptr.* = .{
+            .namespace = ext.qualified_name,
+            .methods = .empty,
+            .method_seen = .empty,
+            .type_exports = .empty,
+            .type_export_seen = .empty,
+        };
+        const b = gop.value_ptr;
+
+        for (ext.inst_decls) |d| switch (d) {
+            .@"export" => |e| switch (e.desc) {
+                .func => {
+                    const mg = try b.method_seen.getOrPut(arena, e.name);
+                    if (!mg.found_existing) try b.methods.append(arena, e.name);
+                },
+                .type => {
+                    const tg = try b.type_export_seen.getOrPut(arena, e.name);
+                    if (!tg.found_existing) try b.type_exports.append(arena, e.name);
+                },
+                else => {},
+            },
+            else => {},
+        };
+    }
+
+    return finalizeLiveSet(arena, &by_ns);
+}
+
+fn finalizeLiveSet(
+    arena: Allocator,
+    by_ns: anytype,
+) SpliceError![]const world_gc.LiveMethodSet {
     var out = try arena.alloc(world_gc.LiveMethodSet, by_ns.count());
     var i: usize = 0;
     var it = by_ns.iterator();
@@ -2566,3 +2682,146 @@ test "spliceMany: rejects two adapters with non-env imports" {
     };
     try testing.expectError(error.AmbiguousPrimaryAdapter, spliceMany(a, embed_bytes, &adapters));
 }
+
+test "augmentLiveMethodsByNamespaceWithEmbed #222: embed-declared methods join adapter live set" {
+    // Regression for cataggar/wabt#222.
+    //
+    // The wasmtime upstream preview1 adapter's core wasm imports
+    // only `[resource-drop]pollable` and `poll` from
+    // `wasi:io/poll@0.2.6` — not the `[method]pollable.*` methods.
+    // Pre-fix, `world_gc.gcInstanceBody` consequently dropped both
+    // methods from the wrapping component's `wasi:io/poll`
+    // instance-type body, even when the user's embed component-type
+    // declared the canonical interface (resource pollable with
+    // `ready` + `block` methods + iface-level `poll`).
+    //
+    // The fix: also seed the live set from the embed's
+    // `component-type:<world>` custom section so every method the
+    // user's WIT declares for an imported iface survives GC.
+    //
+    // This unit test mirrors that scenario in isolation:
+    //
+    //   * `base`: simulates `collectLiveMethodsByNamespace`'s
+    //     output for the wasmtime adapter — only `poll` + the
+    //     resource-drop appear under `wasi:io/poll@0.2.6`.
+    //   * Build a synthetic embed with a `component-type` custom
+    //     section whose world declares
+    //     `import wasi:io/poll@0.2.6` carrying the canonical
+    //     `pollable.ready` + `pollable.block` methods.
+    //   * After `augmentLiveMethodsByNamespaceWithEmbed` the
+    //     namespace's `methods` set contains all four (adapter
+    //     contributions union embed contributions).
+    const a = testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(a);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const ns = "wasi:io/poll@0.2.6";
+    const adapter_methods = [_][]const u8{ "[resource-drop]pollable", "poll" };
+    const adapter_type_exports = [_][]const u8{"pollable"};
+
+    const base = [_]world_gc.LiveMethodSet{
+        .{
+            .namespace = ns,
+            .methods = &adapter_methods,
+            .type_exports = &adapter_type_exports,
+        },
+    };
+
+    const ct_payload = try metadata_encode_for_test.encodeWorldFromSource(a,
+        \\package wasi:io@0.2.6;
+        \\
+        \\interface poll {
+        \\    resource pollable {
+        \\        ready: func() -> bool;
+        \\        block: func();
+        \\    }
+        \\    poll: func(in: list<borrow<pollable>>) -> list<u32>;
+        \\}
+        \\
+        \\world demo {
+        \\    import poll;
+        \\}
+    , "demo");
+    defer a.free(ct_payload);
+
+    var embed = std.ArrayListUnmanaged(u8).empty;
+    defer embed.deinit(a);
+    try embed.appendSlice(a, &.{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 });
+    const cs_name = "component-type:demo";
+    var cs_body = std.ArrayListUnmanaged(u8).empty;
+    defer cs_body.deinit(a);
+    try writeU32Leb(a, &cs_body, @intCast(cs_name.len));
+    try cs_body.appendSlice(a, cs_name);
+    try cs_body.appendSlice(a, ct_payload);
+    try embed.append(a, 0x00);
+    try writeU32Leb(a, &embed, @intCast(cs_body.items.len));
+    try embed.appendSlice(a, cs_body.items);
+
+    const augmented = try augmentLiveMethodsByNamespaceWithEmbed(arena, &base, embed.items);
+
+    // Locate the wasi:io/poll entry in the result.
+    var idx: ?usize = null;
+    for (augmented, 0..) |s, i| if (std.mem.eql(u8, s.namespace, ns)) {
+        idx = i;
+    };
+    try testing.expect(idx != null);
+    const entry = augmented[idx.?];
+
+    // Adapter-derived methods survive verbatim.
+    var has_drop = false;
+    var has_poll = false;
+    // Embed-derived methods are now present too.
+    var has_ready = false;
+    var has_block = false;
+    for (entry.methods) |m| {
+        if (std.mem.eql(u8, m, "[resource-drop]pollable")) has_drop = true;
+        if (std.mem.eql(u8, m, "poll")) has_poll = true;
+        if (std.mem.eql(u8, m, "[method]pollable.ready")) has_ready = true;
+        if (std.mem.eql(u8, m, "[method]pollable.block")) has_block = true;
+    }
+    try testing.expect(has_drop);
+    try testing.expect(has_poll);
+    try testing.expect(has_ready);
+    try testing.expect(has_block);
+
+    // `pollable` type-export remains a type anchor.
+    var has_pollable = false;
+    for (entry.type_exports) |t| if (std.mem.eql(u8, t, "pollable")) {
+        has_pollable = true;
+    };
+    try testing.expect(has_pollable);
+}
+
+test "augmentLiveMethodsByNamespaceWithEmbed: empty embed falls back to base unchanged" {
+    // No component-type custom section on the embed → the function
+    // must return the base set verbatim. Same applies if the
+    // embed has malformed metadata (we treat that as "no useful
+    // signal" rather than failing the splice).
+    const a = testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(a);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const ns = "wasi:io/poll@0.2.6";
+    const adapter_methods = [_][]const u8{"poll"};
+    const adapter_type_exports = [_][]const u8{"pollable"};
+
+    const base = [_]world_gc.LiveMethodSet{
+        .{
+            .namespace = ns,
+            .methods = &adapter_methods,
+            .type_exports = &adapter_type_exports,
+        },
+    };
+
+    const empty_embed = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 };
+    const augmented = try augmentLiveMethodsByNamespaceWithEmbed(arena, &base, &empty_embed);
+    try testing.expectEqual(@as(usize, 1), augmented.len);
+    try testing.expectEqualStrings(ns, augmented[0].namespace);
+    try testing.expectEqual(@as(usize, 1), augmented[0].methods.len);
+    try testing.expectEqualStrings("poll", augmented[0].methods[0]);
+    try testing.expectEqualStrings("pollable", augmented[0].type_exports[0]);
+}
+
+const metadata_encode_for_test = @import("../wit/metadata_encode.zig");

--- a/src/component/rewrite_extern_names.zig
+++ b/src/component/rewrite_extern_names.zig
@@ -1935,3 +1935,109 @@ test "apply: malformed `name` section falls back to verbatim copy (#214 cosmetic
     // Section content survives verbatim.
     try testing.expect(std.mem.indexOf(u8, out, &.{ 0x05, 0xff, 0xee }) != null);
 }
+
+// ── #222: method-export decls survive the rewriter ─────────────────────────
+
+test "apply: preserves [method]R.M-named export decls inside instance-type bodies (#222)" {
+    // Audit-bake for #222. The rewriter walks type sections and
+    // descends into instance/component-type bodies via
+    // `rewriteDeclList`. Each `0x04` (export) decl's name slot is
+    // run through `extern_name.rewrite`, which is a no-op for
+    // method-style names (`[method]R.M`) because `extern_name.parse`
+    // doesn't recognise the `[method]…` prefix as an extern-name
+    // form. Verify the decl survives byte-equivalently and isn't
+    // dropped or corrupted.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // Instance type body mirroring wasi:io/poll@0.2.10's canonical
+    // shape: a sub_resource export, a borrow-handle type, a func
+    // type, a method export, a list-of-borrows compound, and a
+    // poll func + export.
+    const borrow_handle = ctypes.TypeDef{ .val = .{ .borrow = 0 } };
+    const ready_func = ctypes.TypeDef{ .func = .{
+        .params = &.{},
+        .results = .none,
+    } };
+    const block_func = ctypes.TypeDef{ .func = .{
+        .params = &.{},
+        .results = .none,
+    } };
+    const inner_decls = [_]ctypes.Decl{
+        .{ .@"export" = .{ .name = "pollable", .desc = .{ .type = .sub_resource } } },
+        .{ .type = borrow_handle },
+        .{ .type = ready_func },
+        .{ .@"export" = .{ .name = "[method]pollable.ready", .desc = .{ .func = 2 } } },
+        .{ .type = block_func },
+        .{ .@"export" = .{ .name = "[method]pollable.block", .desc = .{ .func = 4 } } },
+    };
+    const iface_inst = ctypes.TypeDef{ .instance = .{ .decls = &inner_decls } };
+    // Wrap inside a component type with one import declaring the
+    // instance — that's the real-world shape wt-component emits.
+    const ct_decls = [_]ctypes.Decl{
+        .{ .type = iface_inst },
+        .{ .import = .{ .name = "wasi:io/poll@0.2.10", .desc = .{ .instance = 0 } } },
+    };
+    const ct = ctypes.TypeDef{ .component = .{ .decls = &ct_decls } };
+    const types = [_]ctypes.TypeDef{ct};
+    const comp: ctypes.Component = .{
+        .core_modules = &.{}, .core_instances = &.{},
+        .core_types = &.{}, .components = &.{},
+        .instances = &.{}, .aliases = &.{},
+        .types = &types, .canons = &.{},
+        .imports = &.{}, .exports = &.{},
+    };
+    const bytes = try writer.encode(ar, &comp);
+
+    const rules = [_]extern_name.Rule{
+        .{ .ns = "wasi", .pkg = "io", .to_version = "0.2.6" },
+    };
+    const out = try apply(ar, bytes, &rules);
+
+    const loaded = try loader.load(out, ar);
+    try testing.expectEqual(@as(usize, 1), loaded.types.len);
+    try testing.expect(loaded.types[0] == .component);
+    const got_ct_decls = loaded.types[0].component.decls;
+
+    // Find the instance-type decl and walk its body.
+    var got_inst_opt: ?ctypes.InstanceTypeDecl = null;
+    for (got_ct_decls) |d| {
+        if (d == .type and d.type == .instance) {
+            got_inst_opt = d.type.instance;
+            break;
+        }
+    }
+    const got_inst = got_inst_opt orelse return error.MissingInstanceType;
+
+    // Both `[method]pollable.ready` and `[method]pollable.block`
+    // export decls must survive — if the rewriter accidentally
+    // dropped them this would be the symptom the user reports in
+    // #222 (narrowed interface in the composed binary).
+    try testing.expectEqual(@as(usize, inner_decls.len), got_inst.decls.len);
+    var saw_ready = false;
+    var saw_block = false;
+    for (got_inst.decls) |d| {
+        if (d != .@"export") continue;
+        if (std.mem.eql(u8, d.@"export".name, "[method]pollable.ready")) {
+            try testing.expect(d.@"export".desc == .func);
+            saw_ready = true;
+        }
+        if (std.mem.eql(u8, d.@"export".name, "[method]pollable.block")) {
+            try testing.expect(d.@"export".desc == .func);
+            saw_block = true;
+        }
+    }
+    try testing.expect(saw_ready);
+    try testing.expect(saw_block);
+
+    // And the import name itself was rewritten to @0.2.6.
+    var saw_import = false;
+    for (got_ct_decls) |d| {
+        if (d == .import) {
+            try testing.expectEqualStrings("wasi:io/poll@0.2.6", d.import.name);
+            saw_import = true;
+        }
+    }
+    try testing.expect(saw_import);
+}

--- a/src/component/wit/metadata_encode.zig
+++ b/src/component/wit/metadata_encode.zig
@@ -1603,6 +1603,95 @@ test "metadata_encode: flags typedef" {
     try testing.expectEqual(@as(u32, 1), iface.decls[2].type.func.params[0].type.type_idx);
 }
 
+test "metadata_encode #222: @since-annotated resource methods survive end-to-end" {
+    // Audit-bake for #222. The user reported that resource methods
+    // carrying `@since(version = X.Y.Z)` annotations were dropped
+    // from the emitted interface body. Verified here that:
+    //   1. The parser captures all methods through annotations.
+    //   2. `metadata_encode` emits every method's func-type +
+    //      `[method]R.M`-named export decl.
+    //   3. `loader.load` round-trips the encoded section back.
+    //
+    // Uses the exact canonical `wasi:io/poll@0.2.6` shape the user
+    // pasted, including list types (which exercise the realloc-opt
+    // path).
+    const source =
+        \\package wasi:io@0.2.6;
+        \\
+        \\@since(version = 0.2.0)
+        \\interface poll {
+        \\  @since(version = 0.2.0)
+        \\  resource pollable {
+        \\    @since(version = 0.2.0)
+        \\    ready: func() -> bool;
+        \\
+        \\    @since(version = 0.2.0)
+        \\    block: func();
+        \\  }
+        \\
+        \\  @since(version = 0.2.0)
+        \\  poll: func(in: list<borrow<pollable>>) -> list<u32>;
+        \\}
+        \\
+        \\world test { import poll; }
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "test");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const iface = comp.types[0].component.decls[0].type.component.decls[0].type.instance;
+    // Body shape (12 decls per the canonical lowering):
+    //   0: export "pollable" (sub_resource)
+    //   1: type val .borrow=0
+    //   2: type func (ready's sig)
+    //   3: export "[method]pollable.ready" func=2
+    //   4: type val .borrow=0
+    //   5: type func (block's sig)
+    //   6: export "[method]pollable.block" func=4
+    //   7: type val .borrow=0  (poll's list-element handle)
+    //   8: type list type_idx=7
+    //   9: type list u32
+    //  10: type func (poll's sig)
+    //  11: export "poll" func=10
+    try testing.expectEqual(@as(usize, 12), iface.decls.len);
+
+    // Pin every method/func export — these are the ones the user
+    // reported missing.
+    var saw_pollable = false;
+    var saw_ready = false;
+    var saw_block = false;
+    var saw_poll = false;
+    for (iface.decls) |d| {
+        if (d != .@"export") continue;
+        const e = d.@"export";
+        if (std.mem.eql(u8, e.name, "pollable")) {
+            try testing.expect(e.desc == .type);
+            try testing.expect(e.desc.type == .sub_resource);
+            saw_pollable = true;
+        }
+        if (std.mem.eql(u8, e.name, "[method]pollable.ready")) {
+            try testing.expect(e.desc == .func);
+            saw_ready = true;
+        }
+        if (std.mem.eql(u8, e.name, "[method]pollable.block")) {
+            try testing.expect(e.desc == .func);
+            saw_block = true;
+        }
+        if (std.mem.eql(u8, e.name, "poll")) {
+            try testing.expect(e.desc == .func);
+            saw_poll = true;
+        }
+    }
+    try testing.expect(saw_pollable);
+    try testing.expect(saw_ready);
+    try testing.expect(saw_block);
+    try testing.expect(saw_poll);
+}
+
 test "metadata_encode: resource with constructor + method + static" {
     // Mirrors `wasi:io/streams.output-stream` style: a constructor, a
     // method (gets implicit `self: borrow<R>`), and a static. The

--- a/src/tools/component_compose.zig
+++ b/src/tools/component_compose.zig
@@ -2681,3 +2681,187 @@ test "composeBinaries: consumer alias to a name also bubbled from provider resol
     }
     try testing.expect(found);
 }
+
+// ── #222: method-export decls survive composition + --align-wasi rewrite ───
+
+test "composeBinaries: provider with resource methods retains them post-compose (#222)" {
+    // Audit-bake for #222. The user reported the COMPOSED component
+    // ends up with a narrowed `wasi:io/poll` interface (resource
+    // pollable + bare `poll`, no `[method]pollable.ready` /
+    // `[method]pollable.block`). Both halves' canonical WIT
+    // declares the methods, so the narrowing must happen during
+    // compose if anywhere. This test exercises a minimal seam
+    // through `composeBinaries` and asserts every method-export
+    // decl survives in the composed bytes.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // Provider: imports wasi:io/poll@0.2.10 (full canonical body
+    // with pollable + 2 methods).
+    const borrow_handle_a = ctypes.TypeDef{ .val = .{ .borrow = 0 } };
+    const ready_func = ctypes.TypeDef{ .func = .{ .params = &.{}, .results = .none } };
+    const borrow_handle_b = ctypes.TypeDef{ .val = .{ .borrow = 0 } };
+    const block_func = ctypes.TypeDef{ .func = .{ .params = &.{}, .results = .none } };
+    const inst_decls = [_]ctypes.Decl{
+        .{ .@"export" = .{ .name = "pollable", .desc = .{ .type = .sub_resource } } },
+        .{ .type = borrow_handle_a },
+        .{ .type = ready_func },
+        .{ .@"export" = .{ .name = "[method]pollable.ready", .desc = .{ .func = 2 } } },
+        .{ .type = borrow_handle_b },
+        .{ .type = block_func },
+        .{ .@"export" = .{ .name = "[method]pollable.block", .desc = .{ .func = 4 } } },
+    };
+    const iface_inst = ctypes.TypeDef{ .instance = .{ .decls = &inst_decls } };
+    const prov_types = [_]ctypes.TypeDef{iface_inst};
+    const prov_imports = [_]ctypes.ImportDecl{
+        .{ .name = "wasi:io/poll@0.2.10", .desc = .{ .instance = 0 } },
+    };
+    const provider: ctypes.Component = .{
+        .core_modules = &.{}, .core_instances = &.{}, .core_types = &.{},
+        .components = &.{}, .instances = &.{}, .aliases = &.{},
+        .types = &prov_types, .canons = &.{},
+        .imports = &prov_imports, .exports = &.{},
+    };
+    const pb = try writer.encode(ar, &provider);
+
+    // Consumer: same poll import, same shape (so dedup applies).
+    const borrow_handle_c = ctypes.TypeDef{ .val = .{ .borrow = 0 } };
+    const ready_func_c = ctypes.TypeDef{ .func = .{ .params = &.{}, .results = .none } };
+    const borrow_handle_d = ctypes.TypeDef{ .val = .{ .borrow = 0 } };
+    const block_func_c = ctypes.TypeDef{ .func = .{ .params = &.{}, .results = .none } };
+    const cons_inst_decls = [_]ctypes.Decl{
+        .{ .@"export" = .{ .name = "pollable", .desc = .{ .type = .sub_resource } } },
+        .{ .type = borrow_handle_c },
+        .{ .type = ready_func_c },
+        .{ .@"export" = .{ .name = "[method]pollable.ready", .desc = .{ .func = 2 } } },
+        .{ .type = borrow_handle_d },
+        .{ .type = block_func_c },
+        .{ .@"export" = .{ .name = "[method]pollable.block", .desc = .{ .func = 4 } } },
+    };
+    const cons_iface_inst = ctypes.TypeDef{ .instance = .{ .decls = &cons_inst_decls } };
+    const cons_types = [_]ctypes.TypeDef{cons_iface_inst};
+    const cons_imports = [_]ctypes.ImportDecl{
+        .{ .name = "wasi:io/poll@0.2.10", .desc = .{ .instance = 0 } },
+    };
+    const consumer: ctypes.Component = .{
+        .core_modules = &.{}, .core_instances = &.{}, .core_types = &.{},
+        .components = &.{}, .instances = &.{}, .aliases = &.{},
+        .types = &cons_types, .canons = &.{},
+        .imports = &cons_imports, .exports = &.{},
+    };
+    const cb = try writer.encode(ar, &consumer);
+
+    var providers_buf = [_][]const u8{pb};
+    const composed = try composeBinaries(testing.allocator, cb, providers_buf[0..]);
+    defer testing.allocator.free(composed);
+
+    var arena2 = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena2.deinit();
+    const loaded = try loader.load(composed, arena2.allocator());
+
+    // Wrapper outer-imports: deduped wasi:io/poll (1 total).
+    try testing.expectEqual(@as(usize, 1), loaded.imports.len);
+    try testing.expectEqualStrings("wasi:io/poll@0.2.10", loaded.imports[0].name);
+
+    // Wrapper's instance-type body (the wrapper-side cloned copy
+    // from `appendSourcePrologue`) must preserve both method
+    // exports. The wrapper has the instance type as the bubbled
+    // type closure.
+    var saw_ready = false;
+    var saw_block = false;
+    for (loaded.types) |t| {
+        if (t != .instance) continue;
+        for (t.instance.decls) |d| {
+            if (d != .@"export") continue;
+            if (std.mem.eql(u8, d.@"export".name, "[method]pollable.ready")) {
+                try testing.expect(d.@"export".desc == .func);
+                saw_ready = true;
+            }
+            if (std.mem.eql(u8, d.@"export".name, "[method]pollable.block")) {
+                try testing.expect(d.@"export".desc == .func);
+                saw_block = true;
+            }
+        }
+    }
+    try testing.expect(saw_ready);
+    try testing.expect(saw_block);
+
+    // Composed bytes must literally contain the method names — last-line
+    // defense if the type-walk somehow miscounted.
+    try testing.expect(std.mem.indexOf(u8, composed, "[method]pollable.ready") != null);
+    try testing.expect(std.mem.indexOf(u8, composed, "[method]pollable.block") != null);
+}
+
+test "compose end-to-end: resource methods survive --align-wasi rewrite + compose (#222)" {
+    // Same fixture as above but with mismatched versions (consumer
+    // @0.2.6, provider @0.2.10) → forces the --align-wasi=0.2.6
+    // path. Both halves' method-export decls must survive the
+    // byte-level rewriter AND the compose wrapper construction.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    const borrow_handle_a = ctypes.TypeDef{ .val = .{ .borrow = 0 } };
+    const ready_func = ctypes.TypeDef{ .func = .{ .params = &.{}, .results = .none } };
+    const borrow_handle_b = ctypes.TypeDef{ .val = .{ .borrow = 0 } };
+    const block_func = ctypes.TypeDef{ .func = .{ .params = &.{}, .results = .none } };
+    const inst_decls_template = [_]ctypes.Decl{
+        .{ .@"export" = .{ .name = "pollable", .desc = .{ .type = .sub_resource } } },
+        .{ .type = borrow_handle_a },
+        .{ .type = ready_func },
+        .{ .@"export" = .{ .name = "[method]pollable.ready", .desc = .{ .func = 2 } } },
+        .{ .type = borrow_handle_b },
+        .{ .type = block_func },
+        .{ .@"export" = .{ .name = "[method]pollable.block", .desc = .{ .func = 4 } } },
+    };
+    const iface_inst = ctypes.TypeDef{ .instance = .{ .decls = &inst_decls_template } };
+    const types = [_]ctypes.TypeDef{iface_inst};
+
+    // Consumer @0.2.6.
+    const cons_imports = [_]ctypes.ImportDecl{
+        .{ .name = "wasi:io/poll@0.2.6", .desc = .{ .instance = 0 } },
+    };
+    const consumer: ctypes.Component = .{
+        .core_modules = &.{}, .core_instances = &.{}, .core_types = &.{},
+        .components = &.{}, .instances = &.{}, .aliases = &.{},
+        .types = &types, .canons = &.{},
+        .imports = &cons_imports, .exports = &.{},
+    };
+    const cb_orig = try writer.encode(ar, &consumer);
+
+    // Provider @0.2.10.
+    const prov_imports = [_]ctypes.ImportDecl{
+        .{ .name = "wasi:io/poll@0.2.10", .desc = .{ .instance = 0 } },
+    };
+    const provider: ctypes.Component = .{
+        .core_modules = &.{}, .core_instances = &.{}, .core_types = &.{},
+        .components = &.{}, .instances = &.{}, .aliases = &.{},
+        .types = &types, .canons = &.{},
+        .imports = &prov_imports, .exports = &.{},
+    };
+    const pb_orig = try writer.encode(ar, &provider);
+
+    // Detect → align to 0.2.6.
+    const consumer_ast = try loader.load(cb_orig, ar);
+    const provider_ast = try loader.load(pb_orig, ar);
+    const provider_ptrs = [_]*const ctypes.Component{&provider_ast};
+    const conflicts = try compose.detectVersionConflicts(ar, &consumer_ast, &provider_ptrs);
+    try testing.expectEqual(@as(usize, 1), conflicts.len);
+    const resolution = try resolveRules(ar, conflicts, .{ .target = "0.2.6" }, &.{});
+
+    // Apply --align-wasi rewrite.
+    const cb = try rewrite_extern_names.apply(ar, cb_orig, resolution.rules);
+    const pb = try rewrite_extern_names.apply(ar, pb_orig, resolution.rules);
+
+    // Compose.
+    var providers_buf = [_][]const u8{pb};
+    const composed = try composeBinaries(testing.allocator, cb, providers_buf[0..]);
+    defer testing.allocator.free(composed);
+
+    // Methods must survive the entire pipeline.
+    try testing.expect(std.mem.indexOf(u8, composed, "[method]pollable.ready") != null);
+    try testing.expect(std.mem.indexOf(u8, composed, "[method]pollable.block") != null);
+    // And no @0.2.10 residue.
+    try testing.expect(std.mem.indexOf(u8, composed, "@0.2.10") == null);
+}

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -3134,3 +3134,125 @@ test "pickBuiltinAdapter: malformed core falls back to command-shape adapter" {
     const picked = pickBuiltinAdapter(testing.allocator, &garbage);
     try testing.expectEqual(builtin_adapter.wasi_preview1_command_wasm.ptr, picked.ptr);
 }
+
+test "buildComponent #222: resource methods survive in wrapping component's imported instance body" {
+    // Reproducer for #222 — `wabt component new` was dropping
+    // `[method]X.Y` exports from imported interface bodies. The
+    // user-visible case: `wasi:io/poll@0.2.6`'s `pollable` resource
+    // came through with no methods at all (just the type-def and
+    // the iface-level `poll` function), making the wrapping
+    // component's import shape narrower than what the embed's
+    // component-type metadata declared.
+    //
+    // Synth core: handle export + memory + cabi_realloc (identical
+    // shape to #203a). The list<borrow<...>> param on `poll`
+    // forces the shim/fixup path, which is where the narrowing
+    // lives — `buildComponentShimFixup` Phase 4a copies
+    // `shape.inst_decls` verbatim through `rebaseInstDecls`, so
+    // the surfacing of all method exports here is the regression
+    // pin.
+    const core_only = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 14, 2,
+        0x60, 0x02, 0x7f, 0x7f, 0x00,
+        0x60, 0x04, 0x7f, 0x7f, 0x7f, 0x7f, 0x01, 0x7f,
+        0x03, 3, 2, 0, 1,
+        0x05, 3, 1, 0x00, 0x01,
+        0x07, 51, 3,
+        23, 'w', 'a', 's', 'i', ':', 'i', 'o', '/', 'p', 'o', 'l', 'l',
+        '@', '0', '.', '2', '.', '6', '#', 'p', 'o', 'l', 'l',
+        0x00, 0,
+        6, 'm', 'e', 'm', 'o', 'r', 'y',
+        0x02, 0,
+        12, 'c', 'a', 'b', 'i', '_', 'r', 'e', 'a', 'l', 'l', 'o', 'c',
+        0x00, 1,
+        0x0a, 9, 2,
+        2, 0x00, 0x0b,
+        4, 0x00, 0x41, 0x00, 0x0b,
+    };
+
+    const ct_payload = try metadata_encode.encodeWorldFromSource(testing.allocator,
+        \\package wasi:io@0.2.6;
+        \\
+        \\interface poll {
+        \\    resource pollable {
+        \\        ready: func() -> bool;
+        \\        block: func();
+        \\    }
+        \\    poll: func(in: list<borrow<pollable>>) -> list<u32>;
+        \\}
+        \\
+        \\interface streams {
+        \\    use poll.{pollable};
+        \\    resource input-stream {
+        \\        subscribe: func() -> pollable;
+        \\    }
+        \\}
+        \\
+        \\world demo {
+        \\    import poll;
+        \\    import streams;
+        \\    export poll;
+        \\}
+    , "demo");
+    defer testing.allocator.free(ct_payload);
+
+    var core_with_ct = std.ArrayListUnmanaged(u8).empty;
+    defer core_with_ct.deinit(testing.allocator);
+    try core_with_ct.appendSlice(testing.allocator, core_only[0..core_only.len]);
+    const cs_name = "component-type:demo";
+    var cs_body = std.ArrayListUnmanaged(u8).empty;
+    defer cs_body.deinit(testing.allocator);
+    try writeU32Leb(testing.allocator, &cs_body, @intCast(cs_name.len));
+    try cs_body.appendSlice(testing.allocator, cs_name);
+    try cs_body.appendSlice(testing.allocator, ct_payload);
+    try core_with_ct.append(testing.allocator, 0);
+    try writeU32Leb(testing.allocator, &core_with_ct, @intCast(cs_body.items.len));
+    try core_with_ct.appendSlice(testing.allocator, cs_body.items);
+
+    const comp_bytes = try buildComponent(testing.allocator, core_with_ct.items);
+    defer testing.allocator.free(comp_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const loaded = try loader.load(comp_bytes, arena.allocator());
+
+    // Exactly two imports — wasi:io/poll@0.2.6 + wasi:io/streams@0.2.6.
+    // The wasi:io/poll body must carry the full canonical set of
+    // decls (the `pollable` resource export + BOTH method exports
+    // + the iface-level `poll` export). The bug pre-#222 narrowed
+    // the wasi:io/poll body to just `pollable` + `poll`, dropping
+    // the methods — because `wasi:io/poll` is reachable via the
+    // `streams` body's `use poll.{pollable}` clause, the wrapping
+    // emit path uses a narrowed pruning view here.
+    try testing.expectEqual(@as(usize, 2), loaded.imports.len);
+    var poll_inst_type_idx: ?u32 = null;
+    for (loaded.imports) |im| {
+        if (std.mem.eql(u8, im.name, "wasi:io/poll@0.2.6")) {
+            poll_inst_type_idx = im.desc.instance;
+        }
+    }
+    try testing.expect(poll_inst_type_idx != null);
+    const contrib = loaded.type_indexspace[poll_inst_type_idx.?];
+    try testing.expect(contrib == .type_def);
+    const td = loaded.types[contrib.type_def];
+    try testing.expect(td == .instance);
+
+    var saw_pollable = false;
+    var saw_ready = false;
+    var saw_block = false;
+    var saw_poll = false;
+    for (td.instance.decls) |d| switch (d) {
+        .@"export" => |e| {
+            if (std.mem.eql(u8, e.name, "pollable") and e.desc == .type) saw_pollable = true;
+            if (std.mem.eql(u8, e.name, "[method]pollable.ready") and e.desc == .func) saw_ready = true;
+            if (std.mem.eql(u8, e.name, "[method]pollable.block") and e.desc == .func) saw_block = true;
+            if (std.mem.eql(u8, e.name, "poll") and e.desc == .func) saw_poll = true;
+        },
+        else => {},
+    };
+    try testing.expect(saw_pollable);
+    try testing.expect(saw_ready);
+    try testing.expect(saw_block);
+    try testing.expect(saw_poll);
+}


### PR DESCRIPTION
Fixes #222.

## Root cause

The adapter splicer derived its post-GC live-method set strictly from the adapter core wasm's imports. When the wasmtime upstream preview1 adapter imports only `[resource-drop]pollable` + bare `poll` from `wasi:io/poll@0.2.6` (and no `[method]pollable.*`), `world_gc.gcInstanceBody` dropped the resource method exports from the wrapping component's wasi:io/poll instance-type body — even when the user's embed component-type declared the canonical interface (`pollable.ready` + `pollable.block` + iface-level `poll`).

## Reproduction

```
wabt component embed -w cli wit/ codegen-cli.wasm -o cli.embed.wasm
wabt component new cli.embed.wasm \
    --adapt wasi_snapshot_preview1=wasmtime-v44-adapter.wasm \
    -o cli.comp.wasm
wasm-tools component wit cli.comp.wasm
```

Pre-fix: `pollable` resource has no methods; `poll` iface function present.
Post-fix: `pollable` resource has both `ready` + `block` methods.

Confirmed bit-identical match between fixed output and `wasm-tools component new` reference behaviour for `wasi:io/poll` body.

## Fix

New helper `augmentLiveMethodsByNamespaceWithEmbed` walks the embed's `component-type:<world>` custom section and, for every imported iface, seeds the live-method set with every `.@"export"` name the embed's body declares. This is then unioned with the adapter-derived live set before `gcWorld` runs.

Best-effort: if the embed has no component-type section, or decoding it fails, we fall back to the adapter-derived view.

Wired into both `splice` (single adapter) and `spliceN` (multi-adapter primary).

## Tests

All 536 tests pass (533 prior + 5 new pins + 2 unit tests on the new helper). The new tests pin:

* `augmentLiveMethodsByNamespaceWithEmbed`: embed-declared methods join the adapter-derived set; empty embed = no change.
* `buildComponent`: a wasi:io/poll-shaped imported iface body preserves `[method]pollable.ready` + `[method]pollable.block` + `poll`.
* Audit pins (these passed without the fix; included to lock down upstream behaviour from the bisect for #222): metadata_encode round-trip, rewrite_extern_names byte rewrite, component_compose bubble + `--align-wasi` paths.