### PR TITLE
component new: wire canon-lift options for exported funcs needing string/list lifting (#253)

### DIFF
--- a/src/component/adapter/abi.zig
+++ b/src/component/adapter/abi.zig
@@ -608,6 +608,81 @@ pub fn classifyFunc(ftr: FuncTypeRef) Classification {
     };
 }
 
+/// Canon-*lift* options for an exported func. Distinct from `FuncOpts`
+/// (which is tailored for `canon lower`): on the lift side `realloc`
+/// is needed to lower string/list **params** into guest memory, and
+/// `post_return` is needed to free string/list **results** the guest
+/// allocated. (Lower instead needs `realloc` for its results.)
+pub const LiftOpts = struct {
+    /// `(memory <main_memory>)` — params or results reach memory.
+    memory: bool,
+    /// `(realloc <cabi_realloc>)` — a param contains string/list.
+    realloc: bool,
+    /// `string-encoding=utf8` — any param or result contains string.
+    string_encoding: bool,
+    /// A result contains string/list, so the lift needs a
+    /// `(post-return <cabi_post_…>)` to release it — provided the guest
+    /// actually exports the matching `cabi_post_*` core func.
+    needs_post_return: bool,
+};
+
+/// Classify an exported func for `canon lift`. See `LiftOpts`.
+pub fn classifyFuncLift(ftr: FuncTypeRef) LiftOpts {
+    const ft = ftr.func;
+    const resolver = ftr.resolver;
+
+    var params_flat: u32 = 0;
+    var params_need_memory = false;
+    var params_need_realloc = false;
+    var any_string = false;
+    for (ft.params) |p| {
+        const info = flatten(p.type, resolver);
+        params_flat = saturatingAdd(params_flat, info.flat);
+        if (info.needs_memory) params_need_memory = true;
+        if (info.needs_realloc_alloc) params_need_realloc = true;
+        if (info.contains_string) any_string = true;
+    }
+
+    var results_flat: u32 = 0;
+    var results_need_memory = false;
+    var results_need_cleanup = false;
+    switch (ft.results) {
+        .none => {},
+        .unnamed => |vt| {
+            const info = flatten(vt, resolver);
+            results_flat = info.flat;
+            if (info.needs_memory) results_need_memory = true;
+            if (info.needs_realloc_alloc) results_need_cleanup = true;
+            if (info.contains_string) any_string = true;
+        },
+        .named => |list| for (list) |nv| {
+            const info = flatten(nv.type, resolver);
+            results_flat = saturatingAdd(results_flat, info.flat);
+            if (info.needs_memory) results_need_memory = true;
+            if (info.needs_realloc_alloc) results_need_cleanup = true;
+            if (info.contains_string) any_string = true;
+        },
+    }
+
+    const need_memory =
+        params_need_memory or results_need_memory or
+        params_flat > MAX_FLAT_PARAMS or results_flat > MAX_FLAT_RESULTS;
+
+    return .{
+        .memory = need_memory,
+        .realloc = params_need_realloc,
+        .string_encoding = any_string,
+        .needs_post_return = results_need_cleanup,
+    };
+}
+
+/// True iff lifting this exported func requires any canon-lift option
+/// (and therefore the shim/fixup path, which aliases `memory` /
+/// `cabi_realloc`).
+pub fn liftNeedsOpts(lo: LiftOpts) bool {
+    return lo.memory or lo.realloc or lo.string_encoding or lo.needs_post_return;
+}
+
 /// Compute the flat core-wasm signature an indirect import lowers
 /// to. Used by the splicer when sizing the shim's trampoline slots
 /// (which must match the lowered call's flat repr — params first,

--- a/src/component/adapter/adapter.zig
+++ b/src/component/adapter/adapter.zig
@@ -1855,6 +1855,44 @@ pub fn buildCanonLowerOpts(
     return opts;
 }
 
+/// Build the `canon lift` option list for an exported func. Mirrors
+/// `buildCanonLowerOpts` but uses `abi.LiftOpts` and adds an optional
+/// `(post-return <cabi_post_…>)`. Emission order matches
+/// `wit-component`: memory, realloc, string-encoding, post-return.
+pub fn buildCanonLiftOpts(
+    arena: Allocator,
+    o: abi.LiftOpts,
+    memory_core_idx: u32,
+    realloc_core_idx: u32,
+    post_return_core_idx: ?u32,
+) error{OutOfMemory}![]const ctypes.CanonOpt {
+    var n: usize = 0;
+    if (o.memory) n += 1;
+    if (o.realloc) n += 1;
+    if (o.string_encoding) n += 1;
+    if (post_return_core_idx != null) n += 1;
+
+    const opts = try arena.alloc(ctypes.CanonOpt, n);
+    var i: usize = 0;
+    if (o.memory) {
+        opts[i] = .{ .memory = memory_core_idx };
+        i += 1;
+    }
+    if (o.realloc) {
+        opts[i] = .{ .realloc = realloc_core_idx };
+        i += 1;
+    }
+    if (o.string_encoding) {
+        opts[i] = .{ .string_encoding = .utf8 };
+        i += 1;
+    }
+    if (post_return_core_idx) |p| {
+        opts[i] = .{ .post_return = p };
+        i += 1;
+    }
+    return opts;
+}
+
 const RunInstanceExport = struct {
     qualified_name: []const u8,
     core_export_name: []const u8,

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -1277,6 +1277,32 @@ pub fn buildComponent(alloc: std.mem.Allocator, core_bytes: []const u8) ![]u8 {
         if (any_func_needs_opts) break;
     }
 
+    // ── #253: an exported func whose lift needs `(memory)` / `(realloc)`
+    //    / string-encoding / `(post-return)` (its sig reaches
+    //    string/list/indirect) also requires the shim/fixup path, which
+    //    aliases `memory` + `cabi_realloc`. Scan exported funcs too.
+    if (!any_func_needs_opts) {
+        outer: for (decoded.externs) |ext| {
+            if (!ext.is_export) continue;
+            const resolver = wabt.component.adapter.abi.TypeResolver{
+                .inst_decls = ext.inst_decls,
+                .world_decls = decoded.world_decls,
+            };
+            for (ext.funcs) |fn_ref| {
+                const ftr = wabt.component.adapter.abi.FuncTypeRef{
+                    .func = fn_ref.sig,
+                    .resolver = resolver,
+                };
+                if (wabt.component.adapter.abi.liftNeedsOpts(
+                    wabt.component.adapter.abi.classifyFuncLift(ftr),
+                )) {
+                    any_func_needs_opts = true;
+                    break :outer;
+                }
+            }
+        }
+    }
+
     // ── #250: collect guest-defined (exported) resources. A resource
     //    with a destructor forces the shim/fixup path: its `(type
     //    (resource … (dtor …)))` references a core func that only
@@ -2785,6 +2811,8 @@ fn buildComponentShimFixup(
         fn_name: []const u8,
         func_type_idx: u32,
         core_func_alias_idx: u32,
+        lift_opts: abi.LiftOpts,
+        post_return_core_idx: ?u32,
     };
     var captured_funcs = std.ArrayListUnmanaged(CapturedFunc).empty;
     var ext_export_start = std.ArrayListUnmanaged(struct {
@@ -2809,6 +2837,10 @@ fn buildComponentShimFixup(
             .order = &order,
         };
         const start: u32 = @intCast(captured_funcs.items.len);
+        const lift_resolver = abi.TypeResolver{
+            .inst_decls = ext.inst_decls,
+            .world_decls = decoded.world_decls,
+        };
         for (ext.funcs) |fn_ref| {
             const rewritten = try resolver.rewriteSig(fn_ref.sig);
             try types.append(ar, .{ .func = rewritten });
@@ -2826,11 +2858,33 @@ fn buildComponentShimFixup(
             const cf_idx = core_func_idx;
             core_func_idx += 1;
 
+            // #253: lift options for this exported func, plus an
+            // optional `(post-return cabi_post_<name>)` when its result
+            // needs cleanup and the guest exports the matching
+            // `cabi_post_*` core func.
+            const lift_opts = abi.classifyFuncLift(.{ .func = fn_ref.sig, .resolver = lift_resolver });
+            var post_idx: ?u32 = null;
+            if (lift_opts.needs_post_return) {
+                const cabi_post_name = try std.fmt.allocPrint(ar, "cabi_post_{s}", .{core_func_export_name});
+                if (coreExportsFunc(stripped_core, cabi_post_name) catch false) {
+                    try aliases.append(ar, .{ .instance_export = .{
+                        .sort = .{ .core = .func },
+                        .instance_idx = main_core_inst_idx,
+                        .name = cabi_post_name,
+                    } });
+                    try Section.appendAlias(&order, ar, aliases.items.len);
+                    post_idx = core_func_idx;
+                    core_func_idx += 1;
+                }
+            }
+
             try captured_funcs.append(ar, .{
                 .ext_qualified = ext.qualified_name,
                 .fn_name = fn_ref.name,
                 .func_type_idx = func_type_idx,
                 .core_func_alias_idx = cf_idx,
+                .lift_opts = lift_opts,
+                .post_return_core_idx = post_idx,
             });
         }
         try ext_export_start.append(ar, .{ .ext = ext, .start = start });
@@ -2838,10 +2892,17 @@ fn buildComponentShimFixup(
 
     const lifts_start: u32 = @intCast(canons.items.len);
     for (captured_funcs.items) |cf| {
+        const opts = try wabt.component.adapter.adapter.buildCanonLiftOpts(
+            ar,
+            cf.lift_opts,
+            memory_core_idx,
+            realloc_core_idx,
+            cf.post_return_core_idx,
+        );
         try canons.append(ar, .{ .lift = .{
             .core_func_idx = cf.core_func_alias_idx,
             .type_idx = cf.func_type_idx,
-            .opts = &.{},
+            .opts = opts,
         } });
     }
     const lifts_count: u32 = @as(u32, @intCast(canons.items.len)) - lifts_start;
@@ -4874,6 +4935,22 @@ fn hasResourceTypeDef(loaded: anytype, with_dtor: bool) bool {
     return false;
 }
 
+/// Counts of each canon-lift option kind across every `.lift` canon.
+const LiftOptCounts = struct { memory: usize, realloc: usize, string_encoding: usize, post_return: usize };
+fn liftOptCounts(loaded: anytype) LiftOptCounts {
+    var c = LiftOptCounts{ .memory = 0, .realloc = 0, .string_encoding = 0, .post_return = 0 };
+    for (loaded.canons) |canon| switch (canon) {
+        .lift => |l| for (l.opts) |o| switch (o) {
+            .memory => c.memory += 1,
+            .realloc => c.realloc += 1,
+            .string_encoding => c.string_encoding += 1,
+            .post_return => c.post_return += 1,
+        },
+        else => {},
+    };
+    return c;
+}
+
 test "buildComponent #250: dtor-less exported resource (fast path)" {
     // A guest that *defines* an exported resource with no destructor:
     // a constructor + a method, plus the `[resource-new]`/
@@ -5120,4 +5197,164 @@ test "buildComponent #251: [resource-new] declared without a result is rejected"
     defer testing.allocator.free(core);
 
     try testing.expectError(error.CoreImportSignatureMismatch, buildComponent(testing.allocator, core));
+}
+
+// ── #253: canon-lift options for exported funcs needing string lifting ──
+
+test "buildComponent #253: exported func taking a string lifts with memory+realloc" {
+    const wit =
+        \\package test:g@0.1.0;
+        \\
+        \\interface greeter {
+        \\    take: func(s: string);
+        \\}
+        \\
+        \\world w {
+        \\    export greeter;
+        \\}
+    ;
+    const wat =
+        \\(module
+        \\  (func (export "test:g/greeter@0.1.0#take") (param i32 i32))
+        \\  (memory (export "memory") 1)
+        \\  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) i32.const 0)
+        \\)
+    ;
+    const core = try buildCoreFromWat(testing.allocator, wat, wit, "w");
+    defer testing.allocator.free(core);
+    const comp_bytes = try buildComponent(testing.allocator, core);
+    defer testing.allocator.free(comp_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const loaded = try loader.load(comp_bytes, arena.allocator());
+
+    // String param forces the shim/fixup path.
+    try testing.expectEqual(@as(usize, 3), loaded.core_modules.len);
+    const c = liftOptCounts(loaded);
+    try testing.expectEqual(@as(usize, 1), c.memory);
+    try testing.expectEqual(@as(usize, 1), c.realloc); // for the incoming string param
+    try testing.expectEqual(@as(usize, 1), c.string_encoding);
+    try testing.expectEqual(@as(usize, 0), c.post_return); // no result to clean up
+}
+
+test "buildComponent #253: exported func returning a string lifts with memory+post-return" {
+    const wit =
+        \\package test:g@0.1.0;
+        \\
+        \\interface greeter {
+        \\    make: func() -> string;
+        \\}
+        \\
+        \\world w {
+        \\    export greeter;
+        \\}
+    ;
+    const wat =
+        \\(module
+        \\  (func (export "test:g/greeter@0.1.0#make") (result i32) i32.const 0)
+        \\  (func (export "cabi_post_test:g/greeter@0.1.0#make") (param i32))
+        \\  (memory (export "memory") 1)
+        \\  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) i32.const 0)
+        \\)
+    ;
+    const core = try buildCoreFromWat(testing.allocator, wat, wit, "w");
+    defer testing.allocator.free(core);
+    const comp_bytes = try buildComponent(testing.allocator, core);
+    defer testing.allocator.free(comp_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const loaded = try loader.load(comp_bytes, arena.allocator());
+
+    const c = liftOptCounts(loaded);
+    try testing.expectEqual(@as(usize, 1), c.memory);
+    try testing.expectEqual(@as(usize, 0), c.realloc); // no string params
+    try testing.expectEqual(@as(usize, 1), c.string_encoding);
+    try testing.expectEqual(@as(usize, 1), c.post_return); // frees the returned string
+}
+
+test "buildComponent #253: string-in/string-out export lifts with all four opts" {
+    const wit =
+        \\package test:g@0.1.0;
+        \\
+        \\interface greeter {
+        \\    greet: func(name: string) -> string;
+        \\}
+        \\
+        \\world w {
+        \\    export greeter;
+        \\}
+    ;
+    const wat =
+        \\(module
+        \\  (func (export "test:g/greeter@0.1.0#greet") (param i32 i32) (result i32) i32.const 0)
+        \\  (func (export "cabi_post_test:g/greeter@0.1.0#greet") (param i32))
+        \\  (memory (export "memory") 1)
+        \\  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) i32.const 0)
+        \\)
+    ;
+    const core = try buildCoreFromWat(testing.allocator, wat, wit, "w");
+    defer testing.allocator.free(core);
+    const comp_bytes = try buildComponent(testing.allocator, core);
+    defer testing.allocator.free(comp_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const loaded = try loader.load(comp_bytes, arena.allocator());
+
+    const c = liftOptCounts(loaded);
+    try testing.expectEqual(@as(usize, 1), c.memory);
+    try testing.expectEqual(@as(usize, 1), c.realloc);
+    try testing.expectEqual(@as(usize, 1), c.string_encoding);
+    try testing.expectEqual(@as(usize, 1), c.post_return);
+}
+
+test "buildComponent #253: resource method taking/returning a string (with #250) builds + lifts opts" {
+    // The motivating case: a guest-defined resource whose method takes
+    // and returns a string. Combines the #250 nested re-export + dtor
+    // shim wiring with #253 lift options (incl. post-return).
+    const wit =
+        \\package test:res@0.1.0;
+        \\
+        \\interface things {
+        \\    resource thing {
+        \\        constructor(name: string);
+        \\        greet: func(greeting: string) -> string;
+        \\    }
+        \\}
+        \\
+        \\world w {
+        \\    export things;
+        \\}
+    ;
+    const wat =
+        \\(module
+        \\  (import "[export]test:res/things@0.1.0" "[resource-new]thing" (func (param i32) (result i32)))
+        \\  (import "[export]test:res/things@0.1.0" "[resource-rep]thing" (func (param i32) (result i32)))
+        \\  (func (export "test:res/things@0.1.0#[constructor]thing") (param i32 i32) (result i32) i32.const 0)
+        \\  (func (export "test:res/things@0.1.0#[method]thing.greet") (param i32 i32 i32) (result i32) i32.const 0)
+        \\  (func (export "cabi_post_test:res/things@0.1.0#[method]thing.greet") (param i32))
+        \\  (func (export "test:res/things@0.1.0#[dtor]thing") (param i32))
+        \\  (memory (export "memory") 1)
+        \\  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) i32.const 0)
+        \\)
+    ;
+    const core = try buildCoreFromWat(testing.allocator, wat, wit, "w");
+    defer testing.allocator.free(core);
+    const comp_bytes = try buildComponent(testing.allocator, core);
+    defer testing.allocator.free(comp_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const loaded = try loader.load(comp_bytes, arena.allocator());
+
+    try testing.expectEqual(@as(usize, 3), loaded.core_modules.len);
+    try testing.expect(hasResourceTypeDef(loaded, true)); // dtor'd resource
+    try testing.expect(loaded.components.len == 1); // nested re-export
+    const c = liftOptCounts(loaded);
+    try testing.expect(c.memory >= 1);
+    try testing.expect(c.realloc >= 1);
+    try testing.expect(c.string_encoding >= 1);
+    try testing.expect(c.post_return >= 1); // greet's returned string
 }


### PR DESCRIPTION
Fixes #253.

`component new` lifted exported interface funcs with empty `canon lift` options, so any func whose signature reaches `string` / `list` (or otherwise lifts indirectly) produced an incorrect/rejected component. This emits the option bundle the canonical ABI requires, matching `wit-component` / `wasm-tools`.

### Lift options (distinct from lower)
| case | opts |
| --- | --- |
| `f(s: string)` | `(memory) (realloc) string-encoding` |
| `f() -> string` | `(memory) string-encoding (post-return)` |
| `f(string) -> string` | all four |

- **realloc** is for string/list **params** (host data lowered into guest memory) — *not* results, so `classifyFunc.opts.realloc` (lower) can't be reused.
- **post-return** is added when results contain string/list **and** the guest exports the matching `cabi_post_<core-export-name>`.

### Changes
- `abi.classifyFuncLift` / `abi.liftNeedsOpts` — lift-specific option classification (via `flatten`).
- `adapter.buildCanonLiftOpts` — builds the `CanonOpt` list, reusing the `memory` / `cabi_realloc` the shim path already aliases for import lowers.
- Path selection forces the shim/fixup path when any exported func needs lift opts; the fast path then only ever lifts opt-free funcs.
- Shim Phase 5 computes per-func lift opts and aliases `cabi_post_<name>` for `(post-return …)` when present.

### Verification
- `zig build test` green — new tests: string-param, string-result, string-in/out, and a resource method taking/returning a string combined with #250.
- Generated components pass `wasm-tools validate --features all` and round-trip via `wasm-tools component wit` (verified end-to-end through the `wabt component new` CLI).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
