### PR TITLE
component: emit valid components for worlds importing wasi:http/outgoing-handler (#234)

### DIFF
--- a/src/component/adapter/abi.zig
+++ b/src/component/adapter/abi.zig
@@ -112,7 +112,102 @@ pub const TypeResolver = struct {
     pub fn resolveWorld(self: TypeResolver, idx: u32) ?ctypes.TypeDef {
         return resolveTypeIdxIn(self.world_decls, idx, &.{});
     }
+
+    /// Like `resolveLocal`, but also reports the decls scope in which
+    /// the resolved `TypeDef`'s own child `type_idx` references live.
+    /// When a `type_idx` resolves across an interface boundary (via an
+    /// `alias instance-export` into another imported interface's
+    /// body), the resolved type's children are numbered in *that*
+    /// interface's type-index space — so flattening them requires
+    /// rebasing the resolver onto the returned scope. Failing to
+    /// rebase silently drops nested `string`/`list` content and the
+    /// canon-lower opts (`realloc`/`string-encoding`) that go with it
+    /// (#234).
+    pub fn resolveLocalScoped(self: TypeResolver, idx: u32) ?ResolvedType {
+        return resolveTypeIdxInScoped(self.inst_decls, idx, self.world_decls);
+    }
 };
+
+/// A resolved `TypeDef` together with the decls scope its child
+/// `type_idx` references must be interpreted in.
+pub const ResolvedType = struct {
+    td: ctypes.TypeDef,
+    inst_decls: []const ctypes.Decl,
+};
+
+fn resolveTypeIdxInScoped(
+    decls: []const ctypes.Decl,
+    target: u32,
+    outer_decls: []const ctypes.Decl,
+) ?ResolvedType {
+    var cursor: u32 = 0;
+    for (decls) |d| {
+        switch (d) {
+            .type => |td| {
+                if (cursor == target) return .{ .td = td, .inst_decls = decls };
+                cursor += 1;
+            },
+            .core_type => cursor += 1,
+            .alias => |a| {
+                const sort: ctypes.Sort = switch (a) {
+                    .instance_export => |ie| ie.sort,
+                    .outer => |o| o.sort,
+                };
+                if (sort == .type) {
+                    if (cursor == target) return resolveAliasScoped(a, outer_decls);
+                    cursor += 1;
+                }
+            },
+            .@"export" => |e| switch (e.desc) {
+                .type => |bound| {
+                    if (cursor == target) return resolveTypeBoundScoped(bound, decls, outer_decls);
+                    cursor += 1;
+                },
+                else => {},
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn resolveAliasScoped(a: ctypes.Alias, outer_decls: []const ctypes.Decl) ?ResolvedType {
+    return switch (a) {
+        .outer => |o| if (o.sort == .type)
+            resolveTypeIdxInScoped(outer_decls, o.idx, outer_decls)
+        else
+            null,
+        .instance_export => |ie| resolveInstanceTypeExportScoped(outer_decls, ie.instance_idx, ie.name),
+    };
+}
+
+fn resolveInstanceTypeExportScoped(
+    world_decls: []const ctypes.Decl,
+    instance_idx: u32,
+    name: []const u8,
+) ?ResolvedType {
+    const inst_decls = findInstanceBodyAtIdx(world_decls, instance_idx) orelse return null;
+    for (inst_decls) |d| switch (d) {
+        .@"export" => |e| {
+            if (e.desc != .type) continue;
+            if (!std.mem.eql(u8, e.name, name)) continue;
+            return resolveTypeBoundScoped(e.desc.type, inst_decls, world_decls);
+        },
+        else => {},
+    };
+    return null;
+}
+
+fn resolveTypeBoundScoped(
+    bound: ctypes.TypeBound,
+    decls: []const ctypes.Decl,
+    outer_decls: []const ctypes.Decl,
+) ?ResolvedType {
+    return switch (bound) {
+        .eq => |idx| resolveTypeIdxInScoped(decls, idx, outer_decls),
+        .sub_resource => ResolvedType{ .td = .{ .resource = .{} }, .inst_decls = decls },
+    };
+}
 
 /// Walk `decls` (instance or world body) and return the `TypeDef` at
 /// type-indexspace position `target`, following outer aliases into
@@ -309,10 +404,7 @@ fn flattenInner(vt: ctypes.ValType, resolver: TypeResolver, depth: u32) FlatInfo
             // list always flattens to (ptr, len) regardless of
             // element. Element walk only needed to propagate
             // contains_string.
-            const elem_info = if (resolver.resolveLocal(idx)) |td|
-                flattenTypeDef(td, resolver, depth + 1)
-            else
-                FlatInfo{ .flat = 1 };
+            const elem_info = resolveAndFlatten(idx, resolver, depth, FlatInfo{ .flat = 1 });
             break :blk .{
                 .flat = 2,
                 .needs_memory = true,
@@ -320,38 +412,29 @@ fn flattenInner(vt: ctypes.ValType, resolver: TypeResolver, depth: u32) FlatInfo
                 .contains_string = elem_info.contains_string,
             };
         },
-        .type_idx => |idx| if (resolver.resolveLocal(idx)) |td|
-            flattenTypeDef(td, resolver, depth + 1)
-        else
-            // Likely an outer alias to a resource — treat as i32 handle.
-            .{ .flat = 1 },
-        .record => |idx| if (resolver.resolveLocal(idx)) |td|
-            flattenTypeDef(td, resolver, depth + 1)
-        else
-            .{ .flat = 1 },
-        .variant => |idx| if (resolver.resolveLocal(idx)) |td|
-            flattenTypeDef(td, resolver, depth + 1)
-        else
-            .{ .flat = 2 },
-        .tuple => |idx| if (resolver.resolveLocal(idx)) |td|
-            flattenTypeDef(td, resolver, depth + 1)
-        else
-            .{ .flat = 1 },
-        .flags => |idx| if (resolver.resolveLocal(idx)) |td|
-            flattenTypeDef(td, resolver, depth + 1)
-        else
-            .{ .flat = 1 },
+        // Likely an outer alias to a resource — treat as i32 handle.
+        .type_idx => |idx| resolveAndFlatten(idx, resolver, depth, FlatInfo{ .flat = 1 }),
+        .record => |idx| resolveAndFlatten(idx, resolver, depth, FlatInfo{ .flat = 1 }),
+        .variant => |idx| resolveAndFlatten(idx, resolver, depth, FlatInfo{ .flat = 2 }),
+        .tuple => |idx| resolveAndFlatten(idx, resolver, depth, FlatInfo{ .flat = 1 }),
+        .flags => |idx| resolveAndFlatten(idx, resolver, depth, FlatInfo{ .flat = 1 }),
         .enum_ => .{ .flat = 1 },
-        .option => |idx| if (resolver.resolveLocal(idx)) |td|
-            flattenTypeDef(td, resolver, depth + 1)
-        else
-            .{ .flat = 2 },
-        .result => |idx| if (resolver.resolveLocal(idx)) |td|
-            flattenTypeDef(td, resolver, depth + 1)
-        else
-            .{ .flat = 2 },
+        .option => |idx| resolveAndFlatten(idx, resolver, depth, FlatInfo{ .flat = 2 }),
+        .result => |idx| resolveAndFlatten(idx, resolver, depth, FlatInfo{ .flat = 2 }),
     };
 }
+
+/// Resolve `idx` in `resolver`'s scope and flatten the resulting
+/// `TypeDef`, rebasing the resolver onto the scope the resolved type
+/// lives in (so cross-interface `type_idx` children resolve correctly,
+/// #234). Falls back to `unresolved` when `idx` can't be resolved
+/// (e.g. a bare outer alias to a resource → scalar handle).
+fn resolveAndFlatten(idx: u32, resolver: TypeResolver, depth: u32, unresolved: FlatInfo) FlatInfo {
+    const r = resolver.resolveLocalScoped(idx) orelse return unresolved;
+    const sub = TypeResolver{ .inst_decls = r.inst_decls, .world_decls = resolver.world_decls };
+    return flattenTypeDef(r.td, sub, depth + 1);
+}
+
 
 fn flattenTypeDef(td: ctypes.TypeDef, resolver: TypeResolver, depth: u32) FlatInfo {
     return switch (td) {
@@ -614,8 +697,9 @@ fn flattenSlots(
         .option,
         .result,
         => |idx| {
-            if (resolver.resolveLocal(idx)) |td| {
-                try flattenTypeDefSlots(arena, td, resolver, depth + 1, out);
+            if (resolver.resolveLocalScoped(idx)) |r| {
+                const sub = TypeResolver{ .inst_decls = r.inst_decls, .world_decls = resolver.world_decls };
+                try flattenTypeDefSlots(arena, r.td, sub, depth + 1, out);
             } else {
                 // Unresolvable (likely outer-aliased resource handle).
                 // Default depends on the leaf shape.
@@ -929,6 +1013,79 @@ test "classifyFunc: () -> own<resource> is direct (handle is i32)" {
     try testing.expectEqual(Class.direct, cls.class);
     try testing.expect(!cls.opts.memory);
     try testing.expectEqual(@as(u32, 1), cls.results_flat);
+}
+
+test "classifyFunc #234: cross-iface result whose nested string lives in another iface's scope needs realloc" {
+    // Regression for cataggar/wabt#234. Interface B's `make` returns a
+    // variant `err` that B pulls in via `use A.{err};`. `err`'s only
+    // string content is NESTED inside an `option<string>` case payload
+    // whose `type_idx` is numbered in A's local type space. Classifying
+    // `make` must rebase the resolver onto A's scope when it crosses the
+    // `use` boundary — otherwise the nested string is missed and the
+    // canon-lower `realloc` opt is dropped (the `canonical option
+    // realloc is required` validation failure).
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Interface A body:
+    //   slot 0: .type option<string>
+    //   slot 1: .type variant { "boom"(type_idx 0) }
+    //   slot 2: .export "err" (type (eq 1))
+    const a_decls = try a.alloc(ctypes.Decl, 3);
+    a_decls[0] = .{ .type = .{ .option = .{ .inner = .string } } };
+    const cases = try a.alloc(ctypes.Case, 1);
+    cases[0] = .{ .name = "boom", .type = .{ .type_idx = 0 } };
+    a_decls[1] = .{ .type = .{ .variant = .{ .cases = cases } } };
+    a_decls[2] = .{ .@"export" = .{ .name = "err", .desc = .{ .type = .{ .eq = 1 } } } };
+
+    // Interface B body:
+    //   slot 0: .alias outer (type 1 <world-slot 1>)   ← `use A.{err}`
+    //   slot 1: .export "err" (type (eq 0))
+    //   slot 2: .type func () -> type_idx 1
+    //   .export "make" (func 2)
+    const b_decls = try a.alloc(ctypes.Decl, 4);
+    b_decls[0] = .{ .alias = .{ .outer = .{ .sort = .type, .outer_count = 1, .idx = 1 } } };
+    b_decls[1] = .{ .@"export" = .{ .name = "err", .desc = .{ .type = .{ .eq = 0 } } } };
+    b_decls[2] = .{ .type = .{ .func = .{
+        .params = &.{},
+        .results = .{ .unnamed = .{ .type_idx = 1 } },
+    } } };
+    b_decls[3] = .{ .@"export" = .{ .name = "make", .desc = .{ .func = 2 } } };
+
+    const a_inst = try a.create(ctypes.TypeDef);
+    a_inst.* = .{ .instance = .{ .decls = a_decls } };
+    const b_inst = try a.create(ctypes.TypeDef);
+    b_inst.* = .{ .instance = .{ .decls = b_decls } };
+
+    // World body:
+    //   decls[0]: .type instance A        (world type slot 0)
+    //   decls[1]: .import "mock:a/a" (instance 0)
+    //   decls[2]: .alias inst-export type inst=0 "err"  (world type slot 1)
+    //   decls[3]: .type instance B        (world type slot 2)
+    //   decls[4]: .import "mock:b/b" (instance 1)
+    const decls = try a.alloc(ctypes.Decl, 5);
+    decls[0] = .{ .type = a_inst.* };
+    decls[1] = .{ .import = .{ .name = "mock:a/a@0.1.0", .desc = .{ .instance = 0 } } };
+    decls[2] = .{ .alias = .{ .instance_export = .{ .sort = .type, .instance_idx = 0, .name = "err" } } };
+    decls[3] = .{ .type = b_inst.* };
+    decls[4] = .{ .import = .{ .name = "mock:b/b@0.1.0", .desc = .{ .instance = 2 } } };
+
+    const w = decode.AdapterWorld{
+        .component = undefined,
+        .body_decls = decls,
+        .body_type_count = 3,
+        .imports = &.{},
+        .exports = &.{},
+        .world_qualified_name = "mock:abi/abi-mock@0.1.0",
+    };
+
+    // B's instance type is at world type slot 2.
+    const ftr = try findFuncImport(w, 2, "make");
+    const cls = classifyFunc(ftr);
+    try testing.expect(cls.opts.memory);
+    try testing.expect(cls.opts.realloc);
+    try testing.expect(cls.opts.string_encoding);
 }
 
 test "lowerCoreSig: option<u32> result becomes ret-ptr (i32) -> ()" {

--- a/src/component/adapter/adapter.zig
+++ b/src/component/adapter/adapter.zig
@@ -2101,14 +2101,30 @@ fn buildEmbedExtraImports(
         //     wasm sigs.
         var inst_decls = std.ArrayListUnmanaged(ctypes.Decl).empty;
         const canonical_inst_decls = lookupEmbedExtraInstDecls(in.embed_metadata, ns);
-        const used_canonical = canonical_inst_decls != null and
-            isInstBodyAliasFree(canonical_inst_decls.?);
+        // Prune the canonical body down to just the funcs the embed
+        // actually imports from this namespace. A body whose *full*
+        // form carries cross-iface `use` aliases (e.g. wasi:http/types
+        // pulling `duration` from wasi:clocks) reduces to an
+        // alias-free, self-contained body once only the imported funcs
+        // (and their transitive local type-deps — resources, `own`
+        // wrappers, records, …) are retained. Without this, such
+        // namespaces fall to the per-func synthesis path below, which
+        // drops the `Type(Defined(...))` decls the func results
+        // reference and emits dangling local `type_idx` operands
+        // (the `unknown type N` failure in cataggar/wabt#234).
+        const pruned_inst_decls: ?[]const ctypes.Decl = if (canonical_inst_decls) |decls| blk: {
+            const method_names = try a.alloc([]const u8, funcs.items.len);
+            for (funcs.items, 0..) |f, fi| method_names[fi] = f.name;
+            break :blk world_gc.gcInstanceBody(a, decls, method_names, &.{}) catch null;
+        } else null;
+        const canonical_body = pruned_inst_decls orelse canonical_inst_decls;
+        const used_canonical = canonical_body != null and
+            isInstBodyAliasFree(canonical_body.?);
         if (used_canonical) {
-            // Identity remap: the new body keeps the same local
-            // type-slot layout as the original, so each `type_idx`
-            // operand resolves to the same Defined the embed
-            // declared.
-            const decls = canonical_inst_decls.?;
+            // Identity remap: `gcInstanceBody` already renumbered the
+            // pruned body's local type-slot layout consistently, so
+            // each `type_idx` operand still resolves to its Defined.
+            const decls = canonical_body.?;
             const slot_count = countInstBodyTypeSlots(decls);
             const identity_remap = try a.alloc(u32, @max(slot_count, 1));
             for (identity_remap, 0..) |*x, i| x.* = @intCast(i);

--- a/src/component/adapter/world_gc.zig
+++ b/src/component/adapter/world_gc.zig
@@ -519,7 +519,7 @@ const InstBodyMeta = struct {
 
 /// GC the body of a single instance type. Mirrors `gcWorld` but at
 /// depth 1 with a local type indexspace.
-fn gcInstanceBody(
+pub fn gcInstanceBody(
     arena: Allocator,
     decls: []const ctypes.Decl,
     live_methods: []const []const u8,

--- a/src/component/wit/metadata_encode.zig
+++ b/src/component/wit/metadata_encode.zig
@@ -178,7 +178,13 @@ pub fn encodeWorldFromResolver(
                 const is_export = item == .@"export";
                 const ext = we;
                 const iface_name = qualifiedName(ar, ext, pkg_id) catch return error.InvalidWit;
-                const iface_decls = try buildInterfaceBody(ar, resolver, ext, world_alias_map);
+                // Type aliases this interface defines that another
+                // interface pulls in via `use <this>.{T};` must be
+                // surfaced as exports of this interface's instance type
+                // (see `buildInterfaceBody`'s `.alias` arm / #234).
+                const requested_exports: ?[]const []const u8 =
+                    if (alias_requests.get(iface_name)) |l| l.items else null;
+                const iface_decls = try buildInterfaceBody(ar, resolver, ext, world_alias_map, requested_exports);
                 const iface_type_idx = world_type_idx;
                 try world_decls.append(ar, .{ .type = .{
                     .instance = .{ .decls = iface_decls },
@@ -320,6 +326,17 @@ fn collectUseRequests(
             if (!already) try gop.value_ptr.append(ar, n.name);
         }
     }
+}
+
+/// Whether `name` is one of the type names another interface pulls in
+/// via `use <this-iface>.{name};` — i.e. a name that must be exported
+/// from this interface's instance type rather than inlined (#234).
+fn typeNameRequested(requested: ?[]const []const u8, name: []const u8) bool {
+    const list = requested orelse return false;
+    for (list) |n| {
+        if (std.mem.eql(u8, n, name)) return true;
+    }
+    return false;
 }
 
 /// Convenience: parse `source` and encode the named world.
@@ -667,6 +684,7 @@ fn buildInterfaceBody(
     resolver: wit_resolver.Resolver,
     ext: ast.WorldExtern,
     world_alias_map: std.StringHashMapUnmanaged(u32),
+    requested_exports: ?[]const []const u8,
 ) EncodeError![]const ctypes.Decl {
     const ref = switch (ext) {
         .interface_ref => |ir| ir.ref,
@@ -712,7 +730,27 @@ fn buildInterfaceBody(
             .type => |td| switch (td.kind) {
                 .alias => |inner| {
                     const vt = try builder.lowerType(inner);
-                    try builder.bindName(td.name, vt);
+                    if (typeNameRequested(requested_exports, td.name)) {
+                        // A `type <name> = <T>;` alias that another
+                        // interface pulls in via `use <this>.{<name>};`.
+                        // The world body emits an `alias export …
+                        // "<name>"` against this interface's instance,
+                        // so the name MUST be exported here — otherwise
+                        // the reference dangles and the component fails
+                        // to validate (#234). Inlining (the `else`
+                        // branch) is only safe when no other interface
+                        // references the alias by name. Primitive RHS
+                        // valtypes don't occupy a slot yet, so
+                        // materialize one via a `.val` typedef before
+                        // exporting it.
+                        const body_slot = switch (vt) {
+                            .type_idx => |k| k,
+                            else => (try builder.appendCompound(.{ .val = vt })).type_idx,
+                        };
+                        try builder.exportNamedType(td.name, body_slot);
+                    } else {
+                        try builder.bindName(td.name, vt);
+                    }
                 },
                 .record => |fields| {
                     const lowered = try ar.alloc(ctypes.Field, fields.len);
@@ -2039,6 +2077,50 @@ test "metadata_encode: use clause from qualified versioned source ref" {
     // the alias-instance-export decl between `streams` and `stdout`.
     try testing.expectEqual(@as(usize, 5), world_body.decls.len);
     try testing.expectEqualStrings("output-stream", world_body.decls[2].alias.instance_export.name);
+}
+
+test "metadata_encode #234: cross-iface use of a type alias exports it from the source iface" {
+    // Regression for cataggar/wabt#234. When interface `timer` does
+    // `use clock.{duration}` where `clock` defines `type duration =
+    // u64`, the world body emits an `alias instance-export ...
+    // "duration"` against `clock`'s instance. That alias dangles
+    // unless `clock`'s instance type actually EXPORTS a type named
+    // `duration` — pre-fix the encoder inlined the alias to `u64` and
+    // emitted no export, producing `instance N has no export named
+    // 'duration'` at validation time.
+    const source =
+        \\package wabt:demo@0.0.0;
+        \\interface clock {
+        \\    type duration = u64;
+        \\    now: func() -> duration;
+        \\}
+        \\interface timer {
+        \\    use wabt:demo/clock@0.0.0.{duration};
+        \\    set: func(d: duration);
+        \\}
+        \\world w { import clock; import timer; }
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "w");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const world_body = comp.types[0].component.decls[0].type.component;
+    // decls[0] is the `clock` instance type; it must export `duration`
+    // as a named type so the cross-iface alias resolves.
+    const clock_inst = world_body.decls[0].type.instance;
+    var exports_duration = false;
+    for (clock_inst.decls) |d| {
+        if (d == .@"export" and d.@"export".desc == .type and
+            std.mem.eql(u8, d.@"export".name, "duration"))
+        {
+            exports_duration = true;
+        }
+    }
+    try testing.expect(exports_duration);
 }
 
 // ── #182: auto-wrap bare resource refs with own<> ─────────────────────────

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -500,7 +500,7 @@ pub fn buildComponent(alloc: std.mem.Allocator, core_bytes: []const u8) ![]u8 {
     for (import_shapes.items) |shape| {
         const resolver = wabt.component.adapter.abi.TypeResolver{
             .inst_decls = shape.inst_decls,
-            .world_decls = &.{},
+            .world_decls = decoded.world_decls,
         };
         for (shape.funcs) |fn_ref| {
             const ftr = wabt.component.adapter.abi.FuncTypeRef{
@@ -1059,13 +1059,13 @@ fn buildComponentShimFixup(
     //    core signature. A func is "wired" (gets a canon.lower +
     //    shim slot) iff its body lift would be valid — i.e. its sig
     //    doesn't reach types that the instance-type body's alias
-    //    decls bind. For #203 minimum scope we just call
-    //    classifyFunc with an empty world_decls; the resolver
-    //    falls back to scalar-handle for any unresolvable type idx,
-    //    which is the correct ABI shape for resource handles but
-    //    silently wrong for outer-aliased compound types. The
-    //    follow-up that wires cross-iface refs into the body also
-    //    flips this to a hard skip.
+    //    decls bind. The resolver is seeded with the decoded world
+    //    decls so outer-aliased compound types (e.g. a cross-iface
+    //    `use`d `error-code` variant) resolve to their real
+    //    definition; otherwise they'd fall back to scalar-handle and
+    //    silently drop required canon-lower opts like `realloc`
+    //    (#234). Genuinely unresolvable idxs still fall back to the
+    //    scalar-handle shape, which is correct for resource handles.
     const WiredFunc = struct {
         fn_ref: metadata_decode.FuncRef,
         opts: abi.FuncOpts,
@@ -1078,7 +1078,7 @@ fn buildComponentShimFixup(
         var list = std.ArrayListUnmanaged(WiredFunc).empty;
         const resolver = abi.TypeResolver{
             .inst_decls = shape.inst_decls,
-            .world_decls = &.{},
+            .world_decls = decoded.world_decls,
         };
         for (shape.funcs) |fn_ref| {
             const ftr = abi.FuncTypeRef{ .func = fn_ref.sig, .resolver = resolver };
@@ -1339,6 +1339,14 @@ fn buildComponentShimFixup(
     try core_instances.append(ar, .{ .instantiate = .{ .module_idx = 1, .args = &.{} } });
     const shim_inst_idx: u32 = @intCast(core_instances.items.len - 1);
 
+    // Emit the shim instance as its own core-instance section now, so
+    // the stub aliases that follow (which reference it) validate
+    // against an already-defined core instance. The writer emits
+    // sections strictly in `order` sequence, so a single core-instance
+    // section at the end would place every instance *after* the alias
+    // sections that name them — invalid (#234).
+    try order.append(ar, .{ .kind = .core_instance, .start = shim_inst_idx, .count = 1 });
+
     // Step 2: alias the shim's N stubs by name ("0","1",…) as core
     // funcs. These become the source funcs for the per-shape
     // bundles that satisfy main's `(with …)` args.
@@ -1389,6 +1397,15 @@ fn buildComponentShimFixup(
         .args = try bundle_for_main_args.toOwnedSlice(ar),
     } });
     const main_core_inst_idx: u32 = @intCast(core_instances.items.len - 1);
+
+    // Flush the per-shape bundles + main instance as a core-instance
+    // section before the memory/realloc aliases (Phase 4d) and the
+    // `$imports` table alias (Phase 4e) that reference them (#234).
+    try order.append(ar, .{
+        .kind = .core_instance,
+        .start = shim_inst_idx + 1,
+        .count = main_core_inst_idx - shim_inst_idx,
+    });
 
     // ── Phase 4d: alias `memory` + `cabi_realloc` from main —
     //    these are the canon.lower opts targets.
@@ -1475,10 +1492,14 @@ fn buildComponentShimFixup(
         } });
     }
 
+    // Final core-instance section: the fixup-args bundle + fixup
+    // instance (Phase 4g). It follows the canon.lower section (Phase
+    // 4f) because the fixup args reference the lowered core funcs, and
+    // follows the `$imports` alias (Phase 4e) (#234).
     try order.append(ar, .{
         .kind = .core_instance,
-        .start = 0,
-        .count = @intCast(core_instances.items.len),
+        .start = main_core_inst_idx + 1,
+        .count = @as(u32, @intCast(core_instances.items.len)) - (main_core_inst_idx + 1),
     });
 
     // ── Phase 5: export-side. Mirrors the #202 fast path: walk


### PR DESCRIPTION
Fixes #234.

`wabt component embed` + `wabt component new` produced an **invalid component** for a world importing `wasi:http/outgoing-handler@0.2.6` (and its transitive `wasi:http/types` / `wasi:clocks` / `wasi:io` deps), while `wasm-tools` produced a valid one from the same core + WIT.

Reproduced both the **trimmed-WIT (no adapter)** path and the **adapter-attached command** path (the issue's actual scenario, `wasmtime run -S http`). Each fix below masked the next; all five are required for a valid component.

## Root causes & fixes

1. **`metadata_encode.zig`** — a `type` alias `use`d across interfaces (e.g. `wasi:clocks/monotonic-clock`'s `type duration = u64`) was inlined and never exported from its defining interface's instance type, so the world-level `alias instance-export "duration"` dangled → `instance N has no export named 'duration'`. Now exported when cross-iface `use`d.

2. **`component_new.zig` (shim/fixup ordering)** — every core instance was emitted in a single section appended **last**, placing instances *after* the alias sections that reference them → `unknown core instance 0`. Split into three correctly-ordered core-instance sections (shim; bundles+main; fixup).

3. **`component_new.zig` (classifier resolver)** — the canon-lower classifier resolver was seeded with empty world decls, so cross-iface compound types fell back to scalar handles. Seed it with `decoded.world_decls`.

4. **`abi.zig` (scope rebasing)** — `flatten`/`flattenSlots` didn't rebase the resolver scope when a `type_idx` crossed an interface boundary, missing `string`/`list` nested inside another interface's types (e.g. `error-code`'s `option<string>` payloads) and dropping the `realloc` opt → `canonical option realloc is required`. Added `resolveLocalScoped` and rebase recursion.

5. **`adapter.zig` + `world_gc.zig` (embed-extra import body)** — embed-extra imports whose *full* body carries cross-iface `use` aliases (wasi:http/types) fell to a per-func synthesis path that dropped the `Type(Defined(...))` decls the func results reference → the issue's exact `unknown type 66`. Now prunes the canonical body to the imported func subset first (via `world_gc.gcInstanceBody`, made public), so it becomes alias-free and clones with its resource/`own`/Defined type-defs intact.

## Verification
- `wasm-tools validate` passes for both pipelines; `wasmtime run -S http` runs the adapter-attached command.
- `zig build test` is green (no regressions; existing #203a/#195p5/#222 shim/fixup tests still pass).
- Adds 2 regression tests: cross-iface type-alias export (`metadata_encode`) and cross-iface nested-string realloc classification (`abi`).