### PR TITLE
test(component new): regression for #241 resource-method flattening

### DIFF
--- a/src/component/adapter/adapter.zig
+++ b/src/component/adapter/adapter.zig
@@ -3594,3 +3594,126 @@ test "splice #230: embed-extra canon.lower carries memory + string_encoding opts
     }
     try testing.expect(saw_record_decl);
 }
+
+test "splice #241: resource-bearing embed-extra import keeps own/borrow/option (not flattened to u32)" {
+    // Regression for cataggar/wabt#241.
+    //
+    // A component built from an embed whose WIT imports a resource-
+    // bearing interface (the minimal shape of `wasi:http/types` /
+    // `wasi:io/poll`) was malformed: the wrapping component's import
+    // instance-type body for that namespace lost its resource type
+    // definitions and had every method param flattened to bare `u32`
+    // — `borrow<R>` self handles, `own<R>` constructor results, and
+    // `option<string>` args all collapsed — so `wasm-tools validate`
+    // rejected it with `[constructor]… should return (own $T)`.
+    //
+    // Root cause: `buildEmbedExtraImports` fell back to per-func
+    // primitive synthesis (`coreToCompValType`) for namespaces the
+    // adapter does not hoist when the canonical-body path returned
+    // null. The fix preserves the embed's canonical instance body
+    // (resource defs + own/borrow/option typedefs) verbatim.
+    //
+    // This test splices the resource fixture and asserts the
+    // wrapping component's `docs:res/api@0.1.0` import body still
+    // carries (1) a `(type (sub resource))` export, (2) an `own`
+    // handle typedef (the constructor result), (3) a `borrow` handle
+    // typedef (the method self), and (4) an `option` typedef (the
+    // `option<string>` arg) — none of which survive the lossy
+    // primitive fallback.
+    const a = testing.allocator;
+    const adapter_bytes = try test_fixtures.buildSyntheticAdapter(a);
+    defer a.free(adapter_bytes);
+    const embed_bytes = try test_fixtures.buildSyntheticEmbedWithResourceImport(a);
+    defer a.free(embed_bytes);
+
+    const out = try splice(a, embed_bytes, adapter_bytes, "wasi_snapshot_preview1");
+    defer a.free(out);
+
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const comp = try loader.load(out, arena.allocator());
+
+    // Locate the wrapping component's `docs:res/api@0.1.0` import.
+    var maybe_inst_idx: ?u32 = null;
+    for (comp.imports) |im| {
+        if (std.mem.eql(u8, im.name, test_fixtures.EXTRA_RESOURCE_NAMESPACE)) {
+            try testing.expect(im.desc == .instance);
+            maybe_inst_idx = im.desc.instance;
+        }
+    }
+    try testing.expect(maybe_inst_idx != null);
+
+    const contrib = comp.type_indexspace[maybe_inst_idx.?];
+    try testing.expect(contrib == .type_def);
+    const td = comp.types[contrib.type_def];
+    try testing.expect(td == .instance);
+    const decls = td.instance.decls;
+
+    // Scan the body for the typed decls the lossy fallback would drop.
+    var has_sub_resource = false;
+    var has_own = false;
+    var has_borrow = false;
+    var has_option = false;
+    var ctor_func_slot: ?u32 = null;
+
+    // Build the body's local type-slot table (1:1 with type-allocating
+    // decls) so we can resolve `[constructor]thing`'s func result.
+    var slots = std.ArrayListUnmanaged(?ctypes.TypeDef).empty;
+    for (decls) |d| switch (d) {
+        .type => |t| {
+            switch (t) {
+                .val => |v| switch (v) {
+                    .own => has_own = true,
+                    .borrow => has_borrow = true,
+                    else => {},
+                },
+                .option => has_option = true,
+                else => {},
+            }
+            try slots.append(arena.allocator(), t);
+        },
+        .alias => |al| {
+            const sort: ctypes.Sort = switch (al) {
+                .instance_export => |ie| ie.sort,
+                .outer => |o| o.sort,
+            };
+            if (sort == .type) try slots.append(arena.allocator(), null);
+        },
+        .@"export" => |e| switch (e.desc) {
+            .type => |tb| {
+                if (tb == .sub_resource) has_sub_resource = true;
+                try slots.append(arena.allocator(), null);
+            },
+            .func => |fidx| {
+                if (std.mem.eql(u8, e.name, test_fixtures.EXTRA_RESOURCE_CTOR)) ctor_func_slot = fidx;
+            },
+            else => {},
+        },
+        else => {},
+    };
+
+    // (1) Resource type definition survives.
+    try testing.expect(has_sub_resource);
+    // (2)+(3) own + borrow handle typedefs survive (constructor result +
+    // method self), proving params were NOT flattened to bare u32.
+    try testing.expect(has_own);
+    try testing.expect(has_borrow);
+    // (4) the `option<string>` arg survives as an option typedef.
+    try testing.expect(has_option);
+
+    // Precise check for defect #2: `[constructor]thing`'s func result
+    // resolves to an `own<thing>` handle, not a plain scalar.
+    try testing.expect(ctor_func_slot != null);
+    const ctor_td = slots.items[ctor_func_slot.?] orelse unreachable;
+    try testing.expect(ctor_td == .func);
+    const res = ctor_td.func.results;
+    try testing.expect(res == .unnamed);
+    const res_vt: ctypes.ValType = switch (res.unnamed) {
+        .type_idx => |k| blk: {
+            const slot_td = slots.items[k] orelse break :blk res.unnamed;
+            break :blk if (slot_td == .val) slot_td.val else res.unnamed;
+        },
+        else => res.unnamed,
+    };
+    try testing.expect(res_vt == .own);
+}

--- a/src/component/adapter/test_fixtures.zig
+++ b/src/component/adapter/test_fixtures.zig
@@ -148,6 +148,44 @@ pub const EXTRA_STRING_FUNC = "compute";
 pub const EXTRA_STRING_EMBED_CT_SECTION_NAME =
     "component-type:docs:opts@0.1.0:opts:encoded world";
 
+/// WIT for an embed that imports a non-WASI iface whose body declares
+/// a *resource* with a constructor and a method taking
+/// `option<string>`. Regression fixture for cataggar/wabt#241.
+///
+/// This is the minimal shape of the `wasi:http/types` / `wasi:io/poll`
+/// interfaces that triggered the bug: their import instance-type
+/// bodies lost their resource type definitions and had every method
+/// param flattened to bare `u32` (the `borrow<R>` self handle, the
+/// `option<string>` arg) and `[constructor]thing` no longer returned
+/// `own<thing>`. Pre-fix, `buildEmbedExtraImports` fell back to
+/// per-func primitive synthesis (`coreToCompValType`) for such
+/// namespaces, producing a malformed component
+/// (`[constructor]…` not returning `(own $T)`).
+///
+/// `[constructor]thing` lowers to `() -> i32` (own handle),
+/// `[method]thing.configure` to `(i32, i32, i32, i32) -> ()`
+/// (self borrow + `option<string>` = disc + ptr + len).
+const EXTRA_RESOURCE_EMBED_WIT =
+    \\package docs:res@0.1.0;
+    \\
+    \\interface api {
+    \\    resource thing {
+    \\        constructor();
+    \\        configure: func(path: option<string>);
+    \\    }
+    \\}
+    \\
+    \\world res {
+    \\    import api;
+    \\}
+;
+
+pub const EXTRA_RESOURCE_NAMESPACE = "docs:res/api@0.1.0";
+pub const EXTRA_RESOURCE_CTOR = "[constructor]thing";
+pub const EXTRA_RESOURCE_METHOD = "[method]thing.configure";
+pub const EXTRA_RESOURCE_EMBED_CT_SECTION_NAME =
+    "component-type:docs:res@0.1.0:res:encoded world";
+
 pub const ADAPTER_CT_SECTION_NAME = "component-type:wit-bindgen:0.0.0-mock:wasi:cli@0.1.0:command:encoded world";
 pub const REACTOR_ADAPTER_CT_SECTION_NAME = "component-type:wit-bindgen:0.0.0-mock:wasi:cli@0.1.0:reactor:encoded world";
 pub const EMBED_CT_SECTION_NAME = "component-type:embed-mock";
@@ -1088,6 +1126,133 @@ pub fn buildSyntheticEmbedWithExtraStringImport(allocator: Allocator) ![]u8 {
     }
 
     try appendCustomSection(allocator, &out, EXTRA_STRING_EMBED_CT_SECTION_NAME, ct);
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// Build a synthetic command-shape embed core wasm that imports a
+/// non-WASI namespace whose iface body declares a *resource* with a
+/// constructor and an `option<string>`-taking method. Regression
+/// fixture for cataggar/wabt#241 — see `EXTRA_RESOURCE_EMBED_WIT`.
+///
+/// Imports:
+///   * `wasi_snapshot_preview1.fd_write`     (func, () -> i32)
+///   * `docs:res/api@0.1.0.[constructor]thing`
+///         (func, () -> i32)         — lowered `() -> own<thing>`
+///   * `docs:res/api@0.1.0.[method]thing.configure`
+///         (func, (i32,i32,i32,i32) -> ())
+///         — lowered `(self: borrow<thing>, path: option<string>)`
+///
+/// Exports:
+///   * `_start`        (func, () -> ())
+///   * `memory`        (memory 0)
+///   * `cabi_realloc`  (func, (i32,i32,i32,i32) -> i32)
+///         — needed for the `option<string>` canon-lower opts.
+///
+/// Carries a `component-type:docs:res@0.1.0:res:encoded world`
+/// custom section so the splicer's `embed_metadata` lookup recovers
+/// the canonical `docs:res/api` body — resource def + own/borrow
+/// handles + `option<string>`. Without the fix, the
+/// `buildEmbedExtraImports` fallback would synthesize a primitive
+/// `u32`-only body from the core wasm sigs, dropping the resource
+/// type defs and the `own<thing>` constructor result.
+pub fn buildSyntheticEmbedWithResourceImport(allocator: Allocator) ![]u8 {
+    const ct = try metadata_encode.encodeWorldFromSource(allocator, EXTRA_RESOURCE_EMBED_WIT, "res");
+    defer allocator.free(ct);
+
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+
+    try writeMagic(allocator, &out);
+
+    // Type section: 4 types.
+    //   type 0: () -> i32 (preview1.fd_write + [constructor]thing)
+    //   type 1: () -> () (_start)
+    //   type 2: (i32,i32,i32,i32) -> () ([method]thing.configure)
+    //   type 3: (i32,i32,i32,i32) -> i32 (cabi_realloc)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x04);
+        try b.appendSlice(allocator, &.{ 0x60, 0x00, 0x01, 0x7f });
+        try b.appendSlice(allocator, &.{ 0x60, 0x00, 0x00 });
+        try b.appendSlice(allocator, &.{ 0x60, 0x04, 0x7f, 0x7f, 0x7f, 0x7f, 0x00 });
+        try b.appendSlice(allocator, &.{ 0x60, 0x04, 0x7f, 0x7f, 0x7f, 0x7f, 0x01, 0x7f });
+        try writeSection(allocator, &out, 0x01, b.items);
+    }
+
+    // Import section: preview1.fd_write (type 0) + ctor (type 0) + method (type 2).
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x03);
+        try writeName(allocator, &b, "wasi_snapshot_preview1");
+        try writeName(allocator, &b, PREVIEW1_EXPORT);
+        try b.append(allocator, 0x00);
+        try b.append(allocator, 0x00);
+        try writeName(allocator, &b, EXTRA_RESOURCE_NAMESPACE);
+        try writeName(allocator, &b, EXTRA_RESOURCE_CTOR);
+        try b.append(allocator, 0x00);
+        try b.append(allocator, 0x00);
+        try writeName(allocator, &b, EXTRA_RESOURCE_NAMESPACE);
+        try writeName(allocator, &b, EXTRA_RESOURCE_METHOD);
+        try b.append(allocator, 0x00);
+        try b.append(allocator, 0x02);
+        try writeSection(allocator, &out, 0x02, b.items);
+    }
+
+    // Function section: 2 defined funcs — _start (type 1), cabi_realloc (type 3).
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x03);
+        try writeSection(allocator, &out, 0x03, b.items);
+    }
+
+    // Memory section: 1 memory (limits: min 0, no max)
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x01);
+        try b.append(allocator, 0x00);
+        try b.append(allocator, 0x00);
+        try writeSection(allocator, &out, 0x05, b.items);
+    }
+
+    // Export section: _start (func 3 = imports 0..2 + defined 0),
+    // memory (0), cabi_realloc (func 4 = imports 0..2 + defined 1).
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x03);
+        try writeName(allocator, &b, "_start");
+        try b.appendSlice(allocator, &.{ 0x00, 0x03 });
+        try writeName(allocator, &b, "memory");
+        try b.appendSlice(allocator, &.{ 0x02, 0x00 });
+        try writeName(allocator, &b, "cabi_realloc");
+        try b.appendSlice(allocator, &.{ 0x00, 0x04 });
+        try writeSection(allocator, &out, 0x07, b.items);
+    }
+
+    // Code section: trivial bodies.
+    //   _start: i32.const 0; drop; end
+    //   cabi_realloc: i32.const 0; end
+    {
+        var b = std.ArrayListUnmanaged(u8).empty;
+        defer b.deinit(allocator);
+        try b.append(allocator, 0x02);
+        try b.append(allocator, 0x05);
+        try b.append(allocator, 0x00);
+        try b.appendSlice(allocator, &.{ 0x41, 0x00, 0x1a, 0x0b });
+        try b.append(allocator, 0x04);
+        try b.append(allocator, 0x00);
+        try b.appendSlice(allocator, &.{ 0x41, 0x00, 0x0b });
+        try writeSection(allocator, &out, 0x0a, b.items);
+    }
+
+    try appendCustomSection(allocator, &out, EXTRA_RESOURCE_EMBED_CT_SECTION_NAME, ct);
 
     return out.toOwnedSlice(allocator);
 }


### PR DESCRIPTION
## Summary

Adds a splice regression test for #241, where `wabt component new` emitted a **malformed component**: the import instance-type bodies for resource-bearing namespaces (`wasi:http/types`, `wasi:io/poll`) lost their resource type definitions and had method params flattened to bare `u32` (`borrow<R>`, `own<R>`, `option<string>` all collapsed), so `[constructor]fields` no longer returned `(own $T)` and `wasm-tools validate` rejected it.

## Root cause (already fixed)

`buildEmbedExtraImports` fell back to lossy per-func primitive synthesis (`coreToCompValType`) for namespaces the preview1 adapter does not hoist, whenever the canonical-body path returned `null`. The fixes in #234/#235/#237 made the canonical-body path preserve the embed's typed instance body verbatim.

Verified end-to-end against the real `azure-sdk-for-zig` avs-wasi core: at HEAD (`v3.0.0-dev.13`) `wabt component new` produces a valid, correctly-typed component; built at the pre-fix commit it produced an invalid one. The issue reporter's binary predated the fix.

This PR **pins** that behavior with a focused regression test.

## What's added

- **`test_fixtures.zig`**: `buildSyntheticEmbedWithResourceImport` + `EXTRA_RESOURCE_*` consts — a command-shape embed importing a resource-bearing iface (`resource thing { constructor(); configure: func(path: option<string>); }`). Modeled on the existing #228/#230 fixtures.
- **`adapter.zig`**: `splice #241` test — splices the fixture and asserts the wrapping component's `docs:res/api@0.1.0` import body keeps (1) a `sub_resource` export, (2) an `own` handle typedef, (3) a `borrow` handle typedef, (4) an `option` typedef, and that `[constructor]thing` resolves to `own<thing>`. None survive the lossy fallback.

## Testing

`zig build test --summary all` -> **71/71 steps succeeded; 551/551 tests passed** (lib tests 448->449). Diff is purely additive.

Closes #241
