### PR TITLE
component: implement thread.yield (yield, 0x0c) canonical built-in (#278)

### DIFF
--- a/src/component/adapter/adapter.zig
+++ b/src/component/adapter/adapter.zig
@@ -1156,7 +1156,7 @@ const Builder = struct {
                 self.func_cursor += 1;
                 return i;
             },
-            .lower, .resource_drop, .resource_new, .resource_rep, .future_new, .future_read, .future_write, .future_cancel_read, .future_cancel_write, .future_drop_readable, .future_drop_writable, .stream_new, .stream_read, .stream_write, .stream_cancel_read, .stream_cancel_write, .stream_drop_readable, .stream_drop_writable, .error_context_new, .error_context_debug_message, .error_context_drop, .task_return, .waitable_set_new, .waitable_set_wait, .waitable_set_poll, .waitable_set_drop, .waitable_join, .task_cancel, .subtask_cancel, .subtask_drop, .context_get, .context_set, .backpressure_inc, .backpressure_dec => {
+            .lower, .resource_drop, .resource_new, .resource_rep, .future_new, .future_read, .future_write, .future_cancel_read, .future_cancel_write, .future_drop_readable, .future_drop_writable, .stream_new, .stream_read, .stream_write, .stream_cancel_read, .stream_cancel_write, .stream_drop_readable, .stream_drop_writable, .error_context_new, .error_context_debug_message, .error_context_drop, .task_return, .waitable_set_new, .waitable_set_wait, .waitable_set_poll, .waitable_set_drop, .waitable_join, .task_cancel, .subtask_cancel, .subtask_drop, .context_get, .context_set, .backpressure_inc, .backpressure_dec, .thread_yield => {
                 const i = self.core_func_cursor;
                 self.core_func_cursor += 1;
                 return i;

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -256,7 +256,7 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
                     // Every canon kind except `.lift` contributes a slot
                     // to the core-func indexspace.
                     const contributes = switch (c) {
-                        .lower, .resource_drop, .resource_new, .resource_rep, .future_new, .future_read, .future_write, .future_cancel_read, .future_cancel_write, .future_drop_readable, .future_drop_writable, .stream_new, .stream_read, .stream_write, .stream_cancel_read, .stream_cancel_write, .stream_drop_readable, .stream_drop_writable, .error_context_new, .error_context_debug_message, .error_context_drop, .task_return, .waitable_set_new, .waitable_set_wait, .waitable_set_poll, .waitable_set_drop, .waitable_join, .task_cancel, .subtask_cancel, .subtask_drop, .context_get, .context_set, .backpressure_inc, .backpressure_dec => true,
+                        .lower, .resource_drop, .resource_new, .resource_rep, .future_new, .future_read, .future_write, .future_cancel_read, .future_cancel_write, .future_drop_readable, .future_drop_writable, .stream_new, .stream_read, .stream_write, .stream_cancel_read, .stream_cancel_write, .stream_drop_readable, .stream_drop_writable, .error_context_new, .error_context_debug_message, .error_context_drop, .task_return, .waitable_set_new, .waitable_set_wait, .waitable_set_poll, .waitable_set_drop, .waitable_join, .task_cancel, .subtask_cancel, .subtask_drop, .context_get, .context_set, .backpressure_inc, .backpressure_dec, .thread_yield => true,
                         .lift => false,
                     };
                     if (contributes) try core_func_indexspace.append(allocator, .{ .canon = local_idx });
@@ -805,6 +805,7 @@ fn parseCanon(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!cty
         },
         0x24 => .backpressure_inc,
         0x25 => .backpressure_dec,
+        0x0C => .{ .thread_yield = (try reader.readByte()) != 0 },
         else => error.InvalidEncoding,
     };
 }
@@ -1411,7 +1412,7 @@ test "round-trip subtask/task-cancel/backpressure/context canons through writer 
 
     // Distinguishing payloads catch field-order / operand bugs: the two
     // `context.*` canons carry different (ty, slot) pairs, and
-    // `subtask.cancel` carries an async? flag.
+    // `subtask.cancel` / `thread.yield` carry a cancellable flag.
     const canons = [_]ctypes.Canon{
         .task_cancel,
         .{ .subtask_cancel = true },
@@ -1420,6 +1421,8 @@ test "round-trip subtask/task-cancel/backpressure/context canons through writer 
         .{ .context_set = .{ .ty = .i64, .slot = 3 } },
         .backpressure_inc,
         .backpressure_dec,
+        .{ .thread_yield = false },
+        .{ .thread_yield = true },
     };
     const component: ctypes.Component = .{
         .core_modules = &.{},
@@ -1437,7 +1440,7 @@ test "round-trip subtask/task-cancel/backpressure/context canons through writer 
     const bytes = try writer.encode(ar, &component);
     const loaded = try load(bytes, ar);
 
-    try std.testing.expectEqual(@as(usize, 7), loaded.canons.len);
+    try std.testing.expectEqual(@as(usize, 9), loaded.canons.len);
     try std.testing.expect(loaded.canons[0] == .task_cancel);
     try std.testing.expect(loaded.canons[1].subtask_cancel);
     try std.testing.expect(loaded.canons[2] == .subtask_drop);
@@ -1449,6 +1452,10 @@ test "round-trip subtask/task-cancel/backpressure/context canons through writer 
     try std.testing.expectEqual(@as(u32, 3), loaded.canons[4].context_set.slot);
     try std.testing.expect(loaded.canons[5] == .backpressure_inc);
     try std.testing.expect(loaded.canons[6] == .backpressure_dec);
+    try std.testing.expect(loaded.canons[7] == .thread_yield);
+    try std.testing.expect(!loaded.canons[7].thread_yield);
+    try std.testing.expect(loaded.canons[8] == .thread_yield);
+    try std.testing.expect(loaded.canons[8].thread_yield);
 }
 
 test "round-trip stream-family + error-context canons through writer + loader (#263)" {

--- a/src/component/types.zig
+++ b/src/component/types.zig
@@ -460,6 +460,9 @@ pub const Canon = union(enum) {
     backpressure_inc,
     /// `backpressure.dec` (binary `0x25`).
     backpressure_dec,
+    /// `thread.yield <cancellable>` (binary `0x0c`). Lowers to a core func
+    /// of type `(func (result i32))`.
+    thread_yield: bool,
 };
 
 // ── Imports and exports ─────────────────────────────────────────────────────

--- a/src/component/writer.zig
+++ b/src/component/writer.zig
@@ -707,6 +707,10 @@ fn writeCanon(w: *Writer, c: ctypes.Canon) EncodeError!void {
         },
         .backpressure_inc => try w.appendByte(0x24),
         .backpressure_dec => try w.appendByte(0x25),
+        .thread_yield => |cancellable| {
+            try w.appendByte(0x0C);
+            try w.appendByte(if (cancellable) 0x01 else 0x00);
+        },
     }
 }
 

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -1207,6 +1207,7 @@ const async_intrinsic_prefixes = [_][]const u8{
     "[task]",
     "[subtask]",
     "[context]",
+    "[yield]",
 };
 
 fn isAsyncIntrinsicModule(module: []const u8) bool {
@@ -2020,6 +2021,19 @@ pub fn buildComponent(alloc: std.mem.Allocator, core_bytes: []const u8) ![]u8 {
                     try bundle_exports.append(ar, .{ .name = field, .sort_idx = .{ .sort = .func, .idx = core_func_idx } });
                     core_func_idx += 1;
                 }
+            } else if (std.mem.startsWith(u8, grp.module, "[yield]")) {
+                for (grp.fields.items) |field| {
+                    const canon: ctypes.Canon = if (std.mem.eql(u8, field, "yield"))
+                        .{ .thread_yield = false }
+                    else if (std.mem.eql(u8, field, "yield-cancellable"))
+                        .{ .thread_yield = true }
+                    else
+                        return error.UnsupportedAsyncIntrinsic;
+                    try canons.append(ar, canon);
+                    try order.append(ar, .{ .kind = .canon, .start = @intCast(canons.items.len - 1), .count = 1 });
+                    try bundle_exports.append(ar, .{ .name = field, .sort_idx = .{ .sort = .func, .idx = core_func_idx } });
+                    core_func_idx += 1;
+                }
             } else {
                 // `[error-context]` (always needs the shim path for its
                 // memory ops): not wired in this no-shim path.
@@ -2556,7 +2570,7 @@ fn buildComponentShimFixup(
         mem_op_slot: u32 = 0,
         satisfy_core_idx: u32 = 0,
     };
-    const AsyncFamily = enum { task_return, stream, future, error_context, waitable_set, waitable, backpressure, task, subtask, context };
+    const AsyncFamily = enum { task_return, stream, future, error_context, waitable_set, waitable, backpressure, task, subtask, context, yield };
     const AsyncGroup = struct {
         module: []const u8,
         family: AsyncFamily,
@@ -2752,6 +2766,20 @@ fn buildComponentShimFixup(
                 try async_group_list.append(ar, .{
                     .module = module,
                     .family = .context,
+                    .elem = .u8,
+                    .export_ref = "",
+                    .fields = fields,
+                });
+            } else if (std.mem.startsWith(u8, module, "[yield]")) {
+                for (fsrc, 0..) |f, k| {
+                    if (!std.mem.eql(u8, f, "yield") and
+                        !std.mem.eql(u8, f, "yield-cancellable"))
+                        return error.UnsupportedAsyncIntrinsic;
+                    fields[k] = .{ .name = f, .is_mem_op = false };
+                }
+                try async_group_list.append(ar, .{
+                    .module = module,
+                    .family = .yield,
                     .elem = .u8,
                     .export_ref = "",
                     .fields = fields,
@@ -3353,6 +3381,18 @@ fn buildComponentShimFixup(
                     core_func_idx += 1;
                 }
             },
+            .yield => {
+                for (grp.fields) |*field| {
+                    const canon: ctypes.Canon = if (std.mem.eql(u8, field.name, "yield-cancellable"))
+                        .{ .thread_yield = true }
+                    else
+                        .{ .thread_yield = false };
+                    try canons.append(ar, canon);
+                    try order.append(ar, .{ .kind = .canon, .start = @intCast(canons.items.len - 1), .count = 1 });
+                    field.satisfy_core_idx = core_func_idx;
+                    core_func_idx += 1;
+                }
+            },
         }
     }
 
@@ -3536,6 +3576,7 @@ fn buildComponentShimFixup(
                     .task => unreachable, // task.cancel is never mem-op
                     .subtask => unreachable, // subtask.drop/cancel are never mem-op
                     .context => unreachable, // context.get/set are never mem-op
+                    .yield => unreachable, // thread.yield is never mem-op
                 };
                 try canons.append(ar, canon);
                 core_func_idx += 1;
@@ -6510,6 +6551,116 @@ test "buildComponent #267: operand-carrying canons also wire through the shim/fi
     try testing.expect(saw_set);
     try testing.expect(mainWithArgFor(loaded, "[subtask]"));
     try testing.expect(mainWithArgFor(loaded, "[context]"));
+}
+
+fn countThreadYieldCanons(loaded: anytype) usize {
+    var n: usize = 0;
+    for (loaded.canons) |c| switch (c) {
+        .thread_yield => n += 1,
+        else => {},
+    };
+    return n;
+}
+
+test "buildComponent #278: [yield] thread.yield no-mem control canons wire (fast path)" {
+    // thread.yield (binary 0x0c) is a no-memory direct canon carrying a
+    // cancellable flag (field `yield` ⇒ blocking, `yield-cancellable` ⇒
+    // cancellable). It lowers to a core func of type `(func (result i32))`.
+    // With no mem-op intrinsic and no exported destructor the guest stays on
+    // the fast path: a single (main) core module.
+    const wit =
+        \\package local:p@0.1.0;
+        \\
+        \\interface run {
+        \\    run: async func() -> result;
+        \\}
+        \\
+        \\world hello {
+        \\    export run;
+        \\}
+    ;
+    const wat =
+        \\(module
+        \\  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+        \\  (import "[yield]" "yield" (func (result i32)))
+        \\  (import "[yield]" "yield-cancellable" (func (result i32)))
+        \\  (memory (export "memory") 1)
+        \\  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+        \\  (func (export "local:p/run@0.1.0#run") (call 0 (i32.const 0)))
+        \\)
+    ;
+    const core = try buildCoreFromWat(testing.allocator, wat, wit, "hello");
+    defer testing.allocator.free(core);
+
+    const comp_bytes = try buildComponent(testing.allocator, core);
+    defer testing.allocator.free(comp_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const loaded = try loader.load(comp_bytes, arena.allocator());
+
+    try testing.expectEqual(@as(usize, 1), loaded.core_modules.len);
+    // `yield` (cancellable=false) + `yield-cancellable` (cancellable=true).
+    try testing.expectEqual(@as(usize, 2), countThreadYieldCanons(loaded));
+
+    var saw_plain = false;
+    var saw_cancellable = false;
+    for (loaded.canons) |c| switch (c) {
+        .thread_yield => |cancellable| if (cancellable) {
+            saw_cancellable = true;
+        } else {
+            saw_plain = true;
+        },
+        else => {},
+    };
+    try testing.expect(saw_plain);
+    try testing.expect(saw_cancellable);
+
+    try testing.expect(mainWithArgFor(loaded, "[yield]"));
+    try testing.expect(bundleExportsFunc(loaded, "yield"));
+    try testing.expect(bundleExportsFunc(loaded, "yield-cancellable"));
+}
+
+test "buildComponent #278: thread.yield also wires through the shim/fixup path" {
+    // A mem-op intrinsic (waitable-set.wait) forces the shim/fixup path; the
+    // no-mem thread.yield canon must still wire there (classification +
+    // emission arms), alongside main+shim+fixup.
+    const wit =
+        \\package local:p@0.1.0;
+        \\
+        \\interface run {
+        \\    run: async func() -> result;
+        \\}
+        \\
+        \\world hello {
+        \\    export run;
+        \\}
+    ;
+    const wat =
+        \\(module
+        \\  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+        \\  (import "[yield]" "yield" (func (result i32)))
+        \\  (import "[waitable-set]" "wait" (func (param i32 i32) (result i32)))
+        \\  (memory (export "memory") 1)
+        \\  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+        \\  (func (export "local:p/run@0.1.0#run"))
+        \\)
+    ;
+    const core = try buildCoreFromWat(testing.allocator, wat, wit, "hello");
+    defer testing.allocator.free(core);
+
+    const comp_bytes = try buildComponent(testing.allocator, core);
+    defer testing.allocator.free(comp_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const loaded = try loader.load(comp_bytes, arena.allocator());
+
+    // waitable-set.wait is mem-op ⇒ main + shim + fixup.
+    try testing.expectEqual(@as(usize, 3), loaded.core_modules.len);
+    try testing.expectEqual(@as(usize, 1), countThreadYieldCanons(loaded));
+    try testing.expect(mainWithArgFor(loaded, "[yield]"));
+    try testing.expect(bundleExportsFunc(loaded, "yield"));
 }
 
 test "buildComponent #248: drop-only namespace wires canon resource.drop into the bundle" {

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -1242,6 +1242,21 @@ fn parseContextField(field: []const u8) ?ContextField {
     return .{ .is_set = is_set, .ty = ty, .slot = slot };
 }
 
+/// Decoded `[stream]`/`[future]` cancel intrinsic field. `is_write` selects
+/// `cancel-write` over `cancel-read`; `is_async` is the cancellable flag
+/// (field suffix `-async`, which Wasmtime gates behind
+/// `component-model-more-async-builtins`). `cancel-{read,write}` are
+/// no-memory direct canons (type index + async byte, no `(memory)` opt).
+const StreamCancelField = struct { is_write: bool, is_async: bool };
+
+fn parseStreamCancelField(field: []const u8) ?StreamCancelField {
+    if (std.mem.eql(u8, field, "cancel-read")) return .{ .is_write = false, .is_async = false };
+    if (std.mem.eql(u8, field, "cancel-read-async")) return .{ .is_write = false, .is_async = true };
+    if (std.mem.eql(u8, field, "cancel-write")) return .{ .is_write = true, .is_async = false };
+    if (std.mem.eql(u8, field, "cancel-write-async")) return .{ .is_write = true, .is_async = true };
+    return null;
+}
+
 /// True if an import interface's instance-type body exports a named type
 /// (e.g. a `use`d enum like `wasi:cli/types`'s `error-code`). Such
 /// type-only imports define types other imports' bodies reference via
@@ -1890,8 +1905,13 @@ pub fn buildComponent(alloc: std.mem.Allocator, core_bytes: []const u8) ![]u8 {
                         .{ .stream_drop_readable = ty_idx }
                     else if (std.mem.eql(u8, field, "drop-writable"))
                         .{ .stream_drop_writable = ty_idx }
+                    else if (parseStreamCancelField(field)) |cc|
+                        (if (cc.is_write)
+                            ctypes.Canon{ .stream_cancel_write = .{ .type_idx = ty_idx, .is_async = cc.is_async } }
+                        else
+                            ctypes.Canon{ .stream_cancel_read = .{ .type_idx = ty_idx, .is_async = cc.is_async } })
                     else
-                        // `read`/`write`/`cancel-*` need `(memory)` opts.
+                        // `read`/`write` need `(memory)` opts (shim path).
                         return error.UnsupportedAsyncIntrinsic;
                     try canons.append(ar, canon);
                     try order.append(ar, .{ .kind = .canon, .start = @intCast(canons.items.len - 1), .count = 1 });
@@ -1916,8 +1936,13 @@ pub fn buildComponent(alloc: std.mem.Allocator, core_bytes: []const u8) ![]u8 {
                         .{ .future_drop_readable = ty_idx }
                     else if (std.mem.eql(u8, field, "drop-writable"))
                         .{ .future_drop_writable = ty_idx }
+                    else if (parseStreamCancelField(field)) |cc|
+                        (if (cc.is_write)
+                            ctypes.Canon{ .future_cancel_write = .{ .type_idx = ty_idx, .is_async = cc.is_async } }
+                        else
+                            ctypes.Canon{ .future_cancel_read = .{ .type_idx = ty_idx, .is_async = cc.is_async } })
                     else
-                        // `read`/`write`/`cancel-*` need `(memory)` opts.
+                        // `read`/`write` need `(memory)` opts (shim path).
                         return error.UnsupportedAsyncIntrinsic;
                     try canons.append(ar, canon);
                     try order.append(ar, .{ .kind = .canon, .start = @intCast(canons.items.len - 1), .count = 1 });
@@ -2582,7 +2607,8 @@ fn buildComponentShimFixup(
                 for (fsrc, 0..) |f, k| {
                     const mem_op = std.mem.eql(u8, f, "read") or std.mem.eql(u8, f, "write");
                     const no_mem = std.mem.eql(u8, f, "new") or
-                        std.mem.eql(u8, f, "drop-readable") or std.mem.eql(u8, f, "drop-writable");
+                        std.mem.eql(u8, f, "drop-readable") or std.mem.eql(u8, f, "drop-writable") or
+                        parseStreamCancelField(f) != null;
                     if (!mem_op and !no_mem) return error.UnsupportedAsyncIntrinsic;
                     fields[k] = .{ .name = f, .is_mem_op = mem_op };
                     if (mem_op) {
@@ -2603,7 +2629,8 @@ fn buildComponentShimFixup(
                 for (fsrc, 0..) |f, k| {
                     const mem_op = std.mem.eql(u8, f, "read") or std.mem.eql(u8, f, "write");
                     const no_mem = std.mem.eql(u8, f, "new") or
-                        std.mem.eql(u8, f, "drop-readable") or std.mem.eql(u8, f, "drop-writable");
+                        std.mem.eql(u8, f, "drop-readable") or std.mem.eql(u8, f, "drop-writable") or
+                        parseStreamCancelField(f) != null;
                     if (!mem_op and !no_mem) return error.UnsupportedAsyncIntrinsic;
                     fields[k] = .{ .name = f, .is_mem_op = mem_op };
                     if (mem_op) {
@@ -3156,8 +3183,15 @@ fn buildComponentShimFixup(
                         .{ .stream_new = grp.stream_type_idx }
                     else if (std.mem.eql(u8, field.name, "drop-readable"))
                         .{ .stream_drop_readable = grp.stream_type_idx }
+                    else if (std.mem.eql(u8, field.name, "drop-writable"))
+                        .{ .stream_drop_writable = grp.stream_type_idx }
+                    else if (parseStreamCancelField(field.name)) |cc|
+                        (if (cc.is_write)
+                            ctypes.Canon{ .stream_cancel_write = .{ .type_idx = grp.stream_type_idx, .is_async = cc.is_async } }
+                        else
+                            ctypes.Canon{ .stream_cancel_read = .{ .type_idx = grp.stream_type_idx, .is_async = cc.is_async } })
                     else
-                        .{ .stream_drop_writable = grp.stream_type_idx };
+                        unreachable;
                     try canons.append(ar, canon);
                     try order.append(ar, .{ .kind = .canon, .start = @intCast(canons.items.len - 1), .count = 1 });
                     field.satisfy_core_idx = core_func_idx;
@@ -3178,8 +3212,15 @@ fn buildComponentShimFixup(
                         .{ .future_new = grp.stream_type_idx }
                     else if (std.mem.eql(u8, field.name, "drop-readable"))
                         .{ .future_drop_readable = grp.stream_type_idx }
+                    else if (std.mem.eql(u8, field.name, "drop-writable"))
+                        .{ .future_drop_writable = grp.stream_type_idx }
+                    else if (parseStreamCancelField(field.name)) |cc|
+                        (if (cc.is_write)
+                            ctypes.Canon{ .future_cancel_write = .{ .type_idx = grp.stream_type_idx, .is_async = cc.is_async } }
+                        else
+                            ctypes.Canon{ .future_cancel_read = .{ .type_idx = grp.stream_type_idx, .is_async = cc.is_async } })
                     else
-                        .{ .future_drop_writable = grp.stream_type_idx };
+                        unreachable;
                     try canons.append(ar, canon);
                     try order.append(ar, .{ .kind = .canon, .start = @intCast(canons.items.len - 1), .count = 1 });
                     field.satisfy_core_idx = core_func_idx;
@@ -5921,6 +5962,130 @@ test "buildComponent #264: future.write routes through shim/fixup (memory-opt)" 
     try testing.expect(anyAsyncLift(loaded));
     try testing.expect(mainWithArgFor(loaded, "[future]future<u8>"));
     try testing.expect(mainWithArgFor(loaded, "[task-return]local:p/run@0.1.0#run"));
+}
+
+fn countStreamFutureCancelCanons(loaded: anytype) usize {
+    var n: usize = 0;
+    for (loaded.canons) |c| switch (c) {
+        .stream_cancel_read, .stream_cancel_write, .future_cancel_read, .future_cancel_write => n += 1,
+        else => {},
+    };
+    return n;
+}
+
+test "buildComponent #263: stream/future cancel-read/write wire as no-mem direct canons (fast path)" {
+    // `stream.cancel-{read,write}` / `future.cancel-{read,write}` carry a type
+    // index + an async? flag (field suffix `-async`) and need NO `(memory)`
+    // opt, so they are direct canons (like new/drop) and keep the build on the
+    // fast path. Lowered core sig is `(param i32) (result i32)`. Validated on
+    // wasmtime 46 (`-W component-model-async{,-stackful,-more-async-builtins}`).
+    const wit =
+        \\package local:p@0.1.0;
+        \\
+        \\interface run {
+        \\    run: async func() -> result;
+        \\}
+        \\
+        \\world hello {
+        \\    export run;
+        \\}
+    ;
+    const wat =
+        \\(module
+        \\  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+        \\  (import "[stream]stream<u8>" "new" (func (result i64)))
+        \\  (import "[stream]stream<u8>" "cancel-read" (func (param i32) (result i32)))
+        \\  (import "[stream]stream<u8>" "cancel-write-async" (func (param i32) (result i32)))
+        \\  (import "[future]future<u8>" "new" (func (result i64)))
+        \\  (import "[future]future<u8>" "cancel-read" (func (param i32) (result i32)))
+        \\  (import "[future]future<u8>" "cancel-write" (func (param i32) (result i32)))
+        \\  (memory (export "memory") 1)
+        \\  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+        \\  (func (export "local:p/run@0.1.0#run"))
+        \\)
+    ;
+    const core = try buildCoreFromWat(testing.allocator, wat, wit, "hello");
+    defer testing.allocator.free(core);
+
+    const comp_bytes = try buildComponent(testing.allocator, core);
+    defer testing.allocator.free(comp_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const loaded = try loader.load(comp_bytes, arena.allocator());
+
+    // No mem-op intrinsic ⇒ fast path ⇒ a single (main) core module.
+    try testing.expectEqual(@as(usize, 1), loaded.core_modules.len);
+    // 2 stream-cancel + 2 future-cancel canons.
+    try testing.expectEqual(@as(usize, 4), countStreamFutureCancelCanons(loaded));
+
+    var s_read_sync = false;
+    var s_write_async = false;
+    var f_read_sync = false;
+    var f_write_sync = false;
+    for (loaded.canons) |c| switch (c) {
+        .stream_cancel_read => |cc| if (!cc.is_async) {
+            s_read_sync = true;
+        },
+        .stream_cancel_write => |cc| if (cc.is_async) {
+            s_write_async = true;
+        },
+        .future_cancel_read => |cc| if (!cc.is_async) {
+            f_read_sync = true;
+        },
+        .future_cancel_write => |cc| if (!cc.is_async) {
+            f_write_sync = true;
+        },
+        else => {},
+    };
+    try testing.expect(s_read_sync);
+    try testing.expect(s_write_async);
+    try testing.expect(f_read_sync);
+    try testing.expect(f_write_sync);
+    try testing.expect(bundleExportsFunc(loaded, "cancel-read"));
+    try testing.expect(bundleExportsFunc(loaded, "cancel-write-async"));
+}
+
+test "buildComponent #263: stream/future cancel-* also wire through the shim/fixup path" {
+    // A mem-op intrinsic (stream.write) forces the shim/fixup path; the no-mem
+    // cancel-* canons must still wire there (classification + emission arms).
+    const wit =
+        \\package local:p@0.1.0;
+        \\
+        \\interface run {
+        \\    run: async func() -> result;
+        \\}
+        \\
+        \\world hello {
+        \\    export run;
+        \\}
+    ;
+    const wat =
+        \\(module
+        \\  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+        \\  (import "[stream]stream<u8>" "new" (func (result i64)))
+        \\  (import "[stream]stream<u8>" "write" (func (param i32 i32 i32) (result i32)))
+        \\  (import "[stream]stream<u8>" "cancel-write" (func (param i32) (result i32)))
+        \\  (import "[future]future<u8>" "cancel-read" (func (param i32) (result i32)))
+        \\  (memory (export "memory") 1)
+        \\  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+        \\  (func (export "local:p/run@0.1.0#run"))
+        \\)
+    ;
+    const core = try buildCoreFromWat(testing.allocator, wat, wit, "hello");
+    defer testing.allocator.free(core);
+
+    const comp_bytes = try buildComponent(testing.allocator, core);
+    defer testing.allocator.free(comp_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const loaded = try loader.load(comp_bytes, arena.allocator());
+
+    // stream.write is mem-op ⇒ main + shim + fixup.
+    try testing.expectEqual(@as(usize, 3), loaded.core_modules.len);
+    // stream.cancel-write + future.cancel-read.
+    try testing.expectEqual(@as(usize, 2), countStreamFutureCancelCanons(loaded));
 }
 
 test "buildComponent #263: full streaming hello (stdout write-via-stream + cross-iface)" {

--- a/tests/p3/stream-future-cancel.wat
+++ b/tests/p3/stream-future-cancel.wat
@@ -1,0 +1,13 @@
+;; stream/future cancel-read / cancel-write (sync + async), no-memory direct canons.
+(module
+  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+  (import "[stream]stream<u8>" "new" (func (result i64)))
+  (import "[stream]stream<u8>" "cancel-read" (func (param i32) (result i32)))
+  (import "[stream]stream<u8>" "cancel-write-async" (func (param i32) (result i32)))
+  (import "[future]future<u8>" "new" (func (result i64)))
+  (import "[future]future<u8>" "cancel-read" (func (param i32) (result i32)))
+  (import "[future]future<u8>" "cancel-write" (func (param i32) (result i32)))
+  (memory (export "memory") 1)
+  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+  (func (export "local:p/run@0.1.0#run"))
+)

--- a/tests/p3/thread-yield.wat
+++ b/tests/p3/thread-yield.wat
@@ -1,0 +1,10 @@
+;; thread.yield: no-memory cooperative-yield built-in (lowers to `(func (result i32))`).
+(module
+  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+  (import "[yield]" "yield" (func (result i32)))
+  (memory (export "memory") 1)
+  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+  (func (export "local:p/run@0.1.0#run")
+    (drop (call 1))            ;; thread.yield -> i32, discard
+    (call 0 (i32.const 0)))    ;; task.return
+)


### PR DESCRIPTION
Closes #278.

Implements the 	hread.yield (yield) canonical built-in — the last unimplemented canon from #263's encoding reference. It lets an async task voluntarily yield the event loop so other subtasks make progress. Follow-up to the demand-driven async wiring in #273–#277.

## Encoding (verified vs wasmparser 0.251 / wasmtime 46)
- canon byte 