### PR TITLE
release: publish per-asset .minisig signatures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,5 +9,8 @@
 *.wasm binary
 *.wast binary
 
+# Expect scripts must keep LF endings so they run on the Linux CI runners.
+*.exp text eol=lf
+
 # Parser test fixture with intentional mixed CR/LF line endings; keep bytes exact.
 test/parse/bad-crlf.txt -text

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,8 @@ jobs:
     needs: [build, source]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           merge-multiple: true
@@ -133,6 +135,29 @@ jobs:
       - name: Get version
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign archives with minisign (per-asset .minisig sidecars)
+        env:
+          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+          MINISIGN_PASSWORD:   ${{ secrets.MINISIGN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -qq -y minisign expect
+          # Write the secret key to a file with 0600. The runner workspace
+          # is ephemeral; the trap removes it before the step exits.
+          umask 077
+          printf '%s\n' "$MINISIGN_SECRET_KEY" > minisign.key
+          trap 'rm -f minisign.key' EXIT
+          shopt -s nullglob
+          for asset in wabt-*.tar.gz wabt-*.tar.xz; do
+            # Trusted comment is printed by `ghr install` on successful
+            # verification, so encode self-identifying metadata in it.
+            comment="timestamp:$(date +%s) file:${asset} commit:${GITHUB_SHA} tag:${GITHUB_REF_NAME}"
+            echo "signing ${asset} (trusted comment: ${comment})"
+            expect scripts/sign-asset.exp "$asset" "$comment"
+          done
+          ls -la wabt-*.minisig
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
@@ -149,11 +174,12 @@ jobs:
             **Install:**
 
             ```
-            ghr install cataggar/wabt@v${{ steps.version.outputs.version }}
+            ghr install cataggar/wabt@v${{ steps.version.outputs.version }} RWSBnHWjwk/kkqdYc74cGupHMNVobpmF3lPc7b8RIllYMmYBr5G2EyF0
             ```
           files: |
             wabt-*.tar.gz
             wabt-*.tar.xz
             wabt-*.sbom.spdx.json
+            wabt-*.minisig
           draft: false
           prerelease: ${{ contains(steps.version.outputs.version, 'dev') }}

--- a/scripts/sign-asset.exp
+++ b/scripts/sign-asset.exp
@@ -1,0 +1,45 @@
+#!/usr/bin/env expect
+# Drive `minisign -S` non-interactively in CI: reads the passphrase
+# from the MINISIGN_PASSWORD environment variable instead of /dev/tty
+# (which is how upstream minisign always prompts for it).
+#
+# Usage: expect scripts/sign-asset.exp <asset> <trusted-comment>
+#
+# Requires:
+#   * `minisign` and `expect` on PATH
+#   * `minisign.key` in the current working directory
+#   * MINISIGN_PASSWORD env var set to the secret-key passphrase
+
+if {$argc != 2} {
+    puts stderr "usage: sign-asset.exp <asset> <trusted-comment>"
+    exit 64
+}
+
+set asset   [lindex $argv 0]
+set comment [lindex $argv 1]
+set timeout 30
+
+# Don't echo minisign's output (which would include the prompt) onto the
+# job log. The trusted comment is logged separately by the caller.
+log_user 0
+
+spawn minisign -S -s minisign.key -m $asset -t $comment
+
+expect {
+    "Password:" {
+        send -- "$env(MINISIGN_PASSWORD)\r"
+    }
+    timeout {
+        puts stderr "timeout waiting for minisign password prompt"
+        exit 2
+    }
+    eof {
+        puts stderr "minisign exited before prompting for a password"
+        exit 2
+    }
+}
+
+expect eof
+catch wait result
+# Propagate minisign's exit status so a signature failure fails the job.
+exit [lindex $result 3]


### PR DESCRIPTION
## Summary

Mirror the `cataggar/ghr` release flow by signing each distributable archive with **minisign** and publishing the `.minisig` sidecars alongside the release assets.

## Changes

- Add `scripts/sign-asset.exp` to drive `minisign -S` non-interactively in CI (reads the passphrase from `MINISIGN_PASSWORD` instead of `/dev/tty`).
- `release` job: check out the repo (for the expect script), then sign `wabt-*.tar.gz` and `wabt-*.tar.xz` using the `MINISIGN_SECRET_KEY` / `MINISIGN_PASSWORD` secrets, and upload the resulting `wabt-*.minisig`.
- Embed the minisign public key in the `ghr install` command so the signature is verified on install.
- Pin `*.exp` to LF in `.gitattributes` so the script runs on Linux runners.

## Requirements

The `MINISIGN_SECRET_KEY` and `MINISIGN_PASSWORD` repository secrets must be configured (corresponding to public key `RWSBnHWjwk/kkqdYc74cGupHMNVobpmF3lPc7b8RIllYMmYBr5G2EyF0`).