### PR TITLE
component new: waitable-set / waitable canons for awaiting async ops (#265)

### DIFF
--- a/src/component/adapter/adapter.zig
+++ b/src/component/adapter/adapter.zig
@@ -1156,7 +1156,7 @@ const Builder = struct {
                 self.func_cursor += 1;
                 return i;
             },
-            .lower, .resource_drop, .resource_new, .resource_rep, .future_new, .future_read, .future_write, .future_cancel_read, .future_cancel_write, .future_drop_readable, .future_drop_writable, .stream_new, .stream_read, .stream_write, .stream_cancel_read, .stream_cancel_write, .stream_drop_readable, .stream_drop_writable, .error_context_new, .error_context_debug_message, .error_context_drop, .task_return => {
+            .lower, .resource_drop, .resource_new, .resource_rep, .future_new, .future_read, .future_write, .future_cancel_read, .future_cancel_write, .future_drop_readable, .future_drop_writable, .stream_new, .stream_read, .stream_write, .stream_cancel_read, .stream_cancel_write, .stream_drop_readable, .stream_drop_writable, .error_context_new, .error_context_debug_message, .error_context_drop, .task_return, .waitable_set_new, .waitable_set_wait, .waitable_set_poll, .waitable_set_drop, .waitable_join => {
                 const i = self.core_func_cursor;
                 self.core_func_cursor += 1;
                 return i;

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -256,7 +256,7 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
                     // Every canon kind except `.lift` contributes a slot
                     // to the core-func indexspace.
                     const contributes = switch (c) {
-                        .lower, .resource_drop, .resource_new, .resource_rep, .future_new, .future_read, .future_write, .future_cancel_read, .future_cancel_write, .future_drop_readable, .future_drop_writable, .stream_new, .stream_read, .stream_write, .stream_cancel_read, .stream_cancel_write, .stream_drop_readable, .stream_drop_writable, .error_context_new, .error_context_debug_message, .error_context_drop, .task_return => true,
+                        .lower, .resource_drop, .resource_new, .resource_rep, .future_new, .future_read, .future_write, .future_cancel_read, .future_cancel_write, .future_drop_readable, .future_drop_writable, .stream_new, .stream_read, .stream_write, .stream_cancel_read, .stream_cancel_write, .stream_drop_readable, .stream_drop_writable, .error_context_new, .error_context_debug_message, .error_context_drop, .task_return, .waitable_set_new, .waitable_set_wait, .waitable_set_poll, .waitable_set_drop, .waitable_join => true,
                         .lift => false,
                     };
                     if (contributes) try core_func_indexspace.append(allocator, .{ .canon = local_idx });
@@ -777,6 +777,19 @@ fn parseCanon(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!cty
             const opts = try readCanonOpts(reader, allocator);
             break :blk .{ .task_return = .{ .results = results, .opts = opts } };
         },
+        0x1F => .waitable_set_new,
+        0x20 => blk: {
+            const cancellable = (try reader.readByte()) != 0;
+            const memory = try reader.readU32();
+            break :blk .{ .waitable_set_wait = .{ .cancellable = cancellable, .memory = memory } };
+        },
+        0x21 => blk: {
+            const cancellable = (try reader.readByte()) != 0;
+            const memory = try reader.readU32();
+            break :blk .{ .waitable_set_poll = .{ .cancellable = cancellable, .memory = memory } };
+        },
+        0x22 => .waitable_set_drop,
+        0x23 => .waitable_join,
         else => error.InvalidEncoding,
     };
 }
@@ -1332,6 +1345,47 @@ test "round-trip future-family canons + task.return through writer + loader (#26
     try std.testing.expect(loaded.canons[5] == .future_drop_readable);
     try std.testing.expect(loaded.canons[6] == .future_drop_writable);
     try std.testing.expect(loaded.canons[7].task_return.opts[0] == .async_);
+}
+
+test "round-trip waitable-set/waitable canons through writer + loader (#265)" {
+    const writer = @import("writer.zig");
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // Distinguishing field values catch a writer/loader field-order bug:
+    // `wait` is cancellable with memory 0, `poll` is non-cancellable with
+    // memory 0 — a swapped (memory, cancellable) order would not round-trip.
+    const canons = [_]ctypes.Canon{
+        .waitable_set_new,
+        .{ .waitable_set_wait = .{ .cancellable = true, .memory = 0 } },
+        .{ .waitable_set_poll = .{ .cancellable = false, .memory = 0 } },
+        .waitable_set_drop,
+        .waitable_join,
+    };
+    const component: ctypes.Component = .{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &canons,
+        .imports = &.{},
+        .exports = &.{},
+        .custom_sections = &.{},
+    };
+    const bytes = try writer.encode(ar, &component);
+    const loaded = try load(bytes, ar);
+
+    try std.testing.expectEqual(@as(usize, 5), loaded.canons.len);
+    try std.testing.expect(loaded.canons[0] == .waitable_set_new);
+    try std.testing.expect(loaded.canons[1].waitable_set_wait.cancellable);
+    try std.testing.expectEqual(@as(u32, 0), loaded.canons[1].waitable_set_wait.memory);
+    try std.testing.expect(!loaded.canons[2].waitable_set_poll.cancellable);
+    try std.testing.expect(loaded.canons[3] == .waitable_set_drop);
+    try std.testing.expect(loaded.canons[4] == .waitable_join);
 }
 
 test "round-trip stream-family + error-context canons through writer + loader (#263)" {

--- a/src/component/types.zig
+++ b/src/component/types.zig
@@ -363,6 +363,14 @@ pub const CanonTaskReturn = struct {
     opts: []const CanonOpt,
 };
 
+/// `{ cancellable, memory }` payload for `waitable-set.wait`/`.poll`.
+/// Note: the binary form carries `memory` as a bare u32 index (not the
+/// canon-opts list used by stream/future read/write).
+pub const CanonWaitableSet = struct {
+    cancellable: bool,
+    memory: u32,
+};
+
 /// Canonical function definitions.
 pub const Canon = union(enum) {
     /// Lift a core function to a component function.
@@ -420,6 +428,16 @@ pub const Canon = union(enum) {
     error_context_drop,
     /// `task.return <results> <opts>` (binary `0x09`).
     task_return: CanonTaskReturn,
+    /// `waitable-set.new` (binary `0x1f`).
+    waitable_set_new,
+    /// `waitable-set.wait <cancellable> <memory>` (binary `0x20`).
+    waitable_set_wait: CanonWaitableSet,
+    /// `waitable-set.poll <cancellable> <memory>` (binary `0x21`).
+    waitable_set_poll: CanonWaitableSet,
+    /// `waitable-set.drop` (binary `0x22`).
+    waitable_set_drop,
+    /// `waitable.join` (binary `0x23`).
+    waitable_join,
 };
 
 // ── Imports and exports ─────────────────────────────────────────────────────

--- a/src/component/writer.zig
+++ b/src/component/writer.zig
@@ -676,6 +676,19 @@ fn writeCanon(w: *Writer, c: ctypes.Canon) EncodeError!void {
             try writeResultList(w, t.results);
             try writeCanonOpts(w, t.opts);
         },
+        .waitable_set_new => try w.appendByte(0x1F),
+        .waitable_set_wait => |ws| {
+            try w.appendByte(0x20);
+            try w.appendByte(if (ws.cancellable) 0x01 else 0x00);
+            try w.writeU32Leb(ws.memory);
+        },
+        .waitable_set_poll => |ws| {
+            try w.appendByte(0x21);
+            try w.appendByte(if (ws.cancellable) 0x01 else 0x00);
+            try w.writeU32Leb(ws.memory);
+        },
+        .waitable_set_drop => try w.appendByte(0x22),
+        .waitable_join => try w.appendByte(0x23),
     }
 }
 

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -1265,6 +1265,9 @@ fn coreNeedsAsyncMemOpShim(ar: std.mem.Allocator, core_bytes: []const u8) bool {
             if (std.mem.startsWith(u8, im.module_name, "[future]") and
                 (std.mem.eql(u8, im.field_name, "read") or std.mem.eql(u8, im.field_name, "write")))
                 return true;
+            if (std.mem.startsWith(u8, im.module_name, "[waitable-set]") and
+                (std.mem.eql(u8, im.field_name, "wait") or std.mem.eql(u8, im.field_name, "poll")))
+                return true;
             if (std.mem.eql(u8, im.module_name, "[error-context]") and
                 (std.mem.eql(u8, im.field_name, "new") or std.mem.eql(u8, im.field_name, "debug-message")))
                 return true;
@@ -1891,9 +1894,32 @@ pub fn buildComponent(alloc: std.mem.Allocator, core_bytes: []const u8) ![]u8 {
                     try bundle_exports.append(ar, .{ .name = field, .sort_idx = .{ .sort = .func, .idx = core_func_idx } });
                     core_func_idx += 1;
                 }
+            } else if (std.mem.startsWith(u8, grp.module, "[waitable-set]")) {
+                // `new` / `drop` are no-memory; `wait`/`poll` need
+                // `(memory)` opts and so only reach the shim/fixup path.
+                for (grp.fields.items) |field| {
+                    const canon: ctypes.Canon = if (std.mem.eql(u8, field, "new"))
+                        .waitable_set_new
+                    else if (std.mem.eql(u8, field, "drop"))
+                        .waitable_set_drop
+                    else
+                        return error.UnsupportedAsyncIntrinsic;
+                    try canons.append(ar, canon);
+                    try order.append(ar, .{ .kind = .canon, .start = @intCast(canons.items.len - 1), .count = 1 });
+                    try bundle_exports.append(ar, .{ .name = field, .sort_idx = .{ .sort = .func, .idx = core_func_idx } });
+                    core_func_idx += 1;
+                }
+            } else if (std.mem.startsWith(u8, grp.module, "[waitable]")) {
+                for (grp.fields.items) |field| {
+                    if (!std.mem.eql(u8, field, "join")) return error.UnsupportedAsyncIntrinsic;
+                    try canons.append(ar, .waitable_join);
+                    try order.append(ar, .{ .kind = .canon, .start = @intCast(canons.items.len - 1), .count = 1 });
+                    try bundle_exports.append(ar, .{ .name = field, .sort_idx = .{ .sort = .func, .idx = core_func_idx } });
+                    core_func_idx += 1;
+                }
             } else {
-                // `[error-context]` / `[waitable-set]` / `[waitable]`: not
-                // yet wired here (memory opts / IR work).
+                // `[error-context]` (always needs the shim path for its
+                // memory ops): not wired in this no-shim path.
                 return error.UnsupportedAsyncIntrinsic;
             }
 
@@ -2427,7 +2453,7 @@ fn buildComponentShimFixup(
         mem_op_slot: u32 = 0,
         satisfy_core_idx: u32 = 0,
     };
-    const AsyncFamily = enum { task_return, stream, future, error_context };
+    const AsyncFamily = enum { task_return, stream, future, error_context, waitable_set, waitable };
     const AsyncGroup = struct {
         module: []const u8,
         family: AsyncFamily,
@@ -2536,6 +2562,39 @@ fn buildComponentShimFixup(
                 try async_group_list.append(ar, .{
                     .module = module,
                     .family = .error_context,
+                    .elem = .u8,
+                    .export_ref = "",
+                    .fields = fields,
+                });
+            } else if (std.mem.startsWith(u8, module, "[waitable-set]")) {
+                for (fsrc, 0..) |f, k| {
+                    // wait/poll write an event payload to a retptr → mem-op;
+                    // new/drop are no-memory.
+                    const mem_op = std.mem.eql(u8, f, "wait") or std.mem.eql(u8, f, "poll");
+                    const no_mem = std.mem.eql(u8, f, "new") or std.mem.eql(u8, f, "drop");
+                    if (!mem_op and !no_mem) return error.UnsupportedAsyncIntrinsic;
+                    fields[k] = .{ .name = f, .is_mem_op = mem_op };
+                    if (mem_op) {
+                        fields[k].mem_op_slot = @intCast(async_memop_slots.items.len);
+                        // waitable-set.wait/poll lower to (set, event-ptr)->i32.
+                        try async_memop_slots.append(ar, .{ .params = &i32x2_params, .results = &i32_results });
+                    }
+                }
+                try async_group_list.append(ar, .{
+                    .module = module,
+                    .family = .waitable_set,
+                    .elem = .u8,
+                    .export_ref = "",
+                    .fields = fields,
+                });
+            } else if (std.mem.startsWith(u8, module, "[waitable]")) {
+                for (fsrc, 0..) |f, k| {
+                    if (!std.mem.eql(u8, f, "join")) return error.UnsupportedAsyncIntrinsic;
+                    fields[k] = .{ .name = f, .is_mem_op = false };
+                }
+                try async_group_list.append(ar, .{
+                    .module = module,
+                    .family = .waitable,
                     .elem = .u8,
                     .export_ref = "",
                     .fields = fields,
@@ -2997,6 +3056,32 @@ fn buildComponentShimFixup(
                     core_func_idx += 1;
                 }
             },
+            .waitable_set => {
+                for (grp.fields) |*field| {
+                    if (field.is_mem_op) {
+                        field.satisfy_core_idx = async_memop_stub_core_base + field.mem_op_slot;
+                        continue;
+                    }
+                    // `new` / `drop` are no-memory; `wait`/`poll` are mem-op.
+                    const canon: ctypes.Canon = if (std.mem.eql(u8, field.name, "new"))
+                        .waitable_set_new
+                    else
+                        .waitable_set_drop;
+                    try canons.append(ar, canon);
+                    try order.append(ar, .{ .kind = .canon, .start = @intCast(canons.items.len - 1), .count = 1 });
+                    field.satisfy_core_idx = core_func_idx;
+                    core_func_idx += 1;
+                }
+            },
+            .waitable => {
+                for (grp.fields) |*field| {
+                    // only `join`, no-memory.
+                    try canons.append(ar, .waitable_join);
+                    try order.append(ar, .{ .kind = .canon, .start = @intCast(canons.items.len - 1), .count = 1 });
+                    field.satisfy_core_idx = core_func_idx;
+                    core_func_idx += 1;
+                }
+            },
             .error_context => {
                 for (grp.fields) |*field| {
                     if (field.is_mem_op) {
@@ -3220,6 +3305,13 @@ fn buildComponentShimFixup(
                         else
                             .{ .error_context_debug_message = opts };
                     },
+                    .waitable_set => if (std.mem.eql(u8, field.name, "poll"))
+                        // wait/poll carry a bare memory index (not a CanonOpt
+                        // list); cancellable=false for a plain blocking wait.
+                        .{ .waitable_set_poll = .{ .cancellable = false, .memory = memory_core_idx } }
+                    else
+                        .{ .waitable_set_wait = .{ .cancellable = false, .memory = memory_core_idx } },
+                    .waitable => unreachable, // waitable.join is never mem-op
                     .task_return => unreachable, // task.return is never mem-op
                 };
                 try canons.append(ar, canon);
@@ -5758,6 +5850,74 @@ test "buildComponent #263: error-context.new routes through shim/fixup; drop dir
     // one error-context.new + one error-context.drop.
     try testing.expectEqual(@as(usize, 2), countErrorContextCanons(loaded));
     try testing.expect(mainWithArgFor(loaded, "[error-context]"));
+}
+
+fn countWaitableCanons(loaded: anytype) usize {
+    var n: usize = 0;
+    for (loaded.canons) |c| switch (c) {
+        .waitable_set_new, .waitable_set_wait, .waitable_set_poll, .waitable_set_drop, .waitable_join => n += 1,
+        else => {},
+    };
+    return n;
+}
+
+fn countWaitableSetWait(loaded: anytype) usize {
+    var n: usize = 0;
+    for (loaded.canons) |c| switch (c) {
+        .waitable_set_wait => n += 1,
+        else => {},
+    };
+    return n;
+}
+
+test "buildComponent #265: [waitable-set] new/wait/drop + [waitable] join wires canons" {
+    // Awaiting an async op: `waitable-set.new`/`.drop` and `waitable.join`
+    // are no-memory direct canons; `waitable-set.wait` writes an event to a
+    // retptr ⇒ memory-opt ⇒ shim/fixup. The component must have 3 core
+    // modules (main + shim + fixup), all four waitable canons, and the
+    // `[waitable-set]`/`[waitable]` bundles fed to main.
+    const wit =
+        \\package local:p@0.1.0;
+        \\
+        \\interface run {
+        \\    run: async func() -> result;
+        \\}
+        \\
+        \\world hello {
+        \\    export run;
+        \\}
+    ;
+    const wat =
+        \\(module
+        \\  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+        \\  (import "[waitable-set]" "new" (func (result i32)))
+        \\  (import "[waitable-set]" "wait" (func (param i32 i32) (result i32)))
+        \\  (import "[waitable-set]" "drop" (func (param i32)))
+        \\  (import "[waitable]" "join" (func (param i32 i32)))
+        \\  (memory (export "memory") 1)
+        \\  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+        \\  (func (export "local:p/run@0.1.0#run"))
+        \\)
+    ;
+    const core = try buildCoreFromWat(testing.allocator, wat, wit, "hello");
+    defer testing.allocator.free(core);
+
+    const comp_bytes = try buildComponent(testing.allocator, core);
+    defer testing.allocator.free(comp_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const loaded = try loader.load(comp_bytes, arena.allocator());
+
+    // main + shim + fixup (waitable-set.wait is memory-opt).
+    try testing.expectEqual(@as(usize, 3), loaded.core_modules.len);
+    // new + wait + drop + join.
+    try testing.expectEqual(@as(usize, 4), countWaitableCanons(loaded));
+    try testing.expectEqual(@as(usize, 1), countWaitableSetWait(loaded));
+    try testing.expect(mainWithArgFor(loaded, "[waitable-set]"));
+    try testing.expect(mainWithArgFor(loaded, "[waitable]"));
+    try testing.expect(bundleExportsFunc(loaded, "wait"));
+    try testing.expect(bundleExportsFunc(loaded, "join"));
 }
 
 test "buildComponent #248: drop-only namespace wires canon resource.drop into the bundle" {


### PR DESCRIPTION
## Summary

Follow-up to #263/#264 (both merged). Adds the component-model-async **awaiting** built-ins — `waitable-set` and `waitable` — to the Canon IR and wires them in `component new`, so a guest can block on a waitable-set until an async future/stream/subtask op makes progress.

## Two commits

**1. IR** (`types.zig` / `writer.zig` / `loader.zig` / `adapter.zig`)
- New `Canon` variants: `waitable_set_new` (0x1f), `waitable_set_wait` (0x20), `waitable_set_poll` (0x21), `waitable_set_drop` (0x22), `waitable_join` (0x23); `CanonWaitableSet { cancellable, memory }`.
- `wait`/`poll` encode a `cancellable` byte followed by a **bare u32 memory index** (not the canon-opts list used by stream/future read/write), matching wasmparser 0.251 (wasmtime 46). Covered by a writer↔loader round-trip test using distinguishing field values to catch a field-order regression.

**2. Wiring** (`component_new.zig`)
- `[waitable-set]` new/drop and `[waitable]` join are no-memory direct canons; `[waitable-set]` wait/poll write an event payload to a retptr ⇒ memory-opt ⇒ shim/fixup (lowered `(set, event-ptr)->i32`).
- Extends the same six sites as the future family: `coreNeedsAsyncMemOpShim`, `AsyncFamily`, the analysis grouping, the no-shim path, the family switch, and the mem-op real-canon dispatch.

## Testing
- `zig build test` Debug + ReleaseSafe: **601/601 pass** (IR round-trip + a `[waitable-set]`/`[waitable]` wiring test).
- `wabt component new` emits components using all five waitable canons; wasmtime 46 **validates** them (`wasmtime compile` under `-W component-model-async -W component-model-async-stackful -W component-model-more-async-builtins -W component-model-error-context`).
- A `wasi:cli/run@0.3.0` command exercising `waitable-set.new` / `poll` (mem-op shim) / `drop` **runs to exit 0** on wasmtime 46.
- An await component (`stream.write` + `waitable.join` + `waitable-set.wait` + drops) builds, validates, and **executes the intrinsics** at runtime. Driving a single hand-written guest task all the way to clean blocking-completion needs a host stream consumer / fuller async choreography, which is guest-application logic beyond the generator's scope; the canon wiring itself is accepted and executed by wasmtime.

Closes #265.