### PR TITLE
reader: accept data-count section between elements and code

### DIFF
--- a/src/binary/reader.zig
+++ b/src/binary/reader.zig
@@ -242,10 +242,15 @@ const Reader = struct {
             // Validate section ordering and duplicates (custom sections exempt)
             if (id_byte != 0) {
                 if (id_byte > 13) return error.InvalidSection;
-                // Check ordering: each non-custom section must have a higher ID
-                // than the previous non-custom section (except data_count=12 before code=10)
-                const order_id: u8 = if (id_byte == 12) 9 else id_byte; // data_count sorts before code
-                const last_order: u8 = if (last_non_custom_id == 12) 9 else last_non_custom_id;
+                // Check ordering: non-custom sections appear in increasing ID
+                // order, with one exception — the data-count section (id 12)
+                // sits between the element (id 9) and code (id 10) sections
+                // (WebAssembly spec, "Module" binary grammar). Scale every ID
+                // by 2 so data-count can occupy the half-step 9.5 (→ 19)
+                // without colliding with the element section (9 → 18); a plain
+                // remap to 9 makes `element, data_count` look like a duplicate.
+                const order_id: u8 = if (id_byte == 12) 19 else id_byte *| 2;
+                const last_order: u8 = if (last_non_custom_id == 12) 19 else last_non_custom_id *| 2;
                 if (order_id <= last_order and last_non_custom_id != 0) return error.InvalidSection;
                 // Check for duplicate sections
                 const mask: u16 = @as(u16, 1) << @intCast(id_byte);
@@ -747,4 +752,38 @@ test "read start section" {
     defer module.deinit();
     try std.testing.expect(module.start_var != null);
     try std.testing.expectEqual(@as(types.Index, 0), module.start_var.?.index);
+}
+
+test "accept element then data_count then code then data ordering" {
+    // The data-count section (id 12) is encoded between the element
+    // section (id 9) and the code section (id 10). A naive ordering
+    // check that remaps data_count's order to 9 sees `element(9),
+    // data_count(→9)` as non-increasing and rejects this valid module
+    // with InvalidSection. Regression for that false positive — this
+    // is exactly the section layout Zig's wasm32 backend emits for a
+    // module with a function table + passive/active data segments.
+    const bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: one type () -> ()
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        // function section: one func of type 0
+        0x03, 0x02, 0x01, 0x00,
+        // table section: one funcref table, min 1
+        0x04, 0x04, 0x01, 0x70, 0x00, 0x01,
+        // memory section: one memory, min 1
+        0x05, 0x03, 0x01, 0x00, 0x01,
+        // element section (id 9): one active elem, table 0, offset 0, func 0
+        0x09, 0x07, 0x01, 0x00, 0x41, 0x00, 0x0b, 0x01, 0x00,
+        // data count section (id 12): 1 data segment
+        0x0c, 0x01, 0x01,
+        // code section (id 10): one body, empty (just `end`)
+        0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b,
+        // data section (id 11): one active segment "hi"
+        0x0b, 0x08, 0x01, 0x00, 0x41, 0x00, 0x0b, 0x02, 'h', 'i',
+    };
+    var module = try readModule(std.testing.allocator, &bytes);
+    defer module.deinit();
+    try std.testing.expectEqual(@as(usize, 1), module.data_segments.items.len);
+    try std.testing.expect(module.has_data_count);
+    try std.testing.expectEqual(@as(u32, 1), module.data_count);
 }


### PR DESCRIPTION
## Problem

The binary reader's section-ordering check ([`src/binary/reader.zig`](https://github.com/cataggar/wabt/blob/main/src/binary/reader.zig)) remapped the **data-count** section's id (`12`) to order `9` so it sorts before the **code** section (`10`). But the **element** section is *also* id `9`, so a module encoding `element(9), data_count(12)` was seen as `9, 9` — non-increasing — and rejected with `InvalidSection`, even though that order is **valid per the WebAssembly spec** (the "Module" binary grammar places the data-count section between the element and code sections).

This is exactly the section layout **Zig's wasm32 backend** emits for a module with a function table (indirect calls) plus data segments. The downstream impact:

- `wabt component new` on such a core: `core_imports.extract` failed with `InvalidSection`.
- `coreImportsModule` therefore returned `false`, so the built-in wasi-preview1 → preview2 adapter was **never auto-attached**.
- The resulting component had an unsatisfied `wasi_snapshot_preview1` import, and wasmtime rejected it with:
  ```
  missing module instantiation argument named `wasi_snapshot_preview1`
  ```

It surfaced now (not before) because the affected core newly contains an element section immediately preceding data-count (function-table indirect calls).

## Fix

Scale every section id by 2 for the ordering comparison, letting data-count occupy the half-step between element and code without colliding:

```zig
const order_id: u8 = if (id_byte == 12) 19 else id_byte *| 2; // element 9→18, data_count→19, code 10→20
```

Adds a regression test that parses a module with the exact `element → data_count → code → data` layout.

## Testing

- `zig build test`: **550/550 tests pass** (549 + the new regression test).
- Verified end-to-end: the [`azure-sdk-for-zig` `avs-wasi` example](https://github.com/cataggar/azure-sdk-for-zig/tree/examples/arm_avs_wasi) (whose Zig core now has this section layout) again builds via `wabt component embed` + `wabt component new` with the auto-attached adapter, validates under `wasm-tools`, and runs on `wasmtime -S http` (lists Azure AVS private clouds over `wasi:http`).
