### PR TITLE
component new: embed WIT on the fly + .core.wasm output naming

### DIFF
--- a/src/component/wit/embed.zig
+++ b/src/component/wit/embed.zig
@@ -1,0 +1,157 @@
+//! Shared helpers for embedding a `component-type:<world>` custom
+//! section into a core wasm. Used by both `wabt component embed` and
+//! `wabt component new` (the latter embeds on the fly when given a WIT
+//! path, collapsing the embed+new pipeline into a single call).
+
+const std = @import("std");
+const ast = @import("ast.zig");
+
+/// Collect the names of every `world` item declared in a document, in
+/// declaration order. Caller owns the returned slice.
+pub fn worldNames(alloc: std.mem.Allocator, doc: ast.Document) ![]const []const u8 {
+    var names = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer names.deinit(alloc);
+    for (doc.items) |it| {
+        if (it == .world) try names.append(alloc, it.world.name);
+    }
+    return names.toOwnedSlice(alloc);
+}
+
+/// If exactly one world is defined in the document, return its name;
+/// otherwise (zero or many) return null.
+pub fn autoselectWorld(doc: ast.Document) ?[]const u8 {
+    var found: ?[]const u8 = null;
+    for (doc.items) |it| {
+        if (it == .world) {
+            if (found != null) return null;
+            found = it.world.name;
+        }
+    }
+    return found;
+}
+
+/// Append a custom section with `name` and `payload` to a core wasm
+/// binary. Existing custom sections with the same name are dropped so
+/// re-embedding is idempotent. Caller owns the returned slice.
+pub fn embedCustomSection(
+    alloc: std.mem.Allocator,
+    core_bytes: []const u8,
+    name: []const u8,
+    payload: []const u8,
+) ![]u8 {
+    if (core_bytes.len < 8) return error.InvalidCoreModule;
+    if (!std.mem.eql(u8, core_bytes[0..4], "\x00asm")) return error.InvalidCoreModule;
+
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(alloc);
+
+    // Copy preamble.
+    try out.appendSlice(alloc, core_bytes[0..8]);
+
+    var i: usize = 8;
+    while (i < core_bytes.len) {
+        if (i >= core_bytes.len) break;
+        const id = core_bytes[i];
+        i += 1;
+        const size_res = readU32Leb(core_bytes, i) catch return error.InvalidCoreModule;
+        const sec_size = size_res.value;
+        i += size_res.bytes_read;
+        if (i + sec_size > core_bytes.len) return error.InvalidCoreModule;
+        const body = core_bytes[i .. i + sec_size];
+        i += sec_size;
+
+        if (id == 0) {
+            // Custom section: read its name and skip if it matches.
+            const n_res = readU32Leb(body, 0) catch return error.InvalidCoreModule;
+            const name_len = n_res.value;
+            if (n_res.bytes_read + name_len > body.len) return error.InvalidCoreModule;
+            const sec_name = body[n_res.bytes_read .. n_res.bytes_read + name_len];
+            if (std.mem.eql(u8, sec_name, name)) continue;
+        }
+        // Re-emit unchanged.
+        try out.append(alloc, id);
+        try writeU32Leb(alloc, &out, sec_size);
+        try out.appendSlice(alloc, body);
+    }
+
+    // Append the new custom section.
+    var body = std.ArrayListUnmanaged(u8).empty;
+    defer body.deinit(alloc);
+    try writeU32Leb(alloc, &body, @intCast(name.len));
+    try body.appendSlice(alloc, name);
+    try body.appendSlice(alloc, payload);
+
+    try out.append(alloc, 0);
+    try writeU32Leb(alloc, &out, @intCast(body.items.len));
+    try out.appendSlice(alloc, body.items);
+
+    return try out.toOwnedSlice(alloc);
+}
+
+const LebRead = struct { value: u32, bytes_read: usize };
+
+fn readU32Leb(buf: []const u8, start: usize) !LebRead {
+    var result: u32 = 0;
+    var shift: u5 = 0;
+    var i: usize = start;
+    while (i < buf.len) : (i += 1) {
+        const b = buf[i];
+        result |= @as(u32, b & 0x7f) << shift;
+        if ((b & 0x80) == 0) {
+            return .{ .value = result, .bytes_read = i + 1 - start };
+        }
+        if (shift >= 25) return error.LebOverflow;
+        shift += 7;
+    }
+    return error.LebTruncated;
+}
+
+fn writeU32Leb(alloc: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), v: u32) !void {
+    var x = v;
+    while (true) {
+        var b: u8 = @intCast(x & 0x7f);
+        x >>= 7;
+        if (x != 0) b |= 0x80;
+        try out.append(alloc, b);
+        if (x == 0) break;
+    }
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "embedCustomSection: appends section to a minimal core module" {
+    const core = [_]u8{
+        0x00, 0x61, 0x73, 0x6d,
+        0x01, 0x00, 0x00, 0x00,
+    };
+    const payload = [_]u8{ 0x42, 0x00 };
+    const out = try embedCustomSection(testing.allocator, &core, "component-type:w", &payload);
+    defer testing.allocator.free(out);
+    // preamble (8) + section id (1) + size leb (1) + name_len leb (1)
+    // + name (15) + payload (2)
+    try testing.expectEqual(@as(u8, 0x00), out[8]); // custom section id
+    try testing.expect(std.mem.indexOf(u8, out, "component-type:w") != null);
+}
+
+test "embedCustomSection: replaces existing same-named section" {
+    const core = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // existing custom section "component-type:w" with payload 0xAA
+        0x00, 0x12, 0x10, 'c', 'o', 'm', 'p', 'o', 'n', 'e', 'n', 't', '-', 't', 'y', 'p', 'e', ':', 'w', 0xAA,
+    };
+    const payload = [_]u8{0xBB};
+    const out = try embedCustomSection(testing.allocator, &core, "component-type:w", &payload);
+    defer testing.allocator.free(out);
+    // Only one occurrence of the name (the old section was dropped).
+    var count: usize = 0;
+    var idx: usize = 0;
+    while (std.mem.indexOfPos(u8, out, idx, "component-type:w")) |found| {
+        count += 1;
+        idx = found + 1;
+    }
+    try testing.expectEqual(@as(usize, 1), count);
+    try testing.expect(std.mem.indexOfScalar(u8, out, 0xBB) != null);
+    try testing.expect(std.mem.indexOfScalar(u8, out, 0xAA) == null);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -45,6 +45,7 @@ pub const component = struct {
         pub const resolver = @import("component/wit/resolver.zig");
         pub const metadata_encode = @import("component/wit/metadata_encode.zig");
         pub const metadata_decode = @import("component/wit/metadata_decode.zig");
+        pub const embed = @import("component/wit/embed.zig");
     };
     pub const adapter = struct {
         pub const decode = @import("component/adapter/decode.zig");
@@ -80,6 +81,7 @@ test {
     _ = @import("component/wit/resolver.zig");
     _ = @import("component/wit/metadata_encode.zig");
     _ = @import("component/wit/metadata_decode.zig");
+    _ = @import("component/wit/embed.zig");
     _ = @import("component/adapter/decode.zig");
     _ = @import("component/adapter/core_imports.zig");
     _ = @import("component/adapter/shim.zig");

--- a/src/tools/component_embed.zig
+++ b/src/tools/component_embed.zig
@@ -103,10 +103,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
         std.process.exit(1);
     };
 
-    const world_name = world_arg orelse autoselectWorld(resolver.main) orelse {
-        std.debug.print("error: --world is required (no unique world found in WIT)\n", .{});
-        std.process.exit(1);
-    };
+    const world_name = world_arg orelse resolveSoleWorld(ar, resolver.main, wit_path);
 
     const ct_payload = wabt.component.wit.metadata_encode.encodeWorldFromResolver(alloc, resolver, world_name) catch |err| {
         std.debug.print("error: encoding world '{s}': {s}\n", .{ world_name, @errorName(err) });
@@ -131,7 +128,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     };
     defer alloc.free(section_name);
 
-    const embedded = embedCustomSection(alloc, core_bytes, section_name, ct_payload) catch |err| {
+    const embedded = wabt.component.wit.embed.embedCustomSection(alloc, core_bytes, section_name, ct_payload) catch |err| {
         std.debug.print("error: embedding custom section: {s}\n", .{@errorName(err)});
         std.process.exit(1);
     };
@@ -159,147 +156,40 @@ fn writeStdout(io: std.Io, text: []const u8) void {
     stdout_file.writeStreamingAll(io, text) catch {};
 }
 
-/// If exactly one world is defined in the document, return its name.
-fn autoselectWorld(doc: wabt.component.wit.ast.Document) ?[]const u8 {
-    var found: ?[]const u8 = null;
-    for (doc.items) |it| {
-        if (it == .world) {
-            if (found != null) return null;
-            found = it.world.name;
+/// Resolve the sole world in `doc` (used when `--world` is omitted).
+/// Exits with an informative error if zero or multiple worlds exist.
+fn resolveSoleWorld(
+    ar: std.mem.Allocator,
+    doc: wabt.component.wit.ast.Document,
+    wit_path: []const u8,
+) []const u8 {
+    if (wabt.component.wit.embed.autoselectWorld(doc)) |name| return name;
+
+    const names = wabt.component.wit.embed.worldNames(ar, doc) catch &.{};
+    if (names.len == 0) {
+        std.debug.print(
+            "error: no world found in WIT '{s}'. Define a `world` or pass --world <name>.\n",
+            .{wit_path},
+        );
+    } else {
+        std.debug.print(
+            "error: WIT '{s}' defines {d} worlds; pass --world <name> to pick one.\n  available worlds: ",
+            .{ wit_path, names.len },
+        );
+        for (names, 0..) |n, i| {
+            if (i != 0) std.debug.print(", ", .{});
+            std.debug.print("{s}", .{n});
         }
+        std.debug.print("\n", .{});
     }
-    return found;
-}
-
-/// Append a custom section with `name` and `payload` to a core wasm
-/// binary. Existing custom sections with the same name are dropped.
-fn embedCustomSection(
-    alloc: std.mem.Allocator,
-    core_bytes: []const u8,
-    name: []const u8,
-    payload: []const u8,
-) ![]u8 {
-    if (core_bytes.len < 8) return error.InvalidCoreModule;
-    if (!std.mem.eql(u8, core_bytes[0..4], "\x00asm")) return error.InvalidCoreModule;
-
-    var out = std.ArrayListUnmanaged(u8).empty;
-    errdefer out.deinit(alloc);
-
-    // Copy preamble.
-    try out.appendSlice(alloc, core_bytes[0..8]);
-
-    var i: usize = 8;
-    while (i < core_bytes.len) {
-        if (i >= core_bytes.len) break;
-        const id = core_bytes[i];
-        i += 1;
-        const size_res = readU32Leb(core_bytes, i) catch return error.InvalidCoreModule;
-        const sec_size = size_res.value;
-        i += size_res.bytes_read;
-        if (i + sec_size > core_bytes.len) return error.InvalidCoreModule;
-        const body = core_bytes[i .. i + sec_size];
-        i += sec_size;
-
-        if (id == 0) {
-            // Custom section: read its name and skip if it matches.
-            const n_res = readU32Leb(body, 0) catch return error.InvalidCoreModule;
-            const name_len = n_res.value;
-            if (n_res.bytes_read + name_len > body.len) return error.InvalidCoreModule;
-            const sec_name = body[n_res.bytes_read .. n_res.bytes_read + name_len];
-            if (std.mem.eql(u8, sec_name, name)) continue;
-        }
-        // Re-emit unchanged.
-        try out.append(alloc, id);
-        try writeU32Leb(alloc, &out, sec_size);
-        try out.appendSlice(alloc, body);
-    }
-
-    // Append the new custom section.
-    var body = std.ArrayListUnmanaged(u8).empty;
-    defer body.deinit(alloc);
-    try writeU32Leb(alloc, &body, @intCast(name.len));
-    try body.appendSlice(alloc, name);
-    try body.appendSlice(alloc, payload);
-
-    try out.append(alloc, 0);
-    try writeU32Leb(alloc, &out, @intCast(body.items.len));
-    try out.appendSlice(alloc, body.items);
-
-    return try out.toOwnedSlice(alloc);
-}
-
-const LebRead = struct { value: u32, bytes_read: usize };
-
-fn readU32Leb(buf: []const u8, start: usize) !LebRead {
-    var result: u32 = 0;
-    var shift: u5 = 0;
-    var i: usize = start;
-    while (i < buf.len) : (i += 1) {
-        const b = buf[i];
-        result |= @as(u32, b & 0x7f) << shift;
-        if ((b & 0x80) == 0) {
-            return .{ .value = result, .bytes_read = i + 1 - start };
-        }
-        if (shift >= 25) return error.LebOverflow;
-        shift += 7;
-    }
-    return error.LebTruncated;
-}
-
-fn writeU32Leb(alloc: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), v: u32) !void {
-    var x = v;
-    while (true) {
-        var b: u8 = @intCast(x & 0x7f);
-        x >>= 7;
-        if (x != 0) b |= 0x80;
-        try out.append(alloc, b);
-        if (x == 0) break;
-    }
+    std.process.exit(1);
 }
 
 // ── tests ──────────────────────────────────────────────────────────────────
 
 const testing = std.testing;
 
-test "embedCustomSection: appends section to a minimal core module" {
-    const core = [_]u8{
-        // preamble
-        0x00, 0x61, 0x73, 0x6d,
-        0x01, 0x00, 0x00, 0x00,
-    };
-    const payload = [_]u8{ 0x42, 0x00 };
-    const out = try embedCustomSection(testing.allocator, &core, "component-type:t", &payload);
-    defer testing.allocator.free(out);
-    try testing.expect(out.len > core.len);
-    // Custom section starts after the preamble; first byte of section is id=0.
-    try testing.expectEqual(@as(u8, 0), out[8]);
-}
-
-test "embedCustomSection: replaces existing same-name custom section" {
-    // preamble + custom section "x" with payload "old"
-    const core = [_]u8{
-        0x00, 0x61, 0x73, 0x6d,
-        0x01, 0x00, 0x00, 0x00,
-        0x00, 0x05, // section id=0, size=5
-        0x01, 'x', // name length=1, name="x"
-        'o', 'l', 'd', // payload "old"
-    };
-    const new_payload = "new!";
-    const out = try embedCustomSection(testing.allocator, &core, "x", new_payload);
-    defer testing.allocator.free(out);
-    // The original custom should be gone; only one section should
-    // remain, and it should hold "new!" as its payload.
-    try testing.expect(out.len > 8);
-    // Section starts at out[8], id=0, size LEB, name LEB, name, payload
-    try testing.expectEqual(@as(u8, 0), out[8]);
-    // size LEB single byte: 1 (name len) + 1 (name) + 4 (payload) = 6
-    try testing.expectEqual(@as(u8, 6), out[9]);
-    try testing.expectEqual(@as(u8, 1), out[10]);
-    try testing.expectEqual(@as(u8, 'x'), out[11]);
-    try testing.expectEqualStrings("new!", out[12..16]);
-}
-
-test "embedCustomSection: end-to-end with adder world" {
+test "embed end-to-end with adder world" {
     const wit_source =
         \\package docs:adder@0.1.0;
         \\
@@ -322,7 +212,7 @@ test "embedCustomSection: end-to-end with adder world" {
         0x00, 0x61, 0x73, 0x6d,
         0x01, 0x00, 0x00, 0x00,
     };
-    const out = try embedCustomSection(testing.allocator, &core, "component-type:adder", ct);
+    const out = try wabt.component.wit.embed.embedCustomSection(testing.allocator, &core, "component-type:adder", ct);
     defer testing.allocator.free(out);
 
     // Should be: preamble (8) + custom section (1 id + LEB size + name LEB + name (20) + ct).
@@ -330,3 +220,4 @@ test "embedCustomSection: end-to-end with adder world" {
     try testing.expectEqualSlices(u8, "\x00asm\x01\x00\x00\x00", out[0..8]);
     try testing.expectEqual(@as(u8, 0), out[8]); // custom section id
 }
+

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -62,17 +62,26 @@ const metadata_decode = wabt.component.wit.metadata_decode;
 const core_imports = wabt.component.adapter.core_imports;
 
 pub const usage =
-    \\Usage: wabt component new [options] <input.wasm>
+    \\Usage: wabt component new [options] [<wit-path>] <core.wasm>
     \\
-    \\Wrap a core wasm module (with embedded component-type metadata)
-    \\into a top-level component.
+    \\Wrap a core wasm module into a top-level WebAssembly component.
     \\
-    \\The input must already have a `component-type:<world>` custom
-    \\section, as produced by `wabt component embed` or
-    \\`wasm-tools component embed`.
+    \\The core must carry `component-type:<world>` metadata. Provide it
+    \\either by:
+    \\  * passing a <wit-path> positional (a `.wit` file or directory),
+    \\    in which case the world is embedded on the fly before wrapping
+    \\    — collapsing `wabt component embed` + `wabt component new` into
+    \\    a single call; or
+    \\  * pre-embedding with `wabt component embed` (or
+    \\    `wasm-tools component embed`) and passing only <core.wasm>.
     \\
     \\Options:
-    \\  -o, --output <file>     Output file (default: <input>.component.wasm)
+    \\  -o, --output <file>     Output file. Default: `<name>.wasm` when the
+    \\                          input is `<name>.core.wasm`, else
+    \\                          `<input>.component.wasm`.
+    \\  -w, --world <name>      World to embed from <wit-path>. Required only
+    \\                          when the WIT defines more than one world; with
+    \\                          exactly one world it is selected automatically.
     \\      --skip-validation   Skip post-encoding component validation
     \\      --adapt <n>=<file>  Splice in an adapter (may repeat). The
     \\                          primary is the unique adapter with at
@@ -106,7 +115,9 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var output_file: ?[]const u8 = null;
     var skip_validation: bool = false;
     var no_builtin_adapter: bool = false;
-    var input_path: ?[]const u8 = null;
+    var world_arg: ?[]const u8 = null;
+    var positionals: [2]?[]const u8 = .{ null, null };
+    var pos_count: usize = 0;
     var adapts = std.ArrayListUnmanaged(AdapterSpec).empty;
     defer adapts.deinit(alloc);
 
@@ -120,6 +131,13 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
                 std.process.exit(1);
             }
             output_file = sub_args[i];
+        } else if (std.mem.eql(u8, arg, "-w") or std.mem.eql(u8, arg, "--world")) {
+            i += 1;
+            if (i >= sub_args.len) {
+                std.debug.print("error: {s} requires an argument\n", .{arg});
+                std.process.exit(1);
+            }
+            world_arg = sub_args[i];
         } else if (std.mem.eql(u8, arg, "--skip-validation")) {
             skip_validation = true;
         } else if (std.mem.eql(u8, arg, "--no-builtin-adapter")) {
@@ -140,20 +158,31 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
             std.debug.print("error: unknown option '{s}'. Use `wabt component new help`.\n", .{arg});
             std.process.exit(1);
         } else {
-            if (input_path != null) {
-                std.debug.print("error: unexpected positional argument '{s}'\n", .{arg});
+            if (pos_count >= positionals.len) {
+                std.debug.print("error: unexpected positional argument '{s}'. Use `wabt component new help`.\n", .{arg});
                 std.process.exit(1);
             }
-            input_path = arg;
+            positionals[pos_count] = arg;
+            pos_count += 1;
         }
     }
 
-    const in_path = input_path orelse {
-        std.debug.print("error: component new requires <input.wasm>. Use `wabt component new help`.\n", .{});
+    // Positionals are either `<core.wasm>` (already embedded) or
+    // `<wit-path> <core.wasm>` (embed the WIT world on the fly, then
+    // wrap — collapsing `component embed` + `component new` into one).
+    if (pos_count == 0) {
+        std.debug.print("error: component new requires <core.wasm> (optionally preceded by <wit-path>). Use `wabt component new help`.\n", .{});
         std.process.exit(1);
-    };
+    }
+    const wit_path: ?[]const u8 = if (pos_count == 2) positionals[0].? else null;
+    const in_path = positionals[pos_count - 1].?;
 
-    const core_bytes = std.Io.Dir.cwd().readFileAlloc(
+    if (wit_path == null and world_arg != null) {
+        std.debug.print("error: --world requires a <wit-path> positional to embed from.\n", .{});
+        std.process.exit(1);
+    }
+
+    const raw_core_bytes = std.Io.Dir.cwd().readFileAlloc(
         init.io,
         in_path,
         alloc,
@@ -162,15 +191,35 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
         std.debug.print("error: cannot read '{s}': {any}\n", .{ in_path, err });
         std.process.exit(1);
     };
-    defer alloc.free(core_bytes);
+    defer alloc.free(raw_core_bytes);
+
+    // When a WIT path is given, embed the `component-type:<world>`
+    // section first (the same work `wabt component embed` does), so a
+    // plain core compiled by zig/etc. can be turned into a component
+    // in a single call.
+    const embedded_owned: ?[]u8 = if (wit_path) |wp|
+        embedWorld(init, alloc, wp, world_arg, raw_core_bytes)
+    else
+        null;
+    defer if (embedded_owned) |b| alloc.free(b);
+    const core_bytes: []const u8 = embedded_owned orelse raw_core_bytes;
 
     const out_path = output_file orelse blk: {
+        // A `<name>.core.wasm` input yields `<name>.wasm` — the core
+        // and component are the same artifact minus the `.core` tag.
+        if (std.mem.endsWith(u8, in_path, ".core.wasm")) {
+            const stem = in_path[0 .. in_path.len - ".core.wasm".len];
+            break :blk std.fmt.allocPrint(alloc, "{s}.wasm", .{stem}) catch in_path;
+        }
         if (std.mem.endsWith(u8, in_path, ".wasm")) {
             const stem = in_path[0 .. in_path.len - 5];
             break :blk std.fmt.allocPrint(alloc, "{s}.component.wasm", .{stem}) catch in_path;
         }
         break :blk std.fmt.allocPrint(alloc, "{s}.component.wasm", .{in_path}) catch in_path;
     };
+    // Free the derived default path (skip when it's `output_file`, which
+    // we borrow, or the `catch in_path` OOM fallback).
+    defer if (output_file == null and out_path.ptr != in_path.ptr) alloc.free(out_path);
 
     // Auto-attach the built-in wasi-preview1 → preview2 adapter when
     // the core imports preview1 and the user didn't already supply
@@ -253,6 +302,70 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
 fn writeStdout(io: std.Io, text: []const u8) void {
     var stdout_file = std.Io.File.stdout();
     stdout_file.writeStreamingAll(io, text) catch {};
+}
+
+/// Embed a `component-type:<world>` custom section into `core_bytes`
+/// from the WIT at `wit_path` — the same work `wabt component embed`
+/// does, so `component new` can wrap a plain core in one call. The
+/// world is `world_arg` when given, else the WIT's sole world (an
+/// informative error is printed if zero or multiple worlds exist).
+/// Returns freshly-allocated embedded bytes; exits on error.
+fn embedWorld(
+    init: std.process.Init,
+    alloc: std.mem.Allocator,
+    wit_path: []const u8,
+    world_arg: ?[]const u8,
+    core_bytes: []const u8,
+) []u8 {
+    const wit = wabt.component.wit;
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    const resolver = wit.resolver.parseLayout(ar, init.io, wit_path) catch |err| {
+        std.debug.print("error: parsing WIT layout '{s}': {s}\n", .{ wit_path, @errorName(err) });
+        std.process.exit(1);
+    };
+
+    const world_name = world_arg orelse blk: {
+        if (wit.embed.autoselectWorld(resolver.main)) |name| break :blk name;
+        const names = wit.embed.worldNames(ar, resolver.main) catch &.{};
+        if (names.len == 0) {
+            std.debug.print(
+                "error: no world found in WIT '{s}'. Define a `world` or pass --world <name>.\n",
+                .{wit_path},
+            );
+        } else {
+            std.debug.print(
+                "error: WIT '{s}' defines {d} worlds; pass --world <name> to pick one.\n  available worlds: ",
+                .{ wit_path, names.len },
+            );
+            for (names, 0..) |n, idx| {
+                if (idx != 0) std.debug.print(", ", .{});
+                std.debug.print("{s}", .{n});
+            }
+            std.debug.print("\n", .{});
+        }
+        std.process.exit(1);
+    };
+
+    const ct_payload = wit.metadata_encode.encodeWorldFromResolver(alloc, resolver, world_name) catch |err| {
+        std.debug.print("error: encoding world '{s}': {s}\n", .{ world_name, @errorName(err) });
+        std.process.exit(1);
+    };
+    defer alloc.free(ct_payload);
+
+    const section_name = std.fmt.allocPrint(alloc, "component-type:{s}", .{world_name}) catch |err| {
+        std.debug.print("error: {s}\n", .{@errorName(err)});
+        std.process.exit(1);
+    };
+    defer alloc.free(section_name);
+
+    return wit.embed.embedCustomSection(alloc, core_bytes, section_name, ct_payload) catch |err| {
+        std.debug.print("error: embedding world '{s}': {s}\n", .{ world_name, @errorName(err) });
+        std.process.exit(1);
+    };
 }
 
 fn userSuppliedAdapter(adapts: []const AdapterSpec, needle: []const u8) bool {

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -62,24 +62,28 @@ const metadata_decode = wabt.component.wit.metadata_decode;
 const core_imports = wabt.component.adapter.core_imports;
 
 pub const usage =
-    \\Usage: wabt component new [options] [<wit-path>] <core.wasm>
+    \\Usage: wabt component new [options] <core.wasm>
     \\
     \\Wrap a core wasm module into a top-level WebAssembly component.
     \\
     \\The core must carry `component-type:<world>` metadata. Provide it
     \\either by:
-    \\  * passing a <wit-path> positional (a `.wit` file or directory),
-    \\    in which case the world is embedded on the fly before wrapping
-    \\    — collapsing `wabt component embed` + `wabt component new` into
-    \\    a single call; or
+    \\  * letting `component new` embed it on the fly from a WIT package
+    \\    — `--wit <path>`, or a `wit/` directory in the cwd if present —
+    \\    collapsing `wabt component embed` + `wabt component new` into a
+    \\    single call; or
     \\  * pre-embedding with `wabt component embed` (or
-    \\    `wasm-tools component embed`) and passing only <core.wasm>.
+    \\    `wasm-tools component embed`) and passing a core that already
+    \\    has the section (no WIT path / no `wit/` directory).
     \\
     \\Options:
     \\  -o, --output <file>     Output file. Default: `<name>.wasm` when the
     \\                          input is `<name>.core.wasm`, else
     \\                          `<input>.component.wasm`.
-    \\  -w, --world <name>      World to embed from <wit-path>. Required only
+    \\      --wit <path>        WIT package to embed (a `.wit` file or a
+    \\                          directory). Defaults to `wit/` in the cwd
+    \\                          when that directory exists.
+    \\  -w, --world <name>      World to embed from the WIT. Required only
     \\                          when the WIT defines more than one world; with
     \\                          exactly one world it is selected automatically.
     \\      --skip-validation   Skip post-encoding component validation
@@ -116,8 +120,8 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     var skip_validation: bool = false;
     var no_builtin_adapter: bool = false;
     var world_arg: ?[]const u8 = null;
-    var positionals: [2]?[]const u8 = .{ null, null };
-    var pos_count: usize = 0;
+    var wit_arg: ?[]const u8 = null;
+    var input_path: ?[]const u8 = null;
     var adapts = std.ArrayListUnmanaged(AdapterSpec).empty;
     defer adapts.deinit(alloc);
 
@@ -131,6 +135,13 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
                 std.process.exit(1);
             }
             output_file = sub_args[i];
+        } else if (std.mem.eql(u8, arg, "--wit")) {
+            i += 1;
+            if (i >= sub_args.len) {
+                std.debug.print("error: {s} requires an argument\n", .{arg});
+                std.process.exit(1);
+            }
+            wit_arg = sub_args[i];
         } else if (std.mem.eql(u8, arg, "-w") or std.mem.eql(u8, arg, "--world")) {
             i += 1;
             if (i >= sub_args.len) {
@@ -158,27 +169,33 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
             std.debug.print("error: unknown option '{s}'. Use `wabt component new help`.\n", .{arg});
             std.process.exit(1);
         } else {
-            if (pos_count >= positionals.len) {
+            if (input_path != null) {
                 std.debug.print("error: unexpected positional argument '{s}'. Use `wabt component new help`.\n", .{arg});
                 std.process.exit(1);
             }
-            positionals[pos_count] = arg;
-            pos_count += 1;
+            input_path = arg;
         }
     }
 
-    // Positionals are either `<core.wasm>` (already embedded) or
-    // `<wit-path> <core.wasm>` (embed the WIT world on the fly, then
-    // wrap — collapsing `component embed` + `component new` into one).
-    if (pos_count == 0) {
-        std.debug.print("error: component new requires <core.wasm> (optionally preceded by <wit-path>). Use `wabt component new help`.\n", .{});
+    const in_path = input_path orelse {
+        std.debug.print("error: component new requires <core.wasm>. Use `wabt component new help`.\n", .{});
         std.process.exit(1);
-    }
-    const wit_path: ?[]const u8 = if (pos_count == 2) positionals[0].? else null;
-    const in_path = positionals[pos_count - 1].?;
+    };
+
+    // Resolve the WIT path to embed from (collapsing `component embed`
+    // + `component new` into one call): use `--wit <path>` when given,
+    // else default to a `wit/` directory in the cwd if one exists.
+    // When neither resolves, the core is assumed to already carry a
+    // `component-type:<world>` section (the pre-embedded path).
+    const default_wit_dir = "wit";
+    const wit_path: ?[]const u8 = wit_arg orelse blk: {
+        const stat = std.Io.Dir.cwd().statFile(init.io, default_wit_dir, .{}) catch break :blk null;
+        if (stat.kind == .directory) break :blk default_wit_dir;
+        break :blk null;
+    };
 
     if (wit_path == null and world_arg != null) {
-        std.debug.print("error: --world requires a <wit-path> positional to embed from.\n", .{});
+        std.debug.print("error: --world set but no WIT to embed from (pass --wit <path> or add a 'wit/' directory).\n", .{});
         std.process.exit(1);
     }
 
@@ -193,7 +210,7 @@ pub fn run(init: std.process.Init, sub_args: []const []const u8) !void {
     };
     defer alloc.free(raw_core_bytes);
 
-    // When a WIT path is given, embed the `component-type:<world>`
+    // When a WIT path is resolved, embed the `component-type:<world>`
     // section first (the same work `wabt component embed` does), so a
     // plain core compiled by zig/etc. can be turned into a component
     // in a single call.


### PR DESCRIPTION
## Summary

Collapses the `wabt component embed` + `wabt component new` two-step into a single call, and adds two ergonomic touches.

### 1. Embed WIT on the fly in `component new`

```
wabt component new [<wit-path>] <core.wasm>
```

When a `<wit-path>` positional (a `.wit` file or directory) is given, `component new` embeds its `component-type:<world>` section before wrapping — so a plain core compiled by zig/etc. becomes a component in one command. Passing only `<core.wasm>` keeps the existing pre-embedded behavior.

### 2. `-w, --world <name>` on `component new`

Picks the world to embed from `<wit-path>`. Optional when the WIT defines exactly one world (auto-selected). When it defines several, the error lists the available worlds:

```
error: WIT 'multiworld' defines 2 worlds; pass --world <name> to pick one.
  available worlds: alpha, beta
```

`--world` without a `<wit-path>` is rejected.

### 3. `.core.wasm` → `.wasm` default output naming

A `<name>.core.wasm` input now defaults its output to `<name>.wasm` (the core and component differ only by the `.core` tag). Other inputs keep the `<input>.component.wasm` default. `-o` still overrides.

## Refactor

The embed/world-selection helpers (`embedCustomSection`, `autoselectWorld`, `worldNames`) move into a shared `src/component/wit/embed.zig` so both `component embed` and `component new` use one implementation. `component embed`'s multi-world path now prints the same informative error.

Also frees the derived default output path (previously leaked — benign in a short-lived CLI, but the debug allocator flagged it).

## Result

A core + WIT now wraps in one call:

```sh
wabt component new wit zig-out/bin/avs.core.wasm   # -> zig-out/bin/avs.wasm
```

## Testing

- `zig build test`: **550/550 tests pass** (adds 2 tests in `embed.zig`).
- End-to-end: the [`azure-sdk-for-zig` `avs-wasi` example](https://github.com/cataggar/azure-sdk-for-zig/tree/examples/arm_avs_wasi) now builds its `wasi:http/outgoing-handler` component with a single `wabt component new wit zig-out/bin/avs.core.wasm`, validates under `wasm-tools`, and runs on `wasmtime -S http` (lists Azure AVS private clouds).
