### PR TITLE
component: add remaining P3 async canon built-ins (subtask.*, task.cancel, backpressure.*, context.*) (#267)

### DIFF
--- a/src/component/adapter/adapter.zig
+++ b/src/component/adapter/adapter.zig
@@ -1156,7 +1156,7 @@ const Builder = struct {
                 self.func_cursor += 1;
                 return i;
             },
-            .lower, .resource_drop, .resource_new, .resource_rep, .future_new, .future_read, .future_write, .future_cancel_read, .future_cancel_write, .future_drop_readable, .future_drop_writable, .stream_new, .stream_read, .stream_write, .stream_cancel_read, .stream_cancel_write, .stream_drop_readable, .stream_drop_writable, .error_context_new, .error_context_debug_message, .error_context_drop, .task_return, .waitable_set_new, .waitable_set_wait, .waitable_set_poll, .waitable_set_drop, .waitable_join => {
+            .lower, .resource_drop, .resource_new, .resource_rep, .future_new, .future_read, .future_write, .future_cancel_read, .future_cancel_write, .future_drop_readable, .future_drop_writable, .stream_new, .stream_read, .stream_write, .stream_cancel_read, .stream_cancel_write, .stream_drop_readable, .stream_drop_writable, .error_context_new, .error_context_debug_message, .error_context_drop, .task_return, .waitable_set_new, .waitable_set_wait, .waitable_set_poll, .waitable_set_drop, .waitable_join, .task_cancel, .subtask_cancel, .subtask_drop, .context_get, .context_set, .backpressure_inc, .backpressure_dec => {
                 const i = self.core_func_cursor;
                 self.core_func_cursor += 1;
                 return i;

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -256,7 +256,7 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
                     // Every canon kind except `.lift` contributes a slot
                     // to the core-func indexspace.
                     const contributes = switch (c) {
-                        .lower, .resource_drop, .resource_new, .resource_rep, .future_new, .future_read, .future_write, .future_cancel_read, .future_cancel_write, .future_drop_readable, .future_drop_writable, .stream_new, .stream_read, .stream_write, .stream_cancel_read, .stream_cancel_write, .stream_drop_readable, .stream_drop_writable, .error_context_new, .error_context_debug_message, .error_context_drop, .task_return, .waitable_set_new, .waitable_set_wait, .waitable_set_poll, .waitable_set_drop, .waitable_join => true,
+                        .lower, .resource_drop, .resource_new, .resource_rep, .future_new, .future_read, .future_write, .future_cancel_read, .future_cancel_write, .future_drop_readable, .future_drop_writable, .stream_new, .stream_read, .stream_write, .stream_cancel_read, .stream_cancel_write, .stream_drop_readable, .stream_drop_writable, .error_context_new, .error_context_debug_message, .error_context_drop, .task_return, .waitable_set_new, .waitable_set_wait, .waitable_set_poll, .waitable_set_drop, .waitable_join, .task_cancel, .subtask_cancel, .subtask_drop, .context_get, .context_set, .backpressure_inc, .backpressure_dec => true,
                         .lift => false,
                     };
                     if (contributes) try core_func_indexspace.append(allocator, .{ .canon = local_idx });
@@ -790,6 +790,21 @@ fn parseCanon(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!cty
         },
         0x22 => .waitable_set_drop,
         0x23 => .waitable_join,
+        0x05 => .task_cancel,
+        0x06 => .{ .subtask_cancel = (try reader.readByte()) != 0 },
+        0x0D => .subtask_drop,
+        0x0A => blk: {
+            const ty = try readCoreValType(reader);
+            const slot = try reader.readU32();
+            break :blk .{ .context_get = .{ .ty = ty, .slot = slot } };
+        },
+        0x0B => blk: {
+            const ty = try readCoreValType(reader);
+            const slot = try reader.readU32();
+            break :blk .{ .context_set = .{ .ty = ty, .slot = slot } };
+        },
+        0x24 => .backpressure_inc,
+        0x25 => .backpressure_dec,
         else => error.InvalidEncoding,
     };
 }
@@ -1386,6 +1401,54 @@ test "round-trip waitable-set/waitable canons through writer + loader (#265)" {
     try std.testing.expect(!loaded.canons[2].waitable_set_poll.cancellable);
     try std.testing.expect(loaded.canons[3] == .waitable_set_drop);
     try std.testing.expect(loaded.canons[4] == .waitable_join);
+}
+
+test "round-trip subtask/task-cancel/backpressure/context canons through writer + loader (#267)" {
+    const writer = @import("writer.zig");
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // Distinguishing payloads catch field-order / operand bugs: the two
+    // `context.*` canons carry different (ty, slot) pairs, and
+    // `subtask.cancel` carries an async? flag.
+    const canons = [_]ctypes.Canon{
+        .task_cancel,
+        .{ .subtask_cancel = true },
+        .subtask_drop,
+        .{ .context_get = .{ .ty = .i32, .slot = 0 } },
+        .{ .context_set = .{ .ty = .i64, .slot = 3 } },
+        .backpressure_inc,
+        .backpressure_dec,
+    };
+    const component: ctypes.Component = .{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &canons,
+        .imports = &.{},
+        .exports = &.{},
+        .custom_sections = &.{},
+    };
+    const bytes = try writer.encode(ar, &component);
+    const loaded = try load(bytes, ar);
+
+    try std.testing.expectEqual(@as(usize, 7), loaded.canons.len);
+    try std.testing.expect(loaded.canons[0] == .task_cancel);
+    try std.testing.expect(loaded.canons[1].subtask_cancel);
+    try std.testing.expect(loaded.canons[2] == .subtask_drop);
+    try std.testing.expect(loaded.canons[3] == .context_get);
+    try std.testing.expectEqual(ctypes.CoreValType.i32, loaded.canons[3].context_get.ty);
+    try std.testing.expectEqual(@as(u32, 0), loaded.canons[3].context_get.slot);
+    try std.testing.expect(loaded.canons[4] == .context_set);
+    try std.testing.expectEqual(ctypes.CoreValType.i64, loaded.canons[4].context_set.ty);
+    try std.testing.expectEqual(@as(u32, 3), loaded.canons[4].context_set.slot);
+    try std.testing.expect(loaded.canons[5] == .backpressure_inc);
+    try std.testing.expect(loaded.canons[6] == .backpressure_dec);
 }
 
 test "round-trip stream-family + error-context canons through writer + loader (#263)" {

--- a/src/component/types.zig
+++ b/src/component/types.zig
@@ -371,6 +371,14 @@ pub const CanonWaitableSet = struct {
     memory: u32,
 };
 
+/// `{ ty, slot }` payload for `context.get` / `context.set`. `ty` is the
+/// core valtype of the task-local storage slot (the component-model
+/// validator currently accepts `i32`/`i64`); `slot` is the slot index.
+pub const CanonContext = struct {
+    ty: CoreValType,
+    slot: u32,
+};
+
 /// Canonical function definitions.
 pub const Canon = union(enum) {
     /// Lift a core function to a component function.
@@ -438,6 +446,20 @@ pub const Canon = union(enum) {
     waitable_set_drop,
     /// `waitable.join` (binary `0x23`).
     waitable_join,
+    /// `task.cancel` (binary `0x05`).
+    task_cancel,
+    /// `subtask.cancel <async?>` (binary `0x06`).
+    subtask_cancel: bool,
+    /// `subtask.drop` (binary `0x0d`).
+    subtask_drop,
+    /// `context.get <ty> <slot>` (binary `0x0a`).
+    context_get: CanonContext,
+    /// `context.set <ty> <slot>` (binary `0x0b`).
+    context_set: CanonContext,
+    /// `backpressure.inc` (binary `0x24`).
+    backpressure_inc,
+    /// `backpressure.dec` (binary `0x25`).
+    backpressure_dec,
 };
 
 // ── Imports and exports ─────────────────────────────────────────────────────

--- a/src/component/writer.zig
+++ b/src/component/writer.zig
@@ -689,6 +689,24 @@ fn writeCanon(w: *Writer, c: ctypes.Canon) EncodeError!void {
         },
         .waitable_set_drop => try w.appendByte(0x22),
         .waitable_join => try w.appendByte(0x23),
+        .task_cancel => try w.appendByte(0x05),
+        .subtask_cancel => |is_async| {
+            try w.appendByte(0x06);
+            try w.appendByte(if (is_async) 0x01 else 0x00);
+        },
+        .subtask_drop => try w.appendByte(0x0D),
+        .context_get => |cx| {
+            try w.appendByte(0x0A);
+            try w.appendByte(@intFromEnum(cx.ty));
+            try w.writeU32Leb(cx.slot);
+        },
+        .context_set => |cx| {
+            try w.appendByte(0x0B);
+            try w.appendByte(@intFromEnum(cx.ty));
+            try w.writeU32Leb(cx.slot);
+        },
+        .backpressure_inc => try w.appendByte(0x24),
+        .backpressure_dec => try w.appendByte(0x25),
     }
 }
 


### PR DESCRIPTION
Part of #267 (Phase 1 of 3). Does **not** close the issue — Phase 2 (demand-driven `component new` wiring) and Phase 3 (P4 wasm32-wasip3 conformance) remain.

Follow-up to #263 / #265. Adds the remaining demand-driven component-model-async canonical built-ins to the `Canon` IR with byte + round-trip coverage, mirroring how #265 landed waitable-set / waitable.

## Built-ins added (opcodes verified against wasmparser 0.251 = wasmtime 46)

| Built-in | Byte | Operands |
|---|---|---|
| `task.cancel` | 0x05 | none |
| `subtask.cancel` | 0x06 | `async?` bool |
| `subtask.drop` | 0x0d | none |
| `context.get` | 0x0a | core valtype + `slot` u32 |
| `context.set` | 0x0b | core valtype + `slot` u32 |
| `backpressure.inc` | 0x24 | none |
| `backpressure.dec` | 0x25 | none |

## Changes
- `types.zig`: 7 `Canon` variants + `CanonContext { ty, slot }`.
- `writer.zig` / `loader.zig`: encode + decode for each.
- Registered all 7 as core-func-indexspace contributors in the loader (`loader.zig:259`) and adapter (`adapter.zig`) index trackers.
- New writer→loader round-trip test covering all seven.

## Verification
`zig build test --summary all` → 71/71 steps, 609/609 tests passed.

## Out of scope (tracked under #267)
- `component new` guest wiring stays **demand-driven** — wired per built-in only when a real guest needs it, each tied to a wasmtime-46-validated fixture.
- P4 `wasm32-wasip3` conformance gates / rollout flag — separate effort.



