### PR TITLE
tests: add WASI Preview 3 conformance gate (zig build p3-conformance) (#267)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -368,6 +368,31 @@ pub fn build(b: *std.Build) void {
             test_step.dependOn(&dash_help.step);
         }
     }
+
+    // ── WASI Preview 3 conformance gate (#267 Phase 3) ────────────────
+    // wabt is a toolkit, not a runtime: this gate drives the hand-authored
+    // `tests/p3/*.wat` guests through `wabt component new`, then validates
+    // each produced component on upstream Wasmtime (resolved from the
+    // `WASMTIME` env var; needs P3 feature flags, e.g. wasmtime >= 46). Not
+    // wired into the default `test` aggregate — it requires Python 3 + an
+    // external Wasmtime, and skips cleanly when none is found. CI gates
+    // regressions in a follow-up. Run locally with `zig build p3-conformance`
+    // (optionally `WASMTIME=/path/to/wasmtime`).
+    const p3_runner = b.addSystemCommand(&.{
+        "python3",
+        "scripts/p3_conformance.py",
+        "--fixtures",
+        "tests/p3",
+        "--skip",
+        "tests/p3-conformance-skip.json",
+        "--wabt",
+    });
+    p3_runner.addArtifactArg(wabt_exe);
+    const p3_step = b.step(
+        "p3-conformance",
+        "Validate wabt-produced P3 components against Wasmtime (set WASMTIME)",
+    );
+    p3_step.dependOn(&p3_runner.step);
 }
 
 /// Adapter shape selector used by `buildAdapterArtifact` to pick

--- a/scripts/p3_conformance.py
+++ b/scripts/p3_conformance.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""WASI Preview 3 (component-model-async) conformance gate for wabt.
+
+wabt is a *toolkit*: it produces components, it does not run them. So this
+gate validates that the components wabt produces from P3 guest fixtures are
+accepted by upstream Wasmtime. For each `tests/p3/<name>.wat` fixture it runs:
+
+    wabt text parse   <name>.wat        -> core.wasm
+    wabt component embed -w <world> world.wit core.wasm -> embed.wasm
+    wabt component new  embed.wasm      -> component.wasm
+    wasmtime compile  <p3 flags> component.wasm
+
+A fixture passes when every step exits 0 (i.e. Wasmtime accepts the encoding).
+
+The Wasmtime binary is resolved from the ``WASMTIME`` environment variable,
+falling back to ``wasmtime`` on ``PATH`` (same convention as the wamr P3
+parity gate). When no usable Wasmtime is found the gate prints a notice and
+exits 0 (skipped) unless ``--require-wasmtime`` is passed (set by CI).
+
+Skip-list entries (``tests/p3-conformance-skip.json``) must each carry a
+rationale + tracking issue, mirroring wamr's ``wasi-p3-testsuite-skip.json``.
+
+Run via ``zig build p3-conformance`` (preferred) or directly:
+
+    python3 scripts/p3_conformance.py --wabt <path-to-wabt> --fixtures tests/p3
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Wasmtime feature flags required to validate the full P3 built-in surface
+# that wabt emits (async lift, stream/future, error-context, the async
+# control/context built-ins). Verified against wasmtime 46.0.0.
+WASMTIME_FLAGS = [
+    "-W", "component-model-async",
+    "-W", "component-model-async-stackful",
+    "-W", "component-model-more-async-builtins",
+    "-W", "component-model-error-context",
+]
+
+# The shared world exported by every fixture (see tests/p3/world.wit).
+WORLD = "hello"
+
+
+def run(cmd: list[str]) -> tuple[int, str]:
+    """Run a command, returning (exit_code, combined_output)."""
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def resolve_wasmtime() -> str | None:
+    cand = os.environ.get("WASMTIME") or "wasmtime"
+    found = shutil.which(cand) or (cand if os.path.isfile(cand) else None)
+    if not found:
+        return None
+    code, _ = run([found, "--version"])
+    return found if code == 0 else None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="wabt WASI Preview 3 conformance gate")
+    ap.add_argument("--wabt", default="wabt", help="path to the wabt CLI binary")
+    ap.add_argument("--fixtures", default="tests/p3", help="directory of <name>.wat fixtures")
+    ap.add_argument("--skip", default="tests/p3-conformance-skip.json", help="skip-list JSON")
+    ap.add_argument("--require-wasmtime", action="store_true",
+                    help="fail (not skip) when no usable Wasmtime is found (CI)")
+    args = ap.parse_args()
+
+    fixtures_dir = Path(args.fixtures)
+    world_wit = fixtures_dir / "world.wit"
+    if not world_wit.is_file():
+        print(f"error: shared world WIT not found: {world_wit}", file=sys.stderr)
+        return 2
+
+    skip: dict[str, str] = {}
+    skip_path = Path(args.skip)
+    if skip_path.is_file():
+        data = json.loads(skip_path.read_text())
+        skip = {k: v for k, v in data.items() if not k.startswith("_")}
+
+    wasmtime = resolve_wasmtime()
+    if wasmtime is None:
+        msg = ("no usable Wasmtime found (set WASMTIME or put `wasmtime` on PATH; "
+               "needs P3 feature flags, e.g. wasmtime >= 46)")
+        if args.require_wasmtime:
+            print(f"error: {msg}", file=sys.stderr)
+            return 2
+        print(f"notice: p3-conformance skipped - {msg}")
+        return 0
+
+    fixtures = sorted(fixtures_dir.glob("*.wat"))
+    if not fixtures:
+        print(f"error: no .wat fixtures under {fixtures_dir}", file=sys.stderr)
+        return 2
+
+    passed: list[str] = []
+    skipped: list[str] = []
+    failed: list[tuple[str, str]] = []
+
+    print(f"p3-conformance: wabt={args.wabt} wasmtime={wasmtime}")
+    for wat in fixtures:
+        name = wat.stem
+        if name in skip:
+            skipped.append(name)
+            print(f"  SKIP {name:20s} - {skip[name]}")
+            continue
+        with tempfile.TemporaryDirectory(prefix=f"p3-{name}-") as td:
+            tmp = Path(td)
+            core = tmp / "core.wasm"
+            embed = tmp / "embed.wasm"
+            comp = tmp / "component.wasm"
+            cwasm = tmp / "component.cwasm"
+            steps = [
+                [args.wabt, "text", "parse", str(wat), "-o", str(core)],
+                [args.wabt, "component", "embed", "-w", WORLD, str(world_wit), str(core), "-o", str(embed)],
+                [args.wabt, "component", "new", str(embed), "-o", str(comp)],
+                [wasmtime, "compile", *WASMTIME_FLAGS, str(comp), "-o", str(cwasm)],
+            ]
+            err = None
+            for cmd in steps:
+                code, out = run(cmd)
+                if code != 0:
+                    err = f"`{' '.join(Path(c).name if i == 0 else c for i, c in enumerate(cmd))}` exited {code}\n{out.strip()}"
+                    break
+            if err:
+                failed.append((name, err))
+                print(f"  FAIL {name}")
+            else:
+                passed.append(name)
+                print(f"  PASS {name}")
+
+    print(f"\np3-conformance: {len(passed)} passed, {len(skipped)} skipped, {len(failed)} failed")
+    for name, err in failed:
+        print(f"\n--- {name} ---\n{err}", file=sys.stderr)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/p3-conformance-skip.json
+++ b/tests/p3-conformance-skip.json
@@ -1,0 +1,3 @@
+{
+    "_comment": "Skip-list for `zig build p3-conformance` (scripts/p3_conformance.py). Keys are tests/p3/<name> fixture stems; each value MUST be a rationale ending in a tracking issue (e.g. '... (#NNN)'). Empty = every fixture is expected to validate on the pinned Wasmtime. Mirrors wamr's tests/wasi-p3-testsuite-skip.json convention."
+}

--- a/tests/p3/async-task-return.wat
+++ b/tests/p3/async-task-return.wat
@@ -1,0 +1,7 @@
+;; Async lift + task.return: the minimal P3 async export shape.
+(module
+  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+  (memory (export "memory") 1)
+  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+  (func (export "local:p/run@0.1.0#run") (call 0 (i32.const 0)))
+)

--- a/tests/p3/backpressure.wat
+++ b/tests/p3/backpressure.wat
@@ -1,0 +1,9 @@
+;; backpressure.inc / backpressure.dec: no-memory flow-control built-ins.
+(module
+  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+  (import "[backpressure]" "inc" (func))
+  (import "[backpressure]" "dec" (func))
+  (memory (export "memory") 1)
+  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+  (func (export "local:p/run@0.1.0#run") (call 0 (i32.const 0)))
+)

--- a/tests/p3/error-context.wat
+++ b/tests/p3/error-context.wat
@@ -1,0 +1,9 @@
+;; error-context: new (memory-opt, shim/fixup) + drop (no-memory, direct).
+(module
+  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+  (import "[error-context]" "new" (func (param i32 i32) (result i32)))
+  (import "[error-context]" "drop" (func (param i32)))
+  (memory (export "memory") 1)
+  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+  (func (export "local:p/run@0.1.0#run"))
+)

--- a/tests/p3/future.wat
+++ b/tests/p3/future.wat
@@ -1,0 +1,10 @@
+;; future<u8>: no-memory future.new / drop-readable / drop-writable.
+(module
+  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+  (import "[future]future<u8>" "new" (func (result i64)))
+  (import "[future]future<u8>" "drop-readable" (func (param i32)))
+  (import "[future]future<u8>" "drop-writable" (func (param i32)))
+  (memory (export "memory") 1)
+  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+  (func (export "local:p/run@0.1.0#run"))
+)

--- a/tests/p3/stream-write.wat
+++ b/tests/p3/stream-write.wat
@@ -1,0 +1,10 @@
+;; stream.write: memory-opt intrinsic that routes through the shim/fixup path.
+(module
+  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+  (import "[stream]stream<u8>" "new" (func (result i64)))
+  (import "[stream]stream<u8>" "write" (func (param i32 i32 i32) (result i32)))
+  (import "[stream]stream<u8>" "drop-writable" (func (param i32)))
+  (memory (export "memory") 1)
+  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+  (func (export "local:p/run@0.1.0#run"))
+)

--- a/tests/p3/stream.wat
+++ b/tests/p3/stream.wat
@@ -1,0 +1,10 @@
+;; stream<u8>: no-memory stream.new / drop-readable / drop-writable.
+(module
+  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+  (import "[stream]stream<u8>" "new" (func (result i64)))
+  (import "[stream]stream<u8>" "drop-readable" (func (param i32)))
+  (import "[stream]stream<u8>" "drop-writable" (func (param i32)))
+  (memory (export "memory") 1)
+  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+  (func (export "local:p/run@0.1.0#run"))
+)

--- a/tests/p3/subtask-context.wat
+++ b/tests/p3/subtask-context.wat
@@ -1,0 +1,11 @@
+;; subtask.cancel (sync + async) + context.get / context.set (i32 slot 0).
+(module
+  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+  (import "[subtask]" "cancel" (func (param i32) (result i32)))
+  (import "[subtask]" "cancel-async" (func (param i32) (result i32)))
+  (import "[context]" "get-i32-0" (func (result i32)))
+  (import "[context]" "set-i32-0" (func (param i32)))
+  (memory (export "memory") 1)
+  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+  (func (export "local:p/run@0.1.0#run") (call 0 (i32.const 0)))
+)

--- a/tests/p3/task-cancel.wat
+++ b/tests/p3/task-cancel.wat
@@ -1,0 +1,8 @@
+;; task.cancel: no-memory cancellation built-in.
+(module
+  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+  (import "[task]" "cancel" (func))
+  (memory (export "memory") 1)
+  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+  (func (export "local:p/run@0.1.0#run") (call 0 (i32.const 0)))
+)

--- a/tests/p3/waitable.wat
+++ b/tests/p3/waitable.wat
@@ -1,0 +1,11 @@
+;; waitable-set new/wait/drop (wait is memory-opt) + waitable.join.
+(module
+  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+  (import "[waitable-set]" "new" (func (result i32)))
+  (import "[waitable-set]" "wait" (func (param i32 i32) (result i32)))
+  (import "[waitable-set]" "drop" (func (param i32)))
+  (import "[waitable]" "join" (func (param i32 i32)))
+  (memory (export "memory") 1)
+  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+  (func (export "local:p/run@0.1.0#run"))
+)

--- a/tests/p3/world.wit
+++ b/tests/p3/world.wit
@@ -1,0 +1,9 @@
+package local:p@0.1.0;
+
+interface run {
+    run: async func() -> result;
+}
+
+world hello {
+    export run;
+}


### PR DESCRIPTION
Part of #267 (Phase 3a). Does **not** close the issue — CI wiring + `wasmtime run` validation remain.

## Framing
wabt is a *toolkit*, not a *runtime* — it produces components, it doesn't execute them. So the P3 conformance gate is the analog of wamr's **Wasmtime parity gate**: drive guest fixtures through `wabt component new` and validate each produced component on upstream Wasmtime.

## What's added
- `tests/p3/*.wat` — hand-authored guest cores, one per P3 family landed in #263–#275: async lift + `task.return`, `stream`, `stream.write` (shim), `future`, `error-context`, `waitable-set`/`waitable`, `backpressure`, `task.cancel`, `subtask` (drop + cancel), `context` (get/set) — over a shared `tests/p3/world.wit`.
- `scripts/p3_conformance.py` — per fixture runs `wabt text parse` → `component embed` → `component new` → `wasmtime compile` (with the P3 `-W` feature flags). Resolves Wasmtime from `WASMTIME` (default `wasmtime` on PATH).
- `tests/p3-conformance-skip.json` — rationale + tracking-issue per entry (empty; all fixtures pass).
- `zig build p3-conformance` step.

## Behavior
- **Not** in the default `test` aggregate (needs Python 3 + an external Wasmtime).
- Skips cleanly (exit 0) when no usable Wasmtime is found; `--require-wasmtime` makes it hard-fail (for CI).
- All **9 fixtures pass** on wasmtime 46.0.0 (`-W component-model-async{,-stackful,-more-async-builtins,-error-context}`).
- Default `zig build test` unaffected: 71/71 steps, 613/613 tests.

## Decisions (with maintainer)
- Fixture corpus: hand-authored minimal fixtures (self-contained, no cargo/wit-bindgen).
- **Rollout: P3 stays always-on, no flag** — additive and opt-in by guest imports (a non-P3 guest yields an identical non-P3 component), matching wasm-tools. No code change.

## Follow-ups (tracked under #267)
- CI job (install a pinned Wasmtime ≥46; on-push-to-main + nightly), analog of wamr's `wasi-p3-parity.yml`.
- `wasmtime run` validation for the runnable `wasi:cli/run` fixtures.


