### PR TITLE
Normalize line endings to LF; preserve bad-crlf fixture

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,6 @@
 *.tsv text
 *.wasm binary
 *.wast binary
+
+# Parser test fixture with intentional mixed CR/LF line endings; keep bytes exact.
+test/parse/bad-crlf.txt -text

--- a/src/text/Parser.zig
+++ b/src/text/Parser.zig
@@ -951,7 +951,7 @@ const Parser = struct {
         meta.type_refs = self.collected_type_refs.toOwnedSlice(self.allocator) catch &.{};
         try module.type_meta.append(self.allocator, meta);
     }
-
+
     /// Scan a GC composite type body for type reference validation and duplicate field names.
     /// Consumes tokens up to (but not including) the closing ')' of the type form.
     fn scanGcTypeRefs(self: *Parser) void {


### PR DESCRIPTION
## What

- Add `test/parse/bad-crlf.txt -text` to `.gitattributes` so the parser fixture's **intentional mixed CR/LF** bytes (`modulez\r\n`, `funcz\r\n`) are preserved exactly.
- Renormalize `src/text/Parser.zig` from CRLF to LF (it was committed with CRLF, conflicting with `*.zig text`). Also stripped one stray lone CR on a blank line.

## Why

`Parser.zig` showed as permanently modified because its committed CRLF clashed with `.gitattributes` (`*.zig text` ⇒ LF). `bad-crlf.txt` is the only file with legitimate CR bytes and must not be normalized.

## Verification

- Content diff for `Parser.zig` is empty under `--ignore-all-space` (EOL-only change).
- `bad-crlf.txt` is byte-identical to before (`cmp` clean).
- `zig build` passes.