### PR TITLE
WIT resolver: embedded wasi-canon as automatic fallback (#256)

### DIFF
--- a/src/component/wit/parser.zig
+++ b/src/component/wit/parser.zig
@@ -49,6 +49,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const lexer = @import("lexer.zig");
 const ast = @import("ast.zig");
+const wasi_canon = @import("wasi_canon.zig");
 
 pub const ParseError = lexer.LexError || error{
     OutOfMemory,
@@ -1432,41 +1433,14 @@ test "parse #195: every canonical wasi-* WIT file parses individually" {
     // is missing, since standalone parse is what's exercised here
     // (multi-file primary-package handling is Phase 2 scope).
     const Fixture = struct { path: []const u8, content: []const u8 };
-    const fixtures = [_]Fixture{
-        .{ .path = "cli/command.wit", .content = @embedFile("wasi-canon/cli/command.wit") },
-        .{ .path = "cli/environment.wit", .content = @embedFile("wasi-canon/cli/environment.wit") },
-        .{ .path = "cli/exit.wit", .content = @embedFile("wasi-canon/cli/exit.wit") },
-        .{ .path = "cli/imports.wit", .content = @embedFile("wasi-canon/cli/imports.wit") },
-        .{ .path = "cli/run.wit", .content = @embedFile("wasi-canon/cli/run.wit") },
-        .{ .path = "cli/stdio.wit", .content = @embedFile("wasi-canon/cli/stdio.wit") },
-        .{ .path = "cli/terminal.wit", .content = @embedFile("wasi-canon/cli/terminal.wit") },
-        .{ .path = "clocks/monotonic-clock.wit", .content = @embedFile("wasi-canon/clocks/monotonic-clock.wit") },
-        .{ .path = "clocks/timezone.wit", .content = @embedFile("wasi-canon/clocks/timezone.wit") },
-        .{ .path = "clocks/wall-clock.wit", .content = @embedFile("wasi-canon/clocks/wall-clock.wit") },
-        .{ .path = "clocks/world.wit", .content = @embedFile("wasi-canon/clocks/world.wit") },
-        .{ .path = "filesystem/preopens.wit", .content = @embedFile("wasi-canon/filesystem/preopens.wit") },
-        .{ .path = "filesystem/types.wit", .content = @embedFile("wasi-canon/filesystem/types.wit") },
-        .{ .path = "filesystem/world.wit", .content = @embedFile("wasi-canon/filesystem/world.wit") },
-        .{ .path = "http/handler.wit", .content = @embedFile("wasi-canon/http/handler.wit") },
-        .{ .path = "http/proxy.wit", .content = @embedFile("wasi-canon/http/proxy.wit") },
-        .{ .path = "http/types.wit", .content = @embedFile("wasi-canon/http/types.wit") },
-        .{ .path = "io/error.wit", .content = @embedFile("wasi-canon/io/error.wit") },
-        .{ .path = "io/poll.wit", .content = @embedFile("wasi-canon/io/poll.wit") },
-        .{ .path = "io/streams.wit", .content = @embedFile("wasi-canon/io/streams.wit") },
-        .{ .path = "io/world.wit", .content = @embedFile("wasi-canon/io/world.wit") },
-        .{ .path = "random/insecure-seed.wit", .content = @embedFile("wasi-canon/random/insecure-seed.wit") },
-        .{ .path = "random/insecure.wit", .content = @embedFile("wasi-canon/random/insecure.wit") },
-        .{ .path = "random/random.wit", .content = @embedFile("wasi-canon/random/random.wit") },
-        .{ .path = "random/world.wit", .content = @embedFile("wasi-canon/random/world.wit") },
-        .{ .path = "sockets/instance-network.wit", .content = @embedFile("wasi-canon/sockets/instance-network.wit") },
-        .{ .path = "sockets/ip-name-lookup.wit", .content = @embedFile("wasi-canon/sockets/ip-name-lookup.wit") },
-        .{ .path = "sockets/network.wit", .content = @embedFile("wasi-canon/sockets/network.wit") },
-        .{ .path = "sockets/tcp-create-socket.wit", .content = @embedFile("wasi-canon/sockets/tcp-create-socket.wit") },
-        .{ .path = "sockets/tcp.wit", .content = @embedFile("wasi-canon/sockets/tcp.wit") },
-        .{ .path = "sockets/udp-create-socket.wit", .content = @embedFile("wasi-canon/sockets/udp-create-socket.wit") },
-        .{ .path = "sockets/udp.wit", .content = @embedFile("wasi-canon/sockets/udp.wit") },
-        .{ .path = "sockets/world.wit", .content = @embedFile("wasi-canon/sockets/world.wit") },
-    };
+    var fixture_list: std.ArrayListUnmanaged(Fixture) = .empty;
+    defer fixture_list.deinit(testing.allocator);
+    for (wasi_canon.packages) |pkg| {
+        for (pkg.files) |file| {
+            try fixture_list.append(testing.allocator, .{ .path = file.path, .content = file.content });
+        }
+    }
+    const fixtures = fixture_list.items;
 
     for (fixtures) |f| {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);

--- a/src/component/wit/resolver.zig
+++ b/src/component/wit/resolver.zig
@@ -27,6 +27,7 @@ const Allocator = std.mem.Allocator;
 
 const ast = @import("ast.zig");
 const parser = @import("parser.zig");
+const wasi_canon = @import("wasi_canon.zig");
 
 pub const ResolveError = parser.ParseError || error{
     /// File or directory IO failure during deps walk.
@@ -290,6 +291,11 @@ pub const WitSource = struct {
     text: []const u8,
 };
 
+/// Result of combining one package's `.wit` files: the concatenated
+/// source buffer and the member file paths in emit order (caller frees
+/// both).
+pub const CombinedWit = struct { text: []u8, paths: [][]const u8 };
+
 /// Read every top-level `*.wit` file under `dir` (sorted, non-recursive)
 /// and concatenate them, separated by '\n'. Returns the concatenated
 /// buffer (caller frees) and the list of file paths included.
@@ -321,7 +327,7 @@ pub fn readWitDir(
     io: std.Io,
     dir_path: []const u8,
     diag: ?*ResolveDiagnostic,
-) ResolveError!struct { text: []u8, paths: [][]const u8 } {
+) ResolveError!CombinedWit {
     var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch
         return error.FileSystemError;
     defer dir.close(io);
@@ -347,27 +353,15 @@ pub fn readWitDir(
         return .{ .text = try alloc.alloc(u8, 0), .paths = try alloc.alloc([]const u8, 0) };
     }
 
-    // Read every file into memory, scan each for its leading package
-    // decl, and validate consistency.
-    const FileEntry = struct {
-        name: []const u8,
-        full_path: []const u8,
-        buf: []u8,
-        pkg_start: usize,
-        pkg_end: usize,
-        has_pkg: bool,
-    };
-    var files = try alloc.alloc(FileEntry, entries.items.len);
+    // Read every file into memory as a WitSource, then combine.
+    var sources = try alloc.alloc(WitSource, entries.items.len);
     defer {
-        for (files) |f| {
-            alloc.free(f.full_path);
-            alloc.free(f.buf);
+        for (sources) |s| {
+            alloc.free(s.path);
+            alloc.free(s.text);
         }
-        alloc.free(files);
+        alloc.free(sources);
     }
-    var canonical_decl: ?[]const u8 = null;
-    var canonical_path: []const u8 = "";
-    var first_decl_idx: ?usize = null;
     for (entries.items, 0..) |name, i| {
         const full = std.fs.path.join(alloc, &.{ dir_path, name }) catch return error.FileSystemError;
         const buf = std.Io.Dir.cwd().readFileAlloc(
@@ -376,31 +370,59 @@ pub fn readWitDir(
             alloc,
             std.Io.Limit.limited(1 << 20),
         ) catch return error.FileSystemError;
-        files[i] = .{
-            .name = name,
-            .full_path = full,
-            .buf = buf,
-            .pkg_start = 0,
-            .pkg_end = 0,
-            .has_pkg = false,
-        };
-        if (scanForPackageDecl(buf)) |range| {
-            files[i].pkg_start = range.start;
-            files[i].pkg_end = range.end;
-            files[i].has_pkg = true;
-            const decl_text = std.mem.trim(u8, buf[range.start..range.end], " \t\r\n");
+        sources[i] = .{ .path = full, .text = buf };
+    }
+
+    return combineWitSources(alloc, sources, dir_path, diag);
+}
+
+/// Combine multiple `.wit` files belonging to a single package into one
+/// parser-digestible source. `sources` should be sorted by file name
+/// for deterministic output.
+///
+/// Canonical WIT directories carry a single `package <id>;` declaration
+/// inherited by every sibling file. We require the set contain exactly
+/// one DISTINCT decl (`PackageDeclConflict` on mismatch,
+/// `NoPackageDeclInDirectory` if none), emit the decl-bearing file
+/// first (decl intact), then the rest with any duplicate decl stripped.
+///
+/// `dir_label` is used only in the `NoPackageDeclInDirectory`
+/// diagnostic. Returns the concatenated buffer and the file paths in
+/// emit order (caller frees both). Empty `sources` → `text.len == 0`.
+fn combineWitSources(
+    alloc: Allocator,
+    sources: []const WitSource,
+    dir_label: []const u8,
+    diag: ?*ResolveDiagnostic,
+) ResolveError!CombinedWit {
+    if (sources.len == 0) {
+        return .{ .text = try alloc.alloc(u8, 0), .paths = try alloc.alloc([]const u8, 0) };
+    }
+
+    const Scan = struct { has_pkg: bool, start: usize, end: usize };
+    const scans = try alloc.alloc(Scan, sources.len);
+    defer alloc.free(scans);
+
+    var canonical_decl: ?[]const u8 = null;
+    var canonical_path: []const u8 = "";
+    var first_decl_idx: ?usize = null;
+    for (sources, 0..) |src, i| {
+        scans[i] = .{ .has_pkg = false, .start = 0, .end = 0 };
+        if (scanForPackageDecl(src.text)) |range| {
+            scans[i] = .{ .has_pkg = true, .start = range.start, .end = range.end };
+            const decl_text = std.mem.trim(u8, src.text[range.start..range.end], " \t\r\n");
             if (canonical_decl) |canon| {
                 if (!std.mem.eql(u8, canon, decl_text)) {
                     if (diag) |d| d.* = .{
                         .msg = "files in the same WIT directory have differing `package` decls",
                         .path = canonical_path,
-                        .path2 = full,
+                        .path2 = src.path,
                     };
                     return error.PackageDeclConflict;
                 }
             } else {
                 canonical_decl = decl_text;
-                canonical_path = full;
+                canonical_path = src.path;
                 first_decl_idx = i;
             }
         }
@@ -409,7 +431,7 @@ pub fn readWitDir(
     if (first_decl_idx == null) {
         if (diag) |d| d.* = .{
             .msg = "no `package <ns>:<name>[@<ver>];` decl found in any file under this directory",
-            .path = dir_path,
+            .path = dir_label,
         };
         return error.NoPackageDeclInDirectory;
     }
@@ -427,20 +449,20 @@ pub fn readWitDir(
     // stripped.
     const first = first_decl_idx.?;
     {
-        const f = files[first];
-        try combined.appendSlice(alloc, f.buf);
+        const src = sources[first];
+        try combined.appendSlice(alloc, src.text);
         try combined.append(alloc, '\n');
-        try paths.append(alloc, try alloc.dupe(u8, f.full_path));
+        try paths.append(alloc, try alloc.dupe(u8, src.path));
     }
-    for (files, 0..) |f, i| {
+    for (sources, 0..) |src, i| {
         if (i == first) continue;
-        try paths.append(alloc, try alloc.dupe(u8, f.full_path));
-        if (f.has_pkg) {
+        try paths.append(alloc, try alloc.dupe(u8, src.path));
+        if (scans[i].has_pkg) {
             // Strip the duplicate decl; keep surrounding content.
-            try combined.appendSlice(alloc, f.buf[0..f.pkg_start]);
-            try combined.appendSlice(alloc, f.buf[f.pkg_end..]);
+            try combined.appendSlice(alloc, src.text[0..scans[i].start]);
+            try combined.appendSlice(alloc, src.text[scans[i].end..]);
         } else {
-            try combined.appendSlice(alloc, f.buf);
+            try combined.appendSlice(alloc, src.text);
         }
         try combined.append(alloc, '\n');
     }
@@ -488,7 +510,7 @@ pub fn parseLayoutWithDiag(
         ) catch return error.FileSystemError;
         if (buf.len == 0) return error.EmptyWit;
         const main = try parser.parse(arena, buf, null);
-        return Resolver.init(main, &.{});
+        return finishWithEmbedded(arena, main, &.{});
     }
 
     // Read main package.
@@ -499,9 +521,9 @@ pub fn parseLayoutWithDiag(
     // Walk deps/ if present.
     const deps_path = std.fs.path.join(arena, &.{ root, "deps" }) catch return error.FileSystemError;
     const deps_stat = std.Io.Dir.cwd().statFile(io, deps_path, .{}) catch {
-        return Resolver.init(main, &.{});
+        return finishWithEmbedded(arena, main, &.{});
     };
-    if (deps_stat.kind != .directory) return Resolver.init(main, &.{});
+    if (deps_stat.kind != .directory) return finishWithEmbedded(arena, main, &.{});
 
     var dep_docs: std.ArrayListUnmanaged(ast.Document) = .empty;
     var deps_dir = std.Io.Dir.cwd().openDir(io, deps_path, .{ .iterate = true }) catch
@@ -552,7 +574,60 @@ pub fn parseLayoutWithDiag(
         }
     }
 
-    return Resolver.init(main, try dep_docs.toOwnedSlice(arena));
+    return finishWithEmbedded(arena, main, dep_docs.items);
+}
+
+/// Finalize a `Resolver`, appending the embedded canonical WASI 0.2.6
+/// packages as **lowest-priority** deps. An embedded package is skipped
+/// when `main` or any on-disk dep already provides a matching package,
+/// so an on-disk `wit/deps/<pkg>/` always wins and existing projects
+/// see no behavior change. Resolution precedence becomes:
+/// `main` → on-disk deps → embedded wasi-canon.
+fn finishWithEmbedded(
+    arena: Allocator,
+    main: ast.Document,
+    on_disk: []const ast.Document,
+) ResolveError!Resolver {
+    var all: std.ArrayListUnmanaged(ast.Document) = .empty;
+    try all.appendSlice(arena, on_disk);
+
+    const embedded = try embeddedWasiDocs(arena);
+    for (embedded) |edoc| {
+        const epkg = edoc.package orelse continue;
+        var provided = false;
+        if (main.package) |mp| {
+            if (packageMatches(mp, epkg)) provided = true;
+        }
+        if (!provided) {
+            for (on_disk) |d| {
+                if (d.package) |dp| {
+                    if (packageMatches(dp, epkg)) {
+                        provided = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (!provided) try all.append(arena, edoc);
+    }
+
+    return Resolver.init(main, try all.toOwnedSlice(arena));
+}
+
+/// Parse the embedded canonical WASI 0.2.6 packages into one
+/// `ast.Document` per package (cli, clocks, filesystem, http, io,
+/// random, sockets). Documents are allocated into `arena`.
+pub fn embeddedWasiDocs(arena: Allocator) ResolveError![]ast.Document {
+    var docs = try arena.alloc(ast.Document, wasi_canon.packages.len);
+    for (wasi_canon.packages, 0..) |pkg, i| {
+        var sources = try arena.alloc(WitSource, pkg.files.len);
+        for (pkg.files, 0..) |file, j| {
+            sources[j] = .{ .path = file.path, .text = file.content };
+        }
+        const combined = try combineWitSources(arena, sources, pkg.name, null);
+        docs[i] = try parser.parse(arena, combined.text, null);
+    }
+    return docs;
 }
 
 // ── tests ───────────────────────────────────────────────────────────────────
@@ -888,6 +963,124 @@ test "resolver #195p2: canonical wasi-http proxy world resolves through the layo
     try std.testing.expect(saw_io);
     try std.testing.expect(saw_random);
     try std.testing.expect(saw_sockets);
+}
+
+test "resolver #256: wasi:* refs resolve from embedded set (no on-disk deps)" {
+    // Acceptance for #256: a `wit/` containing ONLY world.wit (no
+    // deps/) resolves wasi:* refs against the embedded wasi-canon set.
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var ar = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer ar.deinit();
+    const allocator = ar.allocator();
+    const io = std.testing.io;
+
+    try tmp.dir.createDirPath(io, "wit");
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "wit/world.wit",
+        .data =
+        \\package example:app@0.1.0;
+        \\world app {
+        \\  import wasi:io/streams@0.2.6;
+        \\  import wasi:http/types@0.2.6;
+        \\  import wasi:http/incoming-handler@0.2.6;
+        \\}
+        ,
+    });
+
+    const tmp_wit = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}/wit", .{tmp.sub_path});
+    const res = try parseLayout(allocator, io, tmp_wit);
+
+    const v: []const u8 = "0.2.6";
+    try std.testing.expect(res.findInterface(.{
+        .package = .{ .namespace = "wasi", .name = "io", .version = v },
+        .name = "streams",
+    }) != null);
+    try std.testing.expect(res.findInterface(.{
+        .package = .{ .namespace = "wasi", .name = "http", .version = v },
+        .name = "types",
+    }) != null);
+    // incoming-handler lives in handler.wit, which carries NO package
+    // decl — exercises the embedded multi-file combine.
+    try std.testing.expect(res.findInterface(.{
+        .package = .{ .namespace = "wasi", .name = "http", .version = v },
+        .name = "incoming-handler",
+    }) != null);
+    // A version-less ref still matches the pinned 0.2.6 embedded set
+    // (relaxed packageMatches).
+    try std.testing.expect(res.findInterface(.{
+        .package = .{ .namespace = "wasi", .name = "random", .version = null },
+        .name = "random",
+    }) != null);
+}
+
+test "resolver #256: on-disk wasi dep overrides embedded copy" {
+    // An on-disk wit/deps/<pkg>/ takes precedence over the embedded
+    // copy — existing vendored projects see no behavior change.
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var ar = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer ar.deinit();
+    const allocator = ar.allocator();
+    const io = std.testing.io;
+
+    try tmp.dir.createDirPath(io, "wit");
+    try tmp.dir.createDirPath(io, "wit/deps/io");
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "wit/world.wit",
+        .data =
+        \\package example:app@0.1.0;
+        \\world app { import wasi:io/streams@0.2.6; }
+        ,
+    });
+    // Sentinel on-disk wasi:io: a single-item `streams` interface, very
+    // unlike the rich embedded one.
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "wit/deps/io/io.wit",
+        .data =
+        \\package wasi:io@0.2.6;
+        \\interface streams { sentinel-marker: func(); }
+        ,
+    });
+
+    const tmp_wit = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}/wit", .{tmp.sub_path});
+    const res = try parseLayout(allocator, io, tmp_wit);
+
+    const streams = res.findInterface(.{
+        .package = .{ .namespace = "wasi", .name = "io", .version = "0.2.6" },
+        .name = "streams",
+    });
+    try std.testing.expect(streams != null);
+    // The on-disk copy (one item) wins over the embedded set.
+    try std.testing.expectEqual(@as(usize, 1), streams.?.items.len);
+}
+
+test "resolver #256: unknown wasi:* subinterface resolves to null (no panic)" {
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var ar = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer ar.deinit();
+    const allocator = ar.allocator();
+    const io = std.testing.io;
+
+    try tmp.dir.createDirPath(io, "wit");
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "wit/world.wit",
+        .data =
+        \\package example:app@0.1.0;
+        \\world app { import wasi:io/streams@0.2.6; }
+        ,
+    });
+
+    const tmp_wit = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}/wit", .{tmp.sub_path});
+    const res = try parseLayout(allocator, io, tmp_wit);
+
+    // Package matches embedded wasi:io, but the sub-interface does not
+    // exist → clean null, not a crash.
+    try std.testing.expect(res.findInterface(.{
+        .package = .{ .namespace = "wasi", .name = "io", .version = "0.2.6" },
+        .name = "does-not-exist",
+    }) == null);
 }
 
 test "resolver #216: bundled wasi-cli adapter deps now expose stdin" {

--- a/src/component/wit/wasi_canon.zig
+++ b/src/component/wit/wasi_canon.zig
@@ -1,0 +1,98 @@
+//! Embedded canonical WASI 0.2.6 WIT packages.
+//!
+//! The full `wasip2` interface tree from
+//! https://github.com/WebAssembly/WASI/tree/v0.2.6/wasip2 is vendored
+//! verbatim under `wasi-canon/<pkg>/*.wit` and `@embedFile`d here so the
+//! CLI can resolve `wasi:*@0.2.x` references without an on-disk
+//! `wit/deps/` copy. Every file is byte-for-byte identical to upstream
+//! `v0.2.6`; the set is pinned at that version.
+//!
+//! This module is the single source of truth for the embedded set: both
+//! the resolver (embedded-fallback docs) and the parser acceptance test
+//! consume `packages` from here.
+
+const std = @import("std");
+
+/// One embedded `.wit` file. `path` is informational (used in error
+/// messages); `content` is the verbatim source text.
+pub const File = struct {
+    path: []const u8,
+    content: []const u8,
+};
+
+/// A canonical WASI package: a `wasi:<name>@0.2.6` package made of one
+/// or more `.wit` files that share a single `package` declaration.
+pub const Package = struct {
+    /// Bare package name (e.g. `io`, `http`); the namespace is `wasi`.
+    name: []const u8,
+    /// Member files. The combined source carries one `package
+    /// wasi:<name>@0.2.6;` declaration.
+    files: []const File,
+};
+
+/// The pinned canonical version of every embedded package.
+pub const version = "0.2.6";
+
+fn f(comptime path: []const u8) File {
+    return .{ .path = path, .content = @embedFile("wasi-canon/" ++ path) };
+}
+
+/// All canonical WASI 0.2.6 packages, grouped by package.
+pub const packages = [_]Package{
+    .{ .name = "cli", .files = &.{
+        f("cli/command.wit"),
+        f("cli/environment.wit"),
+        f("cli/exit.wit"),
+        f("cli/imports.wit"),
+        f("cli/run.wit"),
+        f("cli/stdio.wit"),
+        f("cli/terminal.wit"),
+    } },
+    .{ .name = "clocks", .files = &.{
+        f("clocks/monotonic-clock.wit"),
+        f("clocks/timezone.wit"),
+        f("clocks/wall-clock.wit"),
+        f("clocks/world.wit"),
+    } },
+    .{ .name = "filesystem", .files = &.{
+        f("filesystem/preopens.wit"),
+        f("filesystem/types.wit"),
+        f("filesystem/world.wit"),
+    } },
+    .{ .name = "http", .files = &.{
+        f("http/handler.wit"),
+        f("http/proxy.wit"),
+        f("http/types.wit"),
+    } },
+    .{ .name = "io", .files = &.{
+        f("io/error.wit"),
+        f("io/poll.wit"),
+        f("io/streams.wit"),
+        f("io/world.wit"),
+    } },
+    .{ .name = "random", .files = &.{
+        f("random/insecure-seed.wit"),
+        f("random/insecure.wit"),
+        f("random/random.wit"),
+        f("random/world.wit"),
+    } },
+    .{ .name = "sockets", .files = &.{
+        f("sockets/instance-network.wit"),
+        f("sockets/ip-name-lookup.wit"),
+        f("sockets/network.wit"),
+        f("sockets/tcp-create-socket.wit"),
+        f("sockets/tcp.wit"),
+        f("sockets/udp-create-socket.wit"),
+        f("sockets/udp.wit"),
+        f("sockets/world.wit"),
+    } },
+};
+
+/// Iterate every embedded file across all packages (declaration order).
+/// Convenience for callers (e.g. the parser acceptance test) that want
+/// the flat list rather than the per-package grouping.
+pub fn eachFile(comptime cb: fn (File) void) void {
+    inline for (packages) |pkg| {
+        inline for (pkg.files) |file| cb(file);
+    }
+}


### PR DESCRIPTION
## What

Wire the already-vendored canonical WASI **0.2.6** WIT packages into the resolver as a **zero-config, lowest-priority fallback**, so a project importing `wasi:*@0.2.x` no longer needs to vendor a byte-for-byte copy into its own `wit/deps/`.

Closes #256. Refs #195.

## Background

`src/component/wit/wasi-canon/<pkg>/*.wit` already embeds the full 0.2.6 set (7 packages, 33 files — verified byte-for-byte identical to [WASI v0.2.6/wasip2](https://github.com/WebAssembly/WASI/tree/v0.2.6/wasip2), including `http/proxy.wit`). But it was only consumed by a parser test; the resolver built its deps purely from on-disk `<root>/deps/`.

## Changes

- **`wasi_canon.zig` (new)** — single source of truth that `@embedFile`s the 0.2.6 set grouped by package. The `#195` parser acceptance test is refactored onto it (drops the duplicated 33-entry fixture list).
- **`resolver.zig`**
  - Factored the multi-file package combine out of `readWitDir` into a shared `combineWitSources` (named `CombinedWit` return type).
  - Added `embeddedWasiDocs` (parse each embedded package into one `ast.Document`) and `finishWithEmbedded` (append embedded docs as **lowest-priority** deps, **deduped** against the main package + any on-disk dep). Wired into every `parseLayoutWithDiag` return path.
  - Resolution precedence: `main` → on-disk deps → embedded. An on-disk `wit/deps/<pkg>/` always wins, so vendored projects see **no behavior change**.
  - Version handling reuses the relaxed `packageMatches` (version-less or exact-0.2.6 ref matches the pinned embedded set).

## Acceptance criteria

- [x] A `world` importing `wasi:io/streams`, `wasi:http/types`, `wasi:http/incoming-handler` resolves from a `wit/` containing **only** `world.wit` (no `deps/`).
- [x] An on-disk `wit/deps/<pkg>/` takes precedence over the embedded copy (override test).
- [x] New resolver tests: (a) embedded-only resolution, (b) on-disk override wins, (c) unknown `wasi:*` subinterface errors cleanly.
- [x] Pre-existing parser/resolver tests keep passing.

## Testing

- `zig test src/component/wit/resolver.zig` → **49/49 pass** (46 existing + 3 new).
- `zig build test` exits 0; the failure set was diffed against a clean checkout — **no new failures** (the only shared failing item is a pre-existing negative test).

## Notes

- Embedded docs are parsed per `parseLayout` call (not cached) — fine since `component new` resolves once per process; can add caching later if profiling warrants.
- Follow-up (separate): bump the dependency in downstream consumers and delete their `wit/deps/` duplicates.