### PR TITLE
component bindgen: support variant/flags/result, tuple, resources, async, aggregate params (#284)

### DIFF
--- a/src/tools/component_bindgen.zig
+++ b/src/tools/component_bindgen.zig
@@ -182,10 +182,28 @@ const Gen = struct {
             });
         }
 
-        // Index every named type so `.name` refs resolve.
+        // Index every named type so `.name` refs resolve, plus any types pulled
+        // in from another interface via `use pkg:iface.{ … }`.
+        const UsedType = struct { name: []const u8, kind: ast.TypeDefKind, iface_id: []const u8 };
+        var used_types = std.ArrayListUnmanaged(UsedType).empty;
         for (uses.items) |u| {
             for (u.iface.items) |it| switch (it) {
                 .type => |td| try self.types.put(self.ar, td.name, td.kind),
+                .use => |use_item| {
+                    const src = self.resolver.findInterface(use_item.from) orelse continue;
+                    const src_id = try ifaceId(self.ar, use_item.from, doc_pkg);
+                    for (use_item.names) |un| {
+                        const local = un.rename orelse un.name;
+                        if (self.types.contains(local)) continue;
+                        for (src.items) |sit| switch (sit) {
+                            .type => |td| if (std.mem.eql(u8, td.name, un.name)) {
+                                try self.types.put(self.ar, local, td.kind);
+                                try used_types.append(self.ar, .{ .name = local, .kind = td.kind, .iface_id = src_id });
+                            },
+                            else => {},
+                        };
+                    }
+                },
                 else => {},
             };
         }
@@ -200,7 +218,10 @@ const Gen = struct {
             \\
         , .{world_name});
 
-        // ── named types ──
+        // ── named types (use-imported first, then locally-defined) ──
+        for (used_types.items) |ut| {
+            try self.emitTypeDef(ut.iface_id, .{ .name = ut.name, .kind = ut.kind });
+        }
         for (uses.items) |u| {
             for (u.iface.items) |it| switch (it) {
                 .type => |td| {
@@ -1541,5 +1562,42 @@ test "generate: aggregate params (variant / record) lower via canon.lowerFlat" {
     try testing.expect(std.mem.indexOf(u8, out, "extern \"demo:m/api\" fn @\"move-to\"(p_0: i32, p_1: i32) i32;") != null);
     try testing.expect(std.mem.indexOf(u8, out, "const p_s = canon.lowerFlat(Point, p, &abi.alloc);") != null);
     try testing.expect(std.mem.indexOf(u8, out, "imp.@\"move-to\"(p_s[0], p_s[1])") != null);
+}
+
+test "generate: use-imported types are indexed and emitted" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // interface base { type duration = u64; }
+    // interface api  { use base.{duration}; tick: func(d: duration) -> u64; }
+    const dur_ty: ast.Type = .u64;
+    const base_items = [_]ast.InterfaceItem{
+        .{ .type = .{ .name = "duration", .kind = .{ .alias = dur_ty } } },
+    };
+    const base_iface = ast.Interface{ .name = "base", .items = &base_items };
+    const dur_ref = ast.Type{ .name = "duration" };
+    const api_items = [_]ast.InterfaceItem{
+        .{ .use = .{ .from = .{ .name = "base" }, .names = &.{.{ .name = "duration" }} } },
+        .{ .func = .{ .name = "tick", .func = .{ .params = &.{.{ .name = "d", .type = dur_ref }}, .result = .u64 } } },
+    };
+    const api_iface = ast.Interface{ .name = "api", .items = &api_items };
+    const imp_world = ast.World{ .name = "guest", .items = &.{
+        .{ .import = .{ .interface_ref = .{ .ref = .{ .name = "api" } } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "demo", .name = "u" },
+        .items = &.{ .{ .interface = base_iface }, .{ .interface = api_iface }, .{ .world = imp_world } },
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+    try g.generate(imp_world, "guest");
+    const out = g.out.items;
+    // the `use`d alias is emitted as a top-level typedef …
+    try testing.expect(std.mem.indexOf(u8, out, "pub const Duration = u64;") != null);
+    // … and resolves through to its underlying core type when used as a param.
+    try testing.expect(std.mem.indexOf(u8, out, "pub fn tick(d: Duration) u64 {") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "extern \"demo:u/api\" fn @\"tick\"(d: i64) i64;") != null);
 }
 

--- a/src/tools/component_bindgen.zig
+++ b/src/tools/component_bindgen.zig
@@ -442,19 +442,25 @@ const Gen = struct {
     /// Emit an async-lifted export: a core `export fn … () void` that lifts its
     /// params, calls the user impl, and delivers the result through the
     /// `[task-return]<iface>#<fn>` intrinsic (the canonical async-lift shape
-    /// `component new` wires for an `async func`). Results that flatten to more
-    /// than one core slot (the direct multi-slot task.return form) are a later
-    /// phase, as is calling *imported* async functions.
+    /// `component new` wires for an `async func`). The result is delivered as its
+    /// flattened core slots; results wider than 16 slots (the spilled,
+    /// memory-pointer task.return form) and calling *imported* async functions
+    /// are later phases.
     fn emitAsyncExportFunc(self: *Gen, iface_id: []const u8, name: []const u8, func: ast.Func) GenError!void {
         const rcount: usize = if (func.result) |t| try self.flatCount(t) else 0;
-        if (rcount > 1) return error.UnsupportedWitType; // async aggregate result: later phase
+        if (rcount > 16) return error.UnsupportedWitType; // spilled task.return (memory): later
 
         // Per-export `[task-return]` helper (extern decls must be container-scope).
         const tname = try std.fmt.allocPrint(self.ar, "__task_{d}", .{self.task_counter});
         self.task_counter += 1;
         self.print("const {s} = struct {{\n", .{tname});
         self.print("    extern \"[task-return]{s}#{s}\" fn @\"task-return\"(", .{ iface_id, name });
-        if (rcount == 1) self.print("d0: {s}", .{@tagName(try self.coreOfResult(func.result.?))});
+        if (func.result) |t| {
+            for ((try self.flatCores(t)), 0..) |c, i| {
+                if (i != 0) self.raw(", ");
+                self.print("d{d}: {s}", .{ i, @tagName(c) });
+            }
+        }
         self.raw(") void;\n};\n\n");
 
         self.print("export fn @\"{s}#{s}\"(", .{ iface_id, name });
@@ -465,14 +471,27 @@ const Gen = struct {
         try self.emitLiftParams(func.params);
 
         const args = try self.implArgList(func.params);
+        const camel_name = try camel(self.ar, name);
         if (func.result == null) {
-            self.print("    Impl.{s}({s});\n", .{ try camel(self.ar, name), args });
+            self.print("    Impl.{s}({s});\n", .{ camel_name, args });
             self.print("    {s}.@\"task-return\"();\n", .{tname});
-        } else {
+        } else if (rcount == 1) {
             self.print(
                 "    {s}.@\"task-return\"(canon.returnResult({s}, Impl.{s}({s}), &abi.alloc));\n",
-                .{ tname, try self.resultZig(func), try camel(self.ar, name), args },
+                .{ tname, try self.resultZig(func), camel_name, args },
             );
+        } else {
+            // multi-slot: flatten the result to its core slots and pass them.
+            self.print(
+                "    const __r = canon.lowerFlat({s}, Impl.{s}({s}), &abi.alloc);\n",
+                .{ try self.resultZig(func), camel_name, args },
+            );
+            self.print("    {s}.@\"task-return\"(", .{tname});
+            for (0..rcount) |i| {
+                if (i != 0) self.raw(", ");
+                self.print("__r[{d}]", .{i});
+            }
+            self.raw(");\n");
         }
         self.raw("}\n\n");
     }
@@ -1398,13 +1417,12 @@ test "generate: async export lift (task.return)" {
     try testing.expect(std.mem.indexOf(u8, out, "__task_1.@\"task-return\"(canon.returnResult(u32, Impl.double(__params.x), &abi.alloc));") != null);
 }
 
-test "generate: async aggregate result and async import are rejected (later phases)" {
+test "generate: async multi-slot result lifts via lowerFlat; async import rejected" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const ar = arena.allocator();
 
-    // `async func() -> string` flattens to 2 slots (the direct multi-slot
-    // task.return form), which is a later phase.
+    // `async func() -> string` flattens to 2 slots → direct multi-slot task.return.
     const agg_items = [_]ast.InterfaceItem{
         .{ .func = .{ .name = "greet", .func = .{ .params = &.{}, .result = .string, .is_async = true } } },
     };
@@ -1423,7 +1441,13 @@ test "generate: async aggregate result and async import are rejected (later phas
 
     {
         var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
-        try testing.expectError(error.UnsupportedWitType, g.generate(agg_exp, "host"));
+        try g.generate(agg_exp, "host");
+        const out = g.out.items;
+        // task.return carries the 2 flattened result slots; the result is lowered
+        // with canon.lowerFlat and passed positionally.
+        try testing.expect(std.mem.indexOf(u8, out, "extern \"[task-return]test:a/api#greet\" fn @\"task-return\"(d0: i32, d1: i32) void;") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "const __r = canon.lowerFlat([]const u8, Impl.greet(), &abi.alloc);") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "__task_0.@\"task-return\"(__r[0], __r[1]);") != null);
     }
     {
         // Calling an imported async function (async lower) is a later phase.

--- a/src/tools/component_bindgen.zig
+++ b/src/tools/component_bindgen.zig
@@ -201,7 +201,12 @@ const Gen = struct {
         // ── named types ──
         for (uses.items) |u| {
             for (u.iface.items) |it| switch (it) {
-                .type => |td| try self.emitTypeDef(td),
+                .type => |td| {
+                    // Exported resources (guest-implemented, resource-new/rep) are
+                    // a later phase; imported resources are handled below.
+                    if (td.kind == .resource and u.is_export) return error.UnsupportedWitType;
+                    try self.emitTypeDef(u.id, td);
+                },
                 else => {},
             };
         }
@@ -228,7 +233,7 @@ const Gen = struct {
 
     // ── type emission ────────────────────────────────────────────────
 
-    fn emitTypeDef(self: *Gen, td: ast.TypeDef) GenError!void {
+    fn emitTypeDef(self: *Gen, iface_id: []const u8, td: ast.TypeDef) GenError!void {
         switch (td.kind) {
             .record => |fields| {
                 self.print("pub const {s} = struct {{\n", .{try pascal(self.ar, td.name)});
@@ -267,7 +272,7 @@ const Gen = struct {
             .alias => |t| {
                 self.print("pub const {s} = {s};\n\n", .{ try pascal(self.ar, td.name), try self.zigType(t) });
             },
-            else => return error.UnsupportedWitType, // resource: later phase
+            .resource => try self.emitResource(iface_id, td),
         }
     }
 
@@ -293,6 +298,7 @@ const Gen = struct {
                 const err = if (r.err) |t| try self.zigType(t.*) else "void";
                 break :blk try std.fmt.allocPrint(self.ar, "canon.Result({s}, {s})", .{ ok, err });
             },
+            .own, .borrow => |r| try pascal(self.ar, r), // resource handle wrapper
             .name => |n| try pascal(self.ar, n),
             else => error.UnsupportedWitType,
         };
@@ -329,10 +335,11 @@ const Gen = struct {
                     },
                     .flags => |labels| (labels.len + 31) / 32, // i32 slots
                     .@"enum" => 1,
+                    .resource => 1, // an i32 handle
                     .alias => |t| try self.flatCount(t),
-                    else => error.UnsupportedWitType,
                 };
             },
+            .own, .borrow => 1, // resource handle (i32)
             else => 1, // scalars (bool/int/float/char/enum)
         };
     }
@@ -474,6 +481,126 @@ const Gen = struct {
         self.raw("    }\n");
     }
 
+    // ── resources (imported) ─────────────────────────────────────────
+
+    /// The canonical extern name for a resource method/static/constructor.
+    fn resourceExternName(self: *Gen, rname: []const u8, m: ast.ResourceMethod) GenError![]const u8 {
+        return switch (m.kind) {
+            .constructor => try std.fmt.allocPrint(self.ar, "[constructor]{s}", .{rname}),
+            .method => try std.fmt.allocPrint(self.ar, "[method]{s}.{s}", .{ rname, m.name }),
+            .static => try std.fmt.allocPrint(self.ar, "[static]{s}.{s}", .{ rname, m.name }),
+        };
+    }
+
+    /// Emit an imported resource as a handle-wrapper struct: an `i32` handle, a
+    /// private `imp` namespace of the canonical resource externs, typed
+    /// method/static/constructor wrappers, and a `deinit` that drops the handle.
+    fn emitResource(self: *Gen, iface_id: []const u8, td: ast.TypeDef) GenError!void {
+        const methods = td.kind.resource;
+        const R = try pascal(self.ar, td.name);
+
+        self.print("pub const {s} = struct {{\n", .{R});
+        self.raw("    handle: i32,\n\n");
+
+        self.raw("    const imp = struct {\n");
+        for (methods) |m| try self.emitResourceExtern(iface_id, td.name, m);
+        self.print("        extern \"{s}\" fn @\"[resource-drop]{s}\"(self: i32) void;\n", .{ iface_id, td.name });
+        self.raw("    };\n\n");
+
+        for (methods) |m| try self.emitResourceWrapper(R, td.name, m);
+
+        self.print("    pub fn deinit(self: {s}) void {{\n", .{R});
+        self.print("        imp.@\"[resource-drop]{s}\"(self.handle);\n", .{td.name});
+        self.raw("    }\n");
+        self.raw("};\n\n");
+    }
+
+    fn emitResourceExtern(self: *Gen, iface_id: []const u8, rname: []const u8, m: ast.ResourceMethod) GenError!void {
+        const func = m.func;
+        if (func.is_async) return error.UnsupportedWitType;
+        const ext = try self.resourceExternName(rname, m);
+
+        self.print("        extern \"{s}\" fn @\"{s}\"(", .{ iface_id, ext });
+        var first = true;
+        if (m.kind == .method) {
+            self.raw("self: i32");
+            first = false;
+        }
+        for (func.params) |p| {
+            const slots = try self.paramSlots(p);
+            for (slots) |s| {
+                if (!first) self.raw(", ");
+                first = false;
+                self.print("{s}: {s}", .{ s.name, @tagName(s.core) });
+            }
+        }
+        if (m.kind == .constructor) {
+            self.raw(") i32;\n"); // -> own<R> handle
+            return;
+        }
+        const rcount: usize = if (func.result) |t| try self.flatCount(t) else 0;
+        if (rcount > 1) {
+            if (!first) self.raw(", ");
+            self.raw("retptr: i32) void;\n");
+        } else if (rcount == 1) {
+            self.print(") {s};\n", .{@tagName(try self.coreOfResult(func.result.?))});
+        } else {
+            self.raw(") void;\n");
+        }
+    }
+
+    fn emitResourceWrapper(self: *Gen, R: []const u8, rname: []const u8, m: ast.ResourceMethod) GenError!void {
+        const func = m.func;
+        if (func.is_async) return error.UnsupportedWitType;
+        const ext = try self.resourceExternName(rname, m);
+        const is_method = m.kind == .method;
+
+        if (m.kind == .constructor) {
+            self.raw("    pub fn init(");
+        } else {
+            self.print("    pub fn {s}(", .{try camel(self.ar, m.name)});
+        }
+        if (is_method) {
+            self.print("self: {s}", .{R});
+            if (func.params.len > 0) self.raw(", ");
+        }
+        try self.emitTypedParamDecls(func.params);
+        if (m.kind == .constructor) {
+            self.print(") {s} {{\n", .{R});
+        } else {
+            self.print(") {s} {{\n", .{try self.resultZig(func)});
+        }
+
+        // lower params → arg expressions (emitting temps as needed)
+        const call_args = try self.lowerParams(func.params);
+        const args = if (is_method) blk: {
+            if (call_args.len > 0) break :blk try std.fmt.allocPrint(self.ar, "self.handle, {s}", .{call_args});
+            break :blk "self.handle";
+        } else call_args;
+
+        if (m.kind == .constructor) {
+            self.print("        return .{{ .handle = imp.@\"{s}\"({s}) }};\n", .{ ext, args });
+            self.raw("    }\n");
+            return;
+        }
+
+        const result_zig = try self.resultZig(func);
+        const rcount: usize = if (func.result) |t| try self.flatCount(t) else 0;
+        if (rcount > 1) {
+            if (args.len > 0) {
+                self.print("        imp.@\"{s}\"({s}, abi.retPtr());\n", .{ ext, args });
+            } else {
+                self.print("        imp.@\"{s}\"(abi.retPtr());\n", .{ext});
+            }
+            self.print("        return canon.lift({s}, abi.retArea());\n", .{result_zig});
+        } else if (func.result == null) {
+            self.print("        imp.@\"{s}\"({s});\n", .{ ext, args });
+        } else {
+            self.print("        return canon.liftResultFlat({s}, imp.@\"{s}\"({s}));\n", .{ result_zig, ext, args });
+        }
+        self.raw("    }\n");
+    }
+
     /// Lower each high-level param into the flat call arguments, emitting temp
     /// statements for `option<…>`. Returns the comma-joined argument list.
     fn lowerParams(self: *Gen, params: []const ast.Param) GenError![]const u8 {
@@ -481,6 +608,10 @@ const Gen = struct {
         for (params) |p| {
             const pn = try snake(self.ar, p.name);
             if (args.items.len != 0) try args.appendSlice(self.ar, ", ");
+            if (self.handleResource(p.type) != null) {
+                try args.appendSlice(self.ar, try std.fmt.allocPrint(self.ar, "{s}.handle", .{pn}));
+                continue;
+            }
             switch (p.type) {
                 .string => {
                     try args.appendSlice(self.ar, try std.fmt.allocPrint(self.ar, "@intCast(@intFromPtr({s}.ptr)), @intCast({s}.len)", .{ pn, pn }));
@@ -558,6 +689,10 @@ const Gen = struct {
     }
 
     fn flattenSlots(self: *Gen, out: *std.ArrayListUnmanaged(Slot), base: []const u8, ty: ast.Type) GenError!void {
+        if (self.handleResource(ty) != null) {
+            try out.append(self.ar, .{ .name = base, .core = .i32 });
+            return;
+        }
         switch (ty) {
             .string, .list => {
                 try out.append(self.ar, .{ .name = try std.fmt.allocPrint(self.ar, "{s}_ptr", .{base}), .core = .i32 });
@@ -578,7 +713,18 @@ const Gen = struct {
             .u64, .s64 => .i64,
             .f32 => .f32,
             .f64 => .f64,
+            .own, .borrow => .i32, // resource handle
             else => error.UnsupportedWitType,
+        };
+    }
+
+    /// If `ty` is a resource handle — `own<R>`, `borrow<R>`, or a bare reference
+    /// to a resource type — return the resource's WIT name; otherwise null.
+    fn handleResource(self: *Gen, ty: ast.Type) ?[]const u8 {
+        return switch (ty) {
+            .own, .borrow => |r| r,
+            .name => |n| if (self.types.get(n)) |k| (if (k == .resource) n else null) else null,
+            else => null,
         };
     }
 
@@ -588,15 +734,16 @@ const Gen = struct {
         // flatten to its i32; a single-field record flattens to that field.
         return switch (ty) {
             .result => .i32,
+            .own, .borrow => .i32, // resource handle
             .name => |n| switch (self.types.get(n) orelse return error.UnknownType) {
                 .@"enum", .variant => .i32,
                 .flags => .i32, // ≤32 labels → a single i32 slot
+                .resource => .i32, // a handle
                 .record => |fields| if (fields.len == 1)
                     try self.coreOfResult(fields[0].type)
                 else
                     error.UnsupportedWitType,
                 .alias => |t| try self.coreOfResult(t),
-                else => error.UnsupportedWitType,
             },
             else => self.coreOf(ty),
         };
@@ -946,6 +1093,67 @@ test "generate: flags typedef + flat return" {
         // ≤32 labels → flat i32.
         try testing.expect(std.mem.indexOf(u8, out, "extern \"test:f/api\" fn @\"get-perms\"() i32;") != null);
         try testing.expect(std.mem.indexOf(u8, out, "return canon.liftResultFlat(Perms, imp.@\"get-perms\"());") != null);
+    }
+}
+
+test "generate: imported resource handle struct + methods/static/ctor/drop" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // resource counter { constructor(start: u32); increment: func(by: u32) -> u32;
+    //   make-zero: static func() -> counter; }
+    const counter_methods = [_]ast.ResourceMethod{
+        .{ .kind = .constructor, .name = "", .func = .{ .params = &.{.{ .name = "start", .type = .u32 }}, .result = null } },
+        .{ .kind = .method, .name = "increment", .func = .{ .params = &.{.{ .name = "by", .type = .u32 }}, .result = .u32 } },
+        .{ .kind = .static, .name = "make-zero", .func = .{ .params = &.{}, .result = ast.Type{ .name = "counter" } } },
+    };
+    const iface_items = [_]ast.InterfaceItem{
+        .{ .type = .{ .name = "counter", .kind = .{ .resource = &counter_methods } } },
+    };
+    const iface = ast.Interface{ .name = "counters", .items = &iface_items };
+    const imp_world = ast.World{ .name = "guest", .items = &.{
+        .{ .import = .{ .interface_ref = .{ .ref = .{ .name = "counters" } } } },
+    } };
+    const exp_world = ast.World{ .name = "host", .items = &.{
+        .{ .@"export" = .{ .interface_ref = .{ .ref = .{ .name = "counters" } } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "test", .name = "res" },
+        .items = &.{
+            .{ .interface = iface },
+            .{ .world = imp_world },
+            .{ .world = exp_world },
+        },
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    {
+        var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+        try g.generate(imp_world, "guest");
+        const out = g.out.items;
+        try testing.expect(std.mem.indexOf(u8, out, "pub const Counter = struct {") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "    handle: i32,") != null);
+        // canonical resource externs (module = iface id).
+        try testing.expect(std.mem.indexOf(u8, out, "extern \"test:res/counters\" fn @\"[constructor]counter\"(start: i32) i32;") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "extern \"test:res/counters\" fn @\"[method]counter.increment\"(self: i32, by: i32) i32;") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "extern \"test:res/counters\" fn @\"[static]counter.make-zero\"() i32;") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "extern \"test:res/counters\" fn @\"[resource-drop]counter\"(self: i32) void;") != null);
+        // typed wrappers.
+        try testing.expect(std.mem.indexOf(u8, out, "pub fn init(start: u32) Counter {") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "return .{ .handle = imp.@\"[constructor]counter\"(@bitCast(start)) };") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "pub fn increment(self: Counter, by: u32) u32 {") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "imp.@\"[method]counter.increment\"(self.handle, @bitCast(by))") != null);
+        // a static returning own<counter> lifts the handle into the wrapper struct.
+        try testing.expect(std.mem.indexOf(u8, out, "pub fn makeZero() Counter {") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "return canon.liftResultFlat(Counter, imp.@\"[static]counter.make-zero\"());") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "pub fn deinit(self: Counter) void {") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "imp.@\"[resource-drop]counter\"(self.handle);") != null);
+    }
+    {
+        // Exported (guest-implemented) resources are not supported yet.
+        var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+        try testing.expectError(error.UnsupportedWitType, g.generate(exp_world, "host"));
     }
 }
 

--- a/src/tools/component_bindgen.zig
+++ b/src/tools/component_bindgen.zig
@@ -157,7 +157,7 @@ const Gen = struct {
         self.out.appendSlice(self.ar, s) catch @panic("OOM");
     }
 
-    const Use = struct { id: []const u8, iface: ast.Interface, is_export: bool };
+    const Use = struct { id: []const u8, iface: ast.Interface, is_export: bool, pkg: ?ast.PackageId };
 
     fn generate(self: *Gen, world: ast.World, world_name: []const u8) GenError!void {
         const doc_pkg = self.resolver.main.package;
@@ -174,28 +174,31 @@ const Gen = struct {
                 .interface_ref => |ir| ir.ref,
                 else => return error.UnsupportedWitType, // named_func/named_interface: v2
             };
-            const iface = self.resolver.findInterface(ref) orelse return error.UnknownInterface;
+            const hit = self.resolver.findInterfaceWithPkg(ref) orelse return error.UnknownInterface;
             try uses.append(self.ar, .{
                 .id = try ifaceId(self.ar, ref, doc_pkg),
-                .iface = iface,
+                .iface = hit.iface,
                 .is_export = ei.is_export,
+                .pkg = hit.pkg,
             });
         }
 
         // Index every named type so `.name` refs resolve, plus any types pulled
-        // in from another interface via `use pkg:iface.{ … }`.
+        // in from another interface via `use pkg:iface.{ … }` (resolved in the
+        // package context of the interface that contains the `use`).
         const UsedType = struct { name: []const u8, kind: ast.TypeDefKind, iface_id: []const u8 };
         var used_types = std.ArrayListUnmanaged(UsedType).empty;
         for (uses.items) |u| {
             for (u.iface.items) |it| switch (it) {
                 .type => |td| try self.types.put(self.ar, td.name, td.kind),
                 .use => |use_item| {
-                    const src = self.resolver.findInterface(use_item.from) orelse continue;
-                    const src_id = try ifaceId(self.ar, use_item.from, doc_pkg);
+                    const hit = self.resolver.findInterfaceWithPkgCtx(use_item.from, u.pkg) orelse continue;
+                    const src_ref = ast.InterfaceRef{ .name = use_item.from.name, .package = hit.pkg };
+                    const src_id = try ifaceId(self.ar, src_ref, doc_pkg);
                     for (use_item.names) |un| {
                         const local = un.rename orelse un.name;
                         if (self.types.contains(local)) continue;
-                        for (src.items) |sit| switch (sit) {
+                        for (hit.iface.items) |sit| switch (sit) {
                             .type => |td| if (std.mem.eql(u8, td.name, un.name)) {
                                 try self.types.put(self.ar, local, td.kind);
                                 try used_types.append(self.ar, .{ .name = local, .kind = td.kind, .iface_id = src_id });
@@ -918,7 +921,13 @@ const Gen = struct {
                 },
                 .alias => unreachable, // resolved above
             },
-            else => &[_]Core{try self.coreOf(ty)}, // scalar
+            else => blk: {
+                // scalar: a single core slot. Allocate in the arena (a
+                // `&[_]Core{runtime}` literal would dangle after return).
+                var l = std.ArrayListUnmanaged(Core).empty;
+                try l.append(self.ar, try self.coreOf(ty));
+                break :blk l.items;
+            },
         };
     }
 

--- a/src/tools/component_bindgen.zig
+++ b/src/tools/component_bindgen.zig
@@ -242,10 +242,21 @@ const Gen = struct {
                 for (cases) |c| self.print("    {s},\n", .{try snake(self.ar, c)});
                 self.raw("};\n\n");
             },
+            .variant => |cases| {
+                self.print("pub const {s} = union(enum) {{\n", .{try pascal(self.ar, td.name)});
+                for (cases) |c| {
+                    if (c.type) |t| {
+                        self.print("    {s}: {s},\n", .{ try snake(self.ar, c.name), try self.zigType(t) });
+                    } else {
+                        self.print("    {s},\n", .{try snake(self.ar, c.name)});
+                    }
+                }
+                self.raw("};\n\n");
+            },
             .alias => |t| {
                 self.print("pub const {s} = {s};\n\n", .{ try pascal(self.ar, td.name), try self.zigType(t) });
             },
-            else => return error.UnsupportedWitType, // variant/flags/resource: v2
+            else => return error.UnsupportedWitType, // flags/resource: later phase
         }
     }
 
@@ -296,6 +307,14 @@ const Gen = struct {
                         var c: usize = 0;
                         for (fields) |f| c += try self.flatCount(f.type);
                         break :r c;
+                    },
+                    .variant => |cases| v: {
+                        // discriminant + the widest case payload (`null` = 0).
+                        var m: usize = 0;
+                        for (cases) |c| if (c.type) |t| {
+                            m = @max(m, try self.flatCount(t));
+                        };
+                        break :v 1 + m;
                     },
                     .@"enum" => 1,
                     .alias => |t| try self.flatCount(t),
@@ -552,10 +571,22 @@ const Gen = struct {
     }
 
     fn coreOfResult(self: *Gen, ty: ast.Type) GenError!Core {
-        // A flat (single-core) `result<_, _>` flattens to its bare i32
-        // discriminant; aggregate results take the indirect (memory) path.
-        if (ty == .result) return .i32;
-        return self.coreOf(ty);
+        // `ty` is a result already known to flatten to a single core slot.
+        // Aggregates carrying a discriminant (result / all-void variant / enum)
+        // flatten to its i32; a single-field record flattens to that field.
+        return switch (ty) {
+            .result => .i32,
+            .name => |n| switch (self.types.get(n) orelse return error.UnknownType) {
+                .@"enum", .variant => .i32,
+                .record => |fields| if (fields.len == 1)
+                    try self.coreOfResult(fields[0].type)
+                else
+                    error.UnsupportedWitType,
+                .alias => |t| try self.coreOfResult(t),
+                else => error.UnsupportedWitType,
+            },
+            else => self.coreOf(ty),
+        };
     }
 };
 
@@ -783,6 +814,74 @@ test "generate: identifier hygiene (param named `a`, single-word import name)" {
         try testing.expect(std.mem.indexOf(u8, out, "extern \"test:e/edge\" fn @\"ack\"() i32;") != null);
         try testing.expect(std.mem.indexOf(u8, out, "imp.@\"ack\"()") != null);
         try testing.expect(std.mem.indexOf(u8, out, "pub fn ack()") != null);
+    }
+}
+
+test "generate: variant typedef + returns (payload-bearing + all-void)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // variant value { num(u32), text(string), nothing }  — payload-bearing.
+    // variant flag2 { on, off }                          — all-void (flat).
+    const u32_ty: ast.Type = .u32;
+    const str_ty: ast.Type = .string;
+    const value_cases = [_]ast.Case{
+        .{ .name = "num", .type = u32_ty },
+        .{ .name = "text", .type = str_ty },
+        .{ .name = "nothing", .type = null },
+    };
+    const flag_cases = [_]ast.Case{
+        .{ .name = "on", .type = null },
+        .{ .name = "off", .type = null },
+    };
+    const iface_items = [_]ast.InterfaceItem{
+        .{ .type = .{ .name = "value", .kind = .{ .variant = &value_cases } } },
+        .{ .type = .{ .name = "flag2", .kind = .{ .variant = &flag_cases } } },
+        .{ .func = .{ .name = "pick", .func = .{ .params = &.{}, .result = ast.Type{ .name = "value" } } } },
+        .{ .func = .{ .name = "state", .func = .{ .params = &.{}, .result = ast.Type{ .name = "flag2" } } } },
+    };
+    const iface = ast.Interface{ .name = "api", .items = &iface_items };
+    const exp_world = ast.World{ .name = "host", .items = &.{
+        .{ .@"export" = .{ .interface_ref = .{ .ref = .{ .name = "api" } } } },
+    } };
+    const imp_world = ast.World{ .name = "guest", .items = &.{
+        .{ .import = .{ .interface_ref = .{ .ref = .{ .name = "api" } } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "test", .name = "v" },
+        .items = &.{
+            .{ .interface = iface },
+            .{ .world = exp_world },
+            .{ .world = imp_world },
+        },
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    {
+        var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+        try g.generate(exp_world, "host");
+        const out = g.out.items;
+        // The named variant becomes a Zig `union(enum)` (void arm for `nothing`).
+        try testing.expect(std.mem.indexOf(u8, out, "pub const Value = union(enum) {") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "    num: u32,") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "    text: []const u8,") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "    nothing,") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "pub const Flag2 = union(enum) {") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "export fn @\"test:v/api#pick\"() canon.CoreReturn(Value)") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "canon.returnResult(Value, Impl.pick(), &abi.alloc)") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "export fn @\"test:v/api#state\"() canon.CoreReturn(Flag2)") != null);
+    }
+    {
+        var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+        try g.generate(imp_world, "guest");
+        const out = g.out.items;
+        // payload-bearing variant → indirect (retptr + lift).
+        try testing.expect(std.mem.indexOf(u8, out, "extern \"test:v/api\" fn @\"pick\"(retptr: i32) void;") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "return canon.lift(Value, abi.retArea());") != null);
+        // all-void variant → flat i32 discriminant.
+        try testing.expect(std.mem.indexOf(u8, out, "extern \"test:v/api\" fn @\"state\"() i32;") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "return canon.liftResultFlat(Flag2, imp.@\"state\"());") != null);
     }
 }
 

--- a/src/tools/component_bindgen.zig
+++ b/src/tools/component_bindgen.zig
@@ -266,6 +266,11 @@ const Gen = struct {
             .string => "[]const u8",
             .list => |e| try std.fmt.allocPrint(self.ar, "[]const {s}", .{try self.zigType(e.*)}),
             .option => |e| try std.fmt.allocPrint(self.ar, "?{s}", .{try self.zigType(e.*)}),
+            .result => |r| blk: {
+                const ok = if (r.ok) |t| try self.zigType(t.*) else "void";
+                const err = if (r.err) |t| try self.zigType(t.*) else "void";
+                break :blk try std.fmt.allocPrint(self.ar, "canon.Result({s}, {s})", .{ ok, err });
+            },
             .name => |n| try pascal(self.ar, n),
             else => error.UnsupportedWitType,
         };
@@ -277,6 +282,13 @@ const Gen = struct {
         return switch (ty) {
             .string, .list => 2,
             .option => |e| 1 + try self.flatCount(e.*),
+            .result => |r| blk: {
+                // discriminant + the wider of the ok/err payloads (the canonical
+                // ABI joins case payloads; the count is the max). `_` arms = 0.
+                const ok = if (r.ok) |t| try self.flatCount(t.*) else 0;
+                const err = if (r.err) |t| try self.flatCount(t.*) else 0;
+                break :blk 1 + @max(ok, err);
+            },
             .name => |n| blk: {
                 const kind = self.types.get(n) orelse return error.UnknownType;
                 break :blk switch (kind) {
@@ -318,9 +330,11 @@ const Gen = struct {
         self.print(") canon.CoreReturn({s}) {{\n", .{result_zig});
         self.raw("    abi.resetScratch();\n");
 
-        // Lift params into a typed struct via canon.
+        // Lift params into a typed struct via canon. The local is named
+        // `__params` (not a WIT-spellable identifier) so it can't shadow a
+        // function parameter that happens to be named `a`/`p`/etc.
         if (func.params.len > 0) {
-            self.raw("    const a = canon.liftParams(struct {\n");
+            self.raw("    const __params = canon.liftParams(struct {\n");
             for (func.params) |p| {
                 self.print("        {s}: {s},\n", .{ try snake(self.ar, p.name), try self.zigType(p.type) });
             }
@@ -347,7 +361,7 @@ const Gen = struct {
         var buf = std.ArrayListUnmanaged(u8).empty;
         for (params, 0..) |p, idx| {
             if (idx != 0) try buf.appendSlice(self.ar, ", ");
-            try buf.appendSlice(self.ar, "a.");
+            try buf.appendSlice(self.ar, "__params.");
             try buf.appendSlice(self.ar, try snake(self.ar, p.name));
         }
         return buf.items;
@@ -358,21 +372,32 @@ const Gen = struct {
     fn emitImportIface(self: *Gen, u: Use) GenError!void {
         const mod = try snake(self.ar, lastSegment(u.id));
         self.print("pub const {s} = struct {{\n", .{mod});
+        // The flattened `extern` import decls live in a private `imp`
+        // namespace: their names are the exact WIT function names, which would
+        // otherwise collide with the typed wrappers below for single-word
+        // functions (e.g. `ack` → both `@"ack"` and `pub fn ack`). Nesting
+        // keeps the canonical wasm import (module + field) intact.
+        self.raw("    const imp = struct {\n");
         for (u.iface.items) |it| switch (it) {
-            .func => |fd| try self.emitImportFunc(u.id, fd.name, fd.func),
+            .func => |fd| try self.emitImportExtern(u.id, fd.name, fd.func),
+            else => {},
+        };
+        self.raw("    };\n\n");
+        for (u.iface.items) |it| switch (it) {
+            .func => |fd| try self.emitImportWrapper(fd.name, fd.func),
             else => {},
         };
         self.raw("};\n\n");
     }
 
-    fn emitImportFunc(self: *Gen, iface_id: []const u8, name: []const u8, func: ast.Func) GenError!void {
+    /// Emit the flattened `extern` import declaration (inside the `imp`
+    /// namespace) for one imported function.
+    fn emitImportExtern(self: *Gen, iface_id: []const u8, name: []const u8, func: ast.Func) GenError!void {
         if (func.is_async) return error.UnsupportedWitType;
-        const result_zig = try self.resultZig(func);
         const rcount: usize = if (func.result) |t| try self.flatCount(t) else 0;
         const indirect = rcount > 1;
 
-        // extern decl
-        self.print("    extern \"{s}\" fn @\"{s}\"(", .{ iface_id, name });
+        self.print("        extern \"{s}\" fn @\"{s}\"(", .{ iface_id, name });
         try self.emitFlatParamDecls(func.params);
         if (indirect) {
             if (func.params.len > 0) self.raw(", ");
@@ -383,8 +408,16 @@ const Gen = struct {
         } else {
             self.raw(") void;\n");
         }
+    }
 
-        // typed wrapper
+    /// Emit the typed wrapper that lowers params, calls the `imp.@"…"` extern,
+    /// and lifts the result.
+    fn emitImportWrapper(self: *Gen, name: []const u8, func: ast.Func) GenError!void {
+        if (func.is_async) return error.UnsupportedWitType;
+        const result_zig = try self.resultZig(func);
+        const rcount: usize = if (func.result) |t| try self.flatCount(t) else 0;
+        const indirect = rcount > 1;
+
         self.print("    pub fn {s}(", .{try camel(self.ar, name)});
         try self.emitTypedParamDecls(func.params);
         self.print(") {s} {{\n", .{result_zig});
@@ -394,16 +427,16 @@ const Gen = struct {
 
         if (indirect) {
             if (call_args.len > 0) {
-                self.print("        @\"{s}\"({s}, abi.retPtr());\n", .{ name, call_args });
+                self.print("        imp.@\"{s}\"({s}, abi.retPtr());\n", .{ name, call_args });
             } else {
-                self.print("        @\"{s}\"(abi.retPtr());\n", .{name});
+                self.print("        imp.@\"{s}\"(abi.retPtr());\n", .{name});
             }
             self.print("        return canon.lift({s}, abi.retArea());\n", .{result_zig});
         } else if (func.result == null) {
-            self.print("        @\"{s}\"({s});\n", .{ name, call_args });
+            self.print("        imp.@\"{s}\"({s});\n", .{ name, call_args });
         } else {
             self.print(
-                "        return canon.liftResultFlat({s}, @\"{s}\"({s}));\n",
+                "        return canon.liftResultFlat({s}, imp.@\"{s}\"({s}));\n",
                 .{ result_zig, name, call_args },
             );
         }
@@ -519,6 +552,9 @@ const Gen = struct {
     }
 
     fn coreOfResult(self: *Gen, ty: ast.Type) GenError!Core {
+        // A flat (single-core) `result<_, _>` flattens to its bare i32
+        // discriminant; aggregate results take the indirect (memory) path.
+        if (ty == .result) return .i32;
         return self.coreOf(ty);
     }
 };
@@ -631,7 +667,7 @@ test "generate: export shells + import wrappers" {
         const out = g.out.items;
         try testing.expect(std.mem.indexOf(u8, out, "pub const Pet = struct {") != null);
         try testing.expect(std.mem.indexOf(u8, out, "export fn @\"test:t/store#ping\"(x: i32) canon.CoreReturn(u32)") != null);
-        try testing.expect(std.mem.indexOf(u8, out, "canon.returnResult(u32, Impl.ping(a.x), &abi.alloc)") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "canon.returnResult(u32, Impl.ping(__params.x), &abi.alloc)") != null);
         try testing.expect(std.mem.indexOf(u8, out, "export fn @\"test:t/store#get\"(id: i32) canon.CoreReturn(?Pet)") != null);
     }
     {
@@ -640,9 +676,113 @@ test "generate: export shells + import wrappers" {
         const out = g.out.items;
         try testing.expect(std.mem.indexOf(u8, out, "pub const store = struct {") != null);
         try testing.expect(std.mem.indexOf(u8, out, "extern \"test:t/store\" fn @\"ping\"(x: i32) i32;") != null);
-        try testing.expect(std.mem.indexOf(u8, out, "return canon.liftResultFlat(u32, @\"ping\"(@bitCast(x)));") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "return canon.liftResultFlat(u32, imp.@\"ping\"(@bitCast(x)));") != null);
         try testing.expect(std.mem.indexOf(u8, out, "extern \"test:t/store\" fn @\"get\"(id: i32, retptr: i32) void;") != null);
         try testing.expect(std.mem.indexOf(u8, out, "return canon.lift(?Pet, abi.retArea());") != null);
+    }
+}
+
+test "generate: result<T,E> returns (indirect + flat all-void)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // make: func() -> result<u32, string>   (flatCount 3 → indirect)
+    // flag: func() -> result                (flatCount 1 → flat discriminant)
+    const u32_ty: ast.Type = .u32;
+    const str_ty: ast.Type = .string;
+    const res_u32_str = ast.Type{ .result = .{ .ok = &u32_ty, .err = &str_ty } };
+    const res_void = ast.Type{ .result = .{ .ok = null, .err = null } };
+    const iface_items = [_]ast.InterfaceItem{
+        .{ .func = .{ .name = "make", .func = .{ .params = &.{}, .result = res_u32_str } } },
+        .{ .func = .{ .name = "flag", .func = .{ .params = &.{}, .result = res_void } } },
+    };
+    const iface = ast.Interface{ .name = "api", .items = &iface_items };
+    const exp_world = ast.World{ .name = "host", .items = &.{
+        .{ .@"export" = .{ .interface_ref = .{ .ref = .{ .name = "api" } } } },
+    } };
+    const imp_world = ast.World{ .name = "guest", .items = &.{
+        .{ .import = .{ .interface_ref = .{ .ref = .{ .name = "api" } } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "test", .name = "r" },
+        .items = &.{
+            .{ .interface = iface },
+            .{ .world = exp_world },
+            .{ .world = imp_world },
+        },
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    {
+        var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+        try g.generate(exp_world, "host");
+        const out = g.out.items;
+        try testing.expect(std.mem.indexOf(u8, out, "export fn @\"test:r/api#make\"() canon.CoreReturn(canon.Result(u32, []const u8))") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "canon.returnResult(canon.Result(u32, []const u8), Impl.make(), &abi.alloc)") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "export fn @\"test:r/api#flag\"() canon.CoreReturn(canon.Result(void, void))") != null);
+    }
+    {
+        var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+        try g.generate(imp_world, "guest");
+        const out = g.out.items;
+        // indirect result: extern takes a retptr, wrapper lifts from the ret area.
+        try testing.expect(std.mem.indexOf(u8, out, "extern \"test:r/api\" fn @\"make\"(retptr: i32) void;") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "return canon.lift(canon.Result(u32, []const u8), abi.retArea());") != null);
+        // flat all-void result: extern returns the i32 discriminant directly.
+        try testing.expect(std.mem.indexOf(u8, out, "extern \"test:r/api\" fn @\"flag\"() i32;") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "return canon.liftResultFlat(canon.Result(void, void), imp.@\"flag\"());") != null);
+    }
+}
+
+test "generate: identifier hygiene (param named `a`, single-word import name)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // pick: func(a: u32) -> u32   — param `a` must not be shadowed by the
+    //                               lifted-params local.
+    // ack:  func() -> u32         — single-word name: the extern and the
+    //                               wrapper must not collide.
+    const edge_items = [_]ast.InterfaceItem{
+        .{ .func = .{ .name = "pick", .func = .{ .params = &.{.{ .name = "a", .type = .u32 }}, .result = .u32 } } },
+        .{ .func = .{ .name = "ack", .func = .{ .params = &.{}, .result = .u32 } } },
+    };
+    const iface = ast.Interface{ .name = "edge", .items = &edge_items };
+    const exp_world = ast.World{ .name = "host", .items = &.{
+        .{ .@"export" = .{ .interface_ref = .{ .ref = .{ .name = "edge" } } } },
+    } };
+    const imp_world = ast.World{ .name = "guest", .items = &.{
+        .{ .import = .{ .interface_ref = .{ .ref = .{ .name = "edge" } } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "test", .name = "e" },
+        .items = &.{
+            .{ .interface = iface },
+            .{ .world = exp_world },
+            .{ .world = imp_world },
+        },
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    {
+        var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+        try g.generate(exp_world, "host");
+        const out = g.out.items;
+        // The export param is still `a`; the lifted-params local is `__params`.
+        try testing.expect(std.mem.indexOf(u8, out, "export fn @\"test:e/edge#pick\"(a: i32)") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "const __params = canon.liftParams(struct {") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "Impl.pick(__params.a)") != null);
+    }
+    {
+        var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+        try g.generate(imp_world, "guest");
+        const out = g.out.items;
+        // Externs are nested in a private namespace, referenced as `imp.@"…"`.
+        try testing.expect(std.mem.indexOf(u8, out, "const imp = struct {") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "extern \"test:e/edge\" fn @\"ack\"() i32;") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "imp.@\"ack\"()") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "pub fn ack()") != null);
     }
 }
 

--- a/src/tools/component_bindgen.zig
+++ b/src/tools/component_bindgen.zig
@@ -662,6 +662,19 @@ const Gen = struct {
         self.raw("    }\n");
     }
 
+    /// Follow `type x = y` aliases to the underlying WIT type.
+    fn resolveAlias(self: *Gen, ty: ast.Type) ast.Type {
+        var t = ty;
+        while (t == .name) {
+            const k = self.types.get(t.name) orelse return t;
+            switch (k) {
+                .alias => |a| t = a,
+                else => return t,
+            }
+        }
+        return t;
+    }
+
     /// Lower each high-level param into the flat call arguments, emitting temp
     /// statements for `option<…>`. Returns the comma-joined argument list.
     fn lowerParams(self: *Gen, params: []const ast.Param) GenError![]const u8 {
@@ -677,24 +690,34 @@ const Gen = struct {
                 .string => {
                     try args.appendSlice(self.ar, try std.fmt.allocPrint(self.ar, "@intCast(@intFromPtr({s}.ptr)), @intCast({s}.len)", .{ pn, pn }));
                 },
-                .option => |e| {
-                    // emit disc/payload temps
-                    self.print("        const {s}_disc: i32 = if ({s} != null) 1 else 0;\n", .{ pn, pn });
-                    switch (e.*) {
-                        .string => {
-                            self.print("        const {s}_ptr: i32 = if ({s}) |v| @intCast(@intFromPtr(v.ptr)) else 0;\n", .{ pn, pn });
-                            self.print("        const {s}_len: i32 = if ({s}) |v| @intCast(v.len) else 0;\n", .{ pn, pn });
-                            try args.appendSlice(self.ar, try std.fmt.allocPrint(self.ar, "{s}_disc, {s}_ptr, {s}_len", .{ pn, pn, pn }));
-                        },
-                        else => return error.UnsupportedWitType,
-                    }
-                },
+                .option => |e| try self.lowerOptionParam(&args, pn, e.*),
                 else => {
                     try args.appendSlice(self.ar, try self.scalarLowerExpr(pn, p.type));
                 },
             }
         }
         return args.items;
+    }
+
+    /// Lower an `option<inner>` param: a discriminant plus the (null-zeroed)
+    /// payload slots. `string` is the (ptr, len) special case; otherwise the
+    /// payload must flatten to a single core slot (a scalar or a handle).
+    fn lowerOptionParam(self: *Gen, args: *std.ArrayListUnmanaged(u8), pn: []const u8, inner: ast.Type) GenError!void {
+        self.print("        const {s}_disc: i32 = if ({s} != null) 1 else 0;\n", .{ pn, pn });
+        if (inner == .string) {
+            self.print("        const {s}_ptr: i32 = if ({s}) |v| @intCast(@intFromPtr(v.ptr)) else 0;\n", .{ pn, pn });
+            self.print("        const {s}_len: i32 = if ({s}) |v| @intCast(v.len) else 0;\n", .{ pn, pn });
+            try args.appendSlice(self.ar, try std.fmt.allocPrint(self.ar, "{s}_disc, {s}_ptr, {s}_len", .{ pn, pn, pn }));
+            return;
+        }
+        if (try self.flatCount(inner) != 1) return error.UnsupportedWitType;
+        const core = @tagName(try self.coreOfResult(inner));
+        const some: []const u8 = if (self.isHandleLike(inner))
+            "v.handle"
+        else
+            try self.scalarLowerExpr("v", self.resolveAlias(inner));
+        self.print("        const {s}_0: {s} = if ({s}) |v| {s} else 0;\n", .{ pn, core, pn, some });
+        try args.appendSlice(self.ar, try std.fmt.allocPrint(self.ar, "{s}_disc, {s}_0", .{ pn, pn }));
     }
 
     fn scalarLowerExpr(self: *Gen, name: []const u8, ty: ast.Type) GenError![]const u8 {
@@ -1336,5 +1359,41 @@ test "generate: future / stream / tuple in signatures" {
     try testing.expect(std.mem.indexOf(u8, out, "imp.@\"[method]pipe.signal\"(self.handle, f.handle)") != null);
     // free function returning tuple<u32, string>.
     try testing.expect(std.mem.indexOf(u8, out, "pub fn makePair() canon.Tuple(.{ u32, []const u8 }) {") != null);
+}
+
+test "generate: option<handle> / option<scalar> params" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // resource thing { }
+    // set-a: func(t: option<thing>, n: option<u32>) -> bool;
+    const thing_methods = [_]ast.ResourceMethod{};
+    const thing_ref = ast.Type{ .name = "thing" };
+    const opt_thing = ast.Type{ .option = &thing_ref };
+    const u32_ty: ast.Type = .u32;
+    const opt_u32 = ast.Type{ .option = &u32_ty };
+    const iface_items = [_]ast.InterfaceItem{
+        .{ .type = .{ .name = "thing", .kind = .{ .resource = &thing_methods } } },
+        .{ .func = .{ .name = "set-a", .func = .{ .params = &.{ .{ .name = "t", .type = opt_thing }, .{ .name = "n", .type = opt_u32 } }, .result = .bool } } },
+    };
+    const iface = ast.Interface{ .name = "api", .items = &iface_items };
+    const imp_world = ast.World{ .name = "guest", .items = &.{
+        .{ .import = .{ .interface_ref = .{ .ref = .{ .name = "api" } } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "demo", .name = "o" },
+        .items = &.{ .{ .interface = iface }, .{ .world = imp_world } },
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+    try g.generate(imp_world, "guest");
+    const out = g.out.items;
+    // each option lowers to a discriminant + a single (null-zeroed) payload slot.
+    try testing.expect(std.mem.indexOf(u8, out, "extern \"demo:o/api\" fn @\"set-a\"(t_disc: i32, t: i32, n_disc: i32, n: i32) i32;") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "const t_0: i32 = if (t) |v| v.handle else 0;") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "const n_0: i32 = if (n) |v| @bitCast(v) else 0;") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "imp.@\"set-a\"(t_disc, t_0, n_disc, n_0)") != null);
 }
 

--- a/src/tools/component_bindgen.zig
+++ b/src/tools/component_bindgen.zig
@@ -253,10 +253,21 @@ const Gen = struct {
                 }
                 self.raw("};\n\n");
             },
+            .flags => |labels| {
+                // A bitset: one bool bit per label (LSB-first) in a backing
+                // integer sized to the canonical ABI (1/2/4 bytes for ≤8/≤16/≤32
+                // labels). >32 labels (multi-i32) is a later phase.
+                if (labels.len > 32) return error.UnsupportedWitType;
+                const bits: usize = if (labels.len <= 8) 8 else if (labels.len <= 16) 16 else 32;
+                self.print("pub const {s} = packed struct(u{d}) {{\n", .{ try pascal(self.ar, td.name), bits });
+                for (labels) |l| self.print("    {s}: bool = false,\n", .{try snake(self.ar, l)});
+                if (bits > labels.len) self.print("    _padding: u{d} = 0,\n", .{bits - labels.len});
+                self.raw("};\n\n");
+            },
             .alias => |t| {
                 self.print("pub const {s} = {s};\n\n", .{ try pascal(self.ar, td.name), try self.zigType(t) });
             },
-            else => return error.UnsupportedWitType, // flags/resource: later phase
+            else => return error.UnsupportedWitType, // resource: later phase
         }
     }
 
@@ -316,6 +327,7 @@ const Gen = struct {
                         };
                         break :v 1 + m;
                     },
+                    .flags => |labels| (labels.len + 31) / 32, // i32 slots
                     .@"enum" => 1,
                     .alias => |t| try self.flatCount(t),
                     else => error.UnsupportedWitType,
@@ -578,6 +590,7 @@ const Gen = struct {
             .result => .i32,
             .name => |n| switch (self.types.get(n) orelse return error.UnknownType) {
                 .@"enum", .variant => .i32,
+                .flags => .i32, // ≤32 labels → a single i32 slot
                 .record => |fields| if (fields.len == 1)
                     try self.coreOfResult(fields[0].type)
                 else
@@ -882,6 +895,57 @@ test "generate: variant typedef + returns (payload-bearing + all-void)" {
         // all-void variant → flat i32 discriminant.
         try testing.expect(std.mem.indexOf(u8, out, "extern \"test:v/api\" fn @\"state\"() i32;") != null);
         try testing.expect(std.mem.indexOf(u8, out, "return canon.liftResultFlat(Flag2, imp.@\"state\"());") != null);
+    }
+}
+
+test "generate: flags typedef + flat return" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // flags perms { read, write, exec } ; get-perms: func() -> perms
+    const labels = [_][]const u8{ "read", "write", "exec" };
+    const iface_items = [_]ast.InterfaceItem{
+        .{ .type = .{ .name = "perms", .kind = .{ .flags = &labels } } },
+        .{ .func = .{ .name = "get-perms", .func = .{ .params = &.{}, .result = ast.Type{ .name = "perms" } } } },
+    };
+    const iface = ast.Interface{ .name = "api", .items = &iface_items };
+    const exp_world = ast.World{ .name = "host", .items = &.{
+        .{ .@"export" = .{ .interface_ref = .{ .ref = .{ .name = "api" } } } },
+    } };
+    const imp_world = ast.World{ .name = "guest", .items = &.{
+        .{ .import = .{ .interface_ref = .{ .ref = .{ .name = "api" } } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "test", .name = "f" },
+        .items = &.{
+            .{ .interface = iface },
+            .{ .world = exp_world },
+            .{ .world = imp_world },
+        },
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    {
+        var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+        try g.generate(exp_world, "host");
+        const out = g.out.items;
+        // 3 labels (≤8) → a u8-backed packed struct with padding to fill it.
+        try testing.expect(std.mem.indexOf(u8, out, "pub const Perms = packed struct(u8) {") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "    read: bool = false,") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "    exec: bool = false,") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "    _padding: u5 = 0,") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "export fn @\"test:f/api#get-perms\"() canon.CoreReturn(Perms)") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "canon.returnResult(Perms, Impl.getPerms(), &abi.alloc)") != null);
+    }
+    {
+        var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+        try g.generate(imp_world, "guest");
+        const out = g.out.items;
+        try testing.expect(std.mem.indexOf(u8, out, "pub const Perms = packed struct(u8) {") != null);
+        // ≤32 labels → flat i32.
+        try testing.expect(std.mem.indexOf(u8, out, "extern \"test:f/api\" fn @\"get-perms\"() i32;") != null);
+        try testing.expect(std.mem.indexOf(u8, out, "return canon.liftResultFlat(Perms, imp.@\"get-perms\"());") != null);
     }
 }
 

--- a/src/tools/component_bindgen.zig
+++ b/src/tools/component_bindgen.zig
@@ -146,6 +146,8 @@ const Gen = struct {
     out: std.ArrayListUnmanaged(u8) = .empty,
     // WIT type name → its kind, across all interfaces in the world.
     types: std.StringHashMapUnmanaged(ast.TypeDefKind) = .empty,
+    // Monotonic counter for naming per-export `[task-return]` helper structs.
+    task_counter: usize = 0,
 
     fn raw(self: *Gen, s: []const u8) void {
         self.out.appendSlice(self.ar, s) catch @panic("OOM");
@@ -360,7 +362,7 @@ const Gen = struct {
     }
 
     fn emitExportFunc(self: *Gen, iface_id: []const u8, name: []const u8, func: ast.Func) GenError!void {
-        if (func.is_async) return error.UnsupportedWitType;
+        if (func.is_async) return self.emitAsyncExportFunc(iface_id, name, func);
         const result_zig = try self.resultZig(func);
 
         self.print("export fn @\"{s}#{s}\"(", .{ iface_id, name });
@@ -368,18 +370,7 @@ const Gen = struct {
         self.print(") canon.CoreReturn({s}) {{\n", .{result_zig});
         self.raw("    abi.resetScratch();\n");
 
-        // Lift params into a typed struct via canon. The local is named
-        // `__params` (not a WIT-spellable identifier) so it can't shadow a
-        // function parameter that happens to be named `a`/`p`/etc.
-        if (func.params.len > 0) {
-            self.raw("    const __params = canon.liftParams(struct {\n");
-            for (func.params) |p| {
-                self.print("        {s}: {s},\n", .{ try snake(self.ar, p.name), try self.zigType(p.type) });
-            }
-            self.raw("    }, .{ ");
-            try self.emitFlatSlotNames(func.params);
-            self.raw(" });\n");
-        }
+        try self.emitLiftParams(func.params);
 
         // Call the user impl + encode the result.
         const args = try self.implArgList(func.params);
@@ -390,6 +381,58 @@ const Gen = struct {
             self.print(
                 "    return canon.returnResult({s}, Impl.{s}({s}), &abi.alloc);\n",
                 .{ result_zig, try camel(self.ar, name), args },
+            );
+        }
+        self.raw("}\n\n");
+    }
+
+    /// Emit the `const __params = canon.liftParams(struct { … }, .{ … });` block
+    /// that decodes an export's flattened core params (named `__params` so it
+    /// can't shadow a parameter named `a`/`p`/etc.). No-op when there are none.
+    fn emitLiftParams(self: *Gen, params: []const ast.Param) GenError!void {
+        if (params.len == 0) return;
+        self.raw("    const __params = canon.liftParams(struct {\n");
+        for (params) |p| {
+            self.print("        {s}: {s},\n", .{ try snake(self.ar, p.name), try self.zigType(p.type) });
+        }
+        self.raw("    }, .{ ");
+        try self.emitFlatSlotNames(params);
+        self.raw(" });\n");
+    }
+
+    /// Emit an async-lifted export: a core `export fn … () void` that lifts its
+    /// params, calls the user impl, and delivers the result through the
+    /// `[task-return]<iface>#<fn>` intrinsic (the canonical async-lift shape
+    /// `component new` wires for an `async func`). Results that flatten to more
+    /// than one core slot (the direct multi-slot task.return form) are a later
+    /// phase, as is calling *imported* async functions.
+    fn emitAsyncExportFunc(self: *Gen, iface_id: []const u8, name: []const u8, func: ast.Func) GenError!void {
+        const rcount: usize = if (func.result) |t| try self.flatCount(t) else 0;
+        if (rcount > 1) return error.UnsupportedWitType; // async aggregate result: later phase
+
+        // Per-export `[task-return]` helper (extern decls must be container-scope).
+        const tname = try std.fmt.allocPrint(self.ar, "__task_{d}", .{self.task_counter});
+        self.task_counter += 1;
+        self.print("const {s} = struct {{\n", .{tname});
+        self.print("    extern \"[task-return]{s}#{s}\" fn @\"task-return\"(", .{ iface_id, name });
+        if (rcount == 1) self.print("d0: {s}", .{@tagName(try self.coreOfResult(func.result.?))});
+        self.raw(") void;\n};\n\n");
+
+        self.print("export fn @\"{s}#{s}\"(", .{ iface_id, name });
+        try self.emitFlatParamDecls(func.params);
+        self.raw(") void {\n");
+        self.raw("    abi.resetScratch();\n");
+
+        try self.emitLiftParams(func.params);
+
+        const args = try self.implArgList(func.params);
+        if (func.result == null) {
+            self.print("    Impl.{s}({s});\n", .{ try camel(self.ar, name), args });
+            self.print("    {s}.@\"task-return\"();\n", .{tname});
+        } else {
+            self.print(
+                "    {s}.@\"task-return\"(canon.returnResult({s}, Impl.{s}({s}), &abi.alloc));\n",
+                .{ tname, try self.resultZig(func), try camel(self.ar, name), args },
             );
         }
         self.raw("}\n\n");
@@ -1154,6 +1197,73 @@ test "generate: imported resource handle struct + methods/static/ctor/drop" {
         // Exported (guest-implemented) resources are not supported yet.
         var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
         try testing.expectError(error.UnsupportedWitType, g.generate(exp_world, "host"));
+    }
+}
+
+test "generate: async export lift (task.return)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // run:    async func() -> result        (flat result → task-return(i32))
+    // double: async func(x: u32) -> u32      (param lift + flat result)
+    const res_void = ast.Type{ .result = .{ .ok = null, .err = null } };
+    const iface_items = [_]ast.InterfaceItem{
+        .{ .func = .{ .name = "run", .func = .{ .params = &.{}, .result = res_void, .is_async = true } } },
+        .{ .func = .{ .name = "double", .func = .{ .params = &.{.{ .name = "x", .type = .u32 }}, .result = .u32, .is_async = true } } },
+    };
+    const iface = ast.Interface{ .name = "run", .items = &iface_items };
+    const exp_world = ast.World{ .name = "host", .items = &.{
+        .{ .@"export" = .{ .interface_ref = .{ .ref = .{ .name = "run" } } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "local", .name = "p", .version = "0.1.0" },
+        .items = &.{ .{ .interface = iface }, .{ .world = exp_world } },
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+    try g.generate(exp_world, "host");
+    const out = g.out.items;
+    // async export = core `() void` + a `[task-return]` intrinsic delivering the result.
+    try testing.expect(std.mem.indexOf(u8, out, "extern \"[task-return]local:p/run@0.1.0#run\" fn @\"task-return\"(d0: i32) void;") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "export fn @\"local:p/run@0.1.0#run\"() void {") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "__task_0.@\"task-return\"(canon.returnResult(canon.Result(void, void), Impl.run(), &abi.alloc));") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "export fn @\"local:p/run@0.1.0#double\"(x: i32) void {") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "__task_1.@\"task-return\"(canon.returnResult(u32, Impl.double(__params.x), &abi.alloc));") != null);
+}
+
+test "generate: async aggregate result and async import are rejected (later phases)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // `async func() -> string` flattens to 2 slots (the direct multi-slot
+    // task.return form), which is a later phase.
+    const agg_items = [_]ast.InterfaceItem{
+        .{ .func = .{ .name = "greet", .func = .{ .params = &.{}, .result = .string, .is_async = true } } },
+    };
+    const agg_iface = ast.Interface{ .name = "api", .items = &agg_items };
+    const agg_exp = ast.World{ .name = "host", .items = &.{
+        .{ .@"export" = .{ .interface_ref = .{ .ref = .{ .name = "api" } } } },
+    } };
+    const agg_imp = ast.World{ .name = "guest", .items = &.{
+        .{ .import = .{ .interface_ref = .{ .ref = .{ .name = "api" } } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "test", .name = "a" },
+        .items = &.{ .{ .interface = agg_iface }, .{ .world = agg_exp }, .{ .world = agg_imp } },
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    {
+        var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+        try testing.expectError(error.UnsupportedWitType, g.generate(agg_exp, "host"));
+    }
+    {
+        // Calling an imported async function (async lower) is a later phase.
+        var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+        try testing.expectError(error.UnsupportedWitType, g.generate(agg_imp, "guest"));
     }
 }
 

--- a/src/tools/component_bindgen.zig
+++ b/src/tools/component_bindgen.zig
@@ -300,9 +300,21 @@ const Gen = struct {
                 const err = if (r.err) |t| try self.zigType(t.*) else "void";
                 break :blk try std.fmt.allocPrint(self.ar, "canon.Result({s}, {s})", .{ ok, err });
             },
+            .tuple => |elems| blk: {
+                var b = std.ArrayListUnmanaged(u8).empty;
+                try b.appendSlice(self.ar, "canon.Tuple(.{ ");
+                for (elems, 0..) |e, i| {
+                    if (i != 0) try b.appendSlice(self.ar, ", ");
+                    try b.appendSlice(self.ar, try self.zigType(e));
+                }
+                try b.appendSlice(self.ar, " })");
+                break :blk b.items;
+            },
+            .future => |e| try std.fmt.allocPrint(self.ar, "canon.Future({s})", .{if (e) |t| try self.zigType(t.*) else "void"}),
+            .stream => |e| try std.fmt.allocPrint(self.ar, "canon.Stream({s})", .{if (e) |t| try self.zigType(t.*) else "void"}),
+            .error_context => "canon.ErrorContextHandle",
             .own, .borrow => |r| try pascal(self.ar, r), // resource handle wrapper
             .name => |n| try pascal(self.ar, n),
-            else => error.UnsupportedWitType,
         };
     }
 
@@ -319,6 +331,12 @@ const Gen = struct {
                 const err = if (r.err) |t| try self.flatCount(t.*) else 0;
                 break :blk 1 + @max(ok, err);
             },
+            .tuple => |elems| blk: {
+                var c: usize = 0;
+                for (elems) |e| c += try self.flatCount(e);
+                break :blk c;
+            },
+            .future, .stream, .error_context => 1, // an i32 handle
             .name => |n| blk: {
                 const kind = self.types.get(n) orelse return error.UnknownType;
                 break :blk switch (kind) {
@@ -651,7 +669,7 @@ const Gen = struct {
         for (params) |p| {
             const pn = try snake(self.ar, p.name);
             if (args.items.len != 0) try args.appendSlice(self.ar, ", ");
-            if (self.handleResource(p.type) != null) {
+            if (self.isHandleLike(p.type)) {
                 try args.appendSlice(self.ar, try std.fmt.allocPrint(self.ar, "{s}.handle", .{pn}));
                 continue;
             }
@@ -732,7 +750,7 @@ const Gen = struct {
     }
 
     fn flattenSlots(self: *Gen, out: *std.ArrayListUnmanaged(Slot), base: []const u8, ty: ast.Type) GenError!void {
-        if (self.handleResource(ty) != null) {
+        if (self.isHandleLike(ty)) {
             try out.append(self.ar, .{ .name = base, .core = .i32 });
             return;
         }
@@ -745,6 +763,9 @@ const Gen = struct {
                 try out.append(self.ar, .{ .name = try std.fmt.allocPrint(self.ar, "{s}_disc", .{base}), .core = .i32 });
                 try self.flattenSlots(out, base, e.*);
             },
+            .tuple => |elems| for (elems, 0..) |e, i| {
+                try self.flattenSlots(out, try std.fmt.allocPrint(self.ar, "{s}_{d}", .{ base, i }), e);
+            },
             else => try out.append(self.ar, .{ .name = base, .core = self.coreOf(ty) catch return error.UnsupportedWitType }),
         }
     }
@@ -756,18 +777,19 @@ const Gen = struct {
             .u64, .s64 => .i64,
             .f32 => .f32,
             .f64 => .f64,
-            .own, .borrow => .i32, // resource handle
+            .own, .borrow, .future, .stream, .error_context => .i32, // handles
             else => error.UnsupportedWitType,
         };
     }
 
-    /// If `ty` is a resource handle — `own<R>`, `borrow<R>`, or a bare reference
-    /// to a resource type — return the resource's WIT name; otherwise null.
-    fn handleResource(self: *Gen, ty: ast.Type) ?[]const u8 {
+    /// True when `ty` lowers to a single `i32` handle accessed via a `.handle`
+    /// field: `own<R>` / `borrow<R>` / a bare resource reference, or a
+    /// `future<T>` / `stream<T>` / `error-context`.
+    fn isHandleLike(self: *Gen, ty: ast.Type) bool {
         return switch (ty) {
-            .own, .borrow => |r| r,
-            .name => |n| if (self.types.get(n)) |k| (if (k == .resource) n else null) else null,
-            else => null,
+            .own, .borrow, .future, .stream, .error_context => true,
+            .name => |n| if (self.types.get(n)) |k| k == .resource else false,
+            else => false,
         };
     }
 
@@ -777,7 +799,8 @@ const Gen = struct {
         // flatten to its i32; a single-field record flattens to that field.
         return switch (ty) {
             .result => .i32,
-            .own, .borrow => .i32, // resource handle
+            .own, .borrow, .future, .stream, .error_context => .i32, // handles
+            .tuple => |elems| if (elems.len == 1) try self.coreOfResult(elems[0]) else error.UnsupportedWitType,
             .name => |n| switch (self.types.get(n) orelse return error.UnknownType) {
                 .@"enum", .variant => .i32,
                 .flags => .i32, // ≤32 labels → a single i32 slot
@@ -1265,5 +1288,53 @@ test "generate: async aggregate result and async import are rejected (later phas
         var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
         try testing.expectError(error.UnsupportedWitType, g.generate(agg_imp, "guest"));
     }
+}
+
+test "generate: future / stream / tuple in signatures" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // resource pipe {
+    //   body: func() -> tuple<stream<u8>, future<u32>>;
+    //   signal: func(f: future<u32>) -> bool;
+    // }
+    // make-pair: func() -> tuple<u32, string>;
+    const u8_ty: ast.Type = .u8;
+    const u32_ty: ast.Type = .u32;
+    const str_ty: ast.Type = .string;
+    const stream_u8 = ast.Type{ .stream = &u8_ty };
+    const future_u32 = ast.Type{ .future = &u32_ty };
+    const body_result = ast.Type{ .tuple = &.{ stream_u8, future_u32 } };
+    const pair_result = ast.Type{ .tuple = &.{ u32_ty, str_ty } };
+    const pipe_methods = [_]ast.ResourceMethod{
+        .{ .kind = .method, .name = "body", .func = .{ .params = &.{}, .result = body_result } },
+        .{ .kind = .method, .name = "signal", .func = .{ .params = &.{.{ .name = "f", .type = future_u32 }}, .result = .bool } },
+    };
+    const iface_items = [_]ast.InterfaceItem{
+        .{ .type = .{ .name = "pipe", .kind = .{ .resource = &pipe_methods } } },
+        .{ .func = .{ .name = "make-pair", .func = .{ .params = &.{}, .result = pair_result } } },
+    };
+    const iface = ast.Interface{ .name = "chan", .items = &iface_items };
+    const imp_world = ast.World{ .name = "guest", .items = &.{
+        .{ .import = .{ .interface_ref = .{ .ref = .{ .name = "chan" } } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "demo", .name = "fs" },
+        .items = &.{ .{ .interface = iface }, .{ .world = imp_world } },
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+    try g.generate(imp_world, "guest");
+    const out = g.out.items;
+    // tuple<stream<u8>, future<u32>> result (indirect, lifted from memory).
+    try testing.expect(std.mem.indexOf(u8, out, "pub fn body(self: Pipe) canon.Tuple(.{ canon.Stream(u8), canon.Future(u32) }) {") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "return canon.lift(canon.Tuple(.{ canon.Stream(u8), canon.Future(u32) }), abi.retArea());") != null);
+    // future<u32> param lowers to its i32 handle.
+    try testing.expect(std.mem.indexOf(u8, out, "pub fn signal(self: Pipe, f: canon.Future(u32)) bool {") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "imp.@\"[method]pipe.signal\"(self.handle, f.handle)") != null);
+    // free function returning tuple<u32, string>.
+    try testing.expect(std.mem.indexOf(u8, out, "pub fn makePair() canon.Tuple(.{ u32, []const u8 }) {") != null);
 }
 

--- a/src/tools/component_bindgen.zig
+++ b/src/tools/component_bindgen.zig
@@ -682,21 +682,44 @@ const Gen = struct {
         for (params) |p| {
             const pn = try snake(self.ar, p.name);
             if (args.items.len != 0) try args.appendSlice(self.ar, ", ");
-            if (self.isHandleLike(p.type)) {
+            const rty = self.resolveAlias(p.type);
+            if (self.isHandleLike(rty)) {
                 try args.appendSlice(self.ar, try std.fmt.allocPrint(self.ar, "{s}.handle", .{pn}));
                 continue;
             }
-            switch (p.type) {
-                .string => {
+            switch (rty) {
+                .string, .list => {
+                    // `string` / `list<T>`: pass the guest slice's (ptr, len).
                     try args.appendSlice(self.ar, try std.fmt.allocPrint(self.ar, "@intCast(@intFromPtr({s}.ptr)), @intCast({s}.len)", .{ pn, pn }));
                 },
-                .option => |e| try self.lowerOptionParam(&args, pn, e.*),
-                else => {
-                    try args.appendSlice(self.ar, try self.scalarLowerExpr(pn, p.type));
+                .option => |e| {
+                    const inner = self.resolveAlias(e.*);
+                    if (inner == .string or (try self.flatCount(inner)) == 1) {
+                        try self.lowerOptionParam(&args, pn, inner);
+                    } else {
+                        try self.lowerAggregateParam(&args, pn, p.type);
+                    }
                 },
+                .bool, .u8, .u16, .u32, .u64, .s8, .s16, .s32, .s64, .f32, .f64, .char => {
+                    try args.appendSlice(self.ar, try self.scalarLowerExpr(pn, rty));
+                },
+                // record / variant / result / tuple / enum / flags: flatten the
+                // whole value to its core slots via canon and pass them positionally.
+                else => try self.lowerAggregateParam(&args, pn, p.type),
             }
         }
         return args.items;
+    }
+
+    /// Lower an aggregate param: `const <pn>_s = canon.lowerFlat(<T>, <pn>,
+    /// &abi.alloc);` then pass `<pn>_s[0], …, <pn>_s[K-1]` positionally.
+    fn lowerAggregateParam(self: *Gen, args: *std.ArrayListUnmanaged(u8), pn: []const u8, ty: ast.Type) GenError!void {
+        const k = (try self.flatCores(ty)).len;
+        self.print("        const {s}_s = canon.lowerFlat({s}, {s}, &abi.alloc);\n", .{ pn, try self.zigType(ty), pn });
+        for (0..k) |i| {
+            if (i != 0) try args.appendSlice(self.ar, ", ");
+            try args.appendSlice(self.ar, try std.fmt.allocPrint(self.ar, "{s}_s[{d}]", .{ pn, i }));
+        }
     }
 
     /// Lower an `option<inner>` param: a discriminant plus the (null-zeroed)
@@ -772,7 +795,8 @@ const Gen = struct {
         return out.items;
     }
 
-    fn flattenSlots(self: *Gen, out: *std.ArrayListUnmanaged(Slot), base: []const u8, ty: ast.Type) GenError!void {
+    fn flattenSlots(self: *Gen, out: *std.ArrayListUnmanaged(Slot), base: []const u8, raw_ty: ast.Type) GenError!void {
+        const ty = self.resolveAlias(raw_ty);
         if (self.isHandleLike(ty)) {
             try out.append(self.ar, .{ .name = base, .core = .i32 });
             return;
@@ -789,7 +813,81 @@ const Gen = struct {
             .tuple => |elems| for (elems, 0..) |e, i| {
                 try self.flattenSlots(out, try std.fmt.allocPrint(self.ar, "{s}_{d}", .{ base, i }), e);
             },
-            else => try out.append(self.ar, .{ .name = base, .core = self.coreOf(ty) catch return error.UnsupportedWitType }),
+            else => {
+                // scalar (1 slot) or aggregate (record/variant/result/enum/flags):
+                // use the canonical flat core types (with the variant join).
+                const cores = try self.flatCores(ty);
+                if (cores.len == 1) {
+                    try out.append(self.ar, .{ .name = base, .core = cores[0] });
+                } else for (cores, 0..) |c, i| {
+                    try out.append(self.ar, .{ .name = try std.fmt.allocPrint(self.ar, "{s}_{d}", .{ base, i }), .core = c });
+                }
+            },
+        }
+    }
+
+    fn joinCoreG(a: Core, b: Core) Core {
+        if (a == b) return a;
+        if ((a == .i32 and b == .f32) or (a == .f32 and b == .i32)) return .i32;
+        return .i64;
+    }
+
+    /// The canonical flat core types `ty` lowers to (mirrors `canon.flatTypeList`,
+    /// including the `variant`/`result` join). Used for both the flattened extern
+    /// signatures and the export param decls.
+    fn flatCores(self: *Gen, raw_ty: ast.Type) GenError![]const Core {
+        const ty = self.resolveAlias(raw_ty);
+        if (self.isHandleLike(ty)) return &[_]Core{.i32};
+        return switch (ty) {
+            .string, .list => &[_]Core{ .i32, .i32 },
+            .option => |e| blk: {
+                var l = std.ArrayListUnmanaged(Core).empty;
+                try l.append(self.ar, .i32);
+                try l.appendSlice(self.ar, try self.flatCores(e.*));
+                break :blk l.items;
+            },
+            .tuple => |elems| blk: {
+                var l = std.ArrayListUnmanaged(Core).empty;
+                for (elems) |e| try l.appendSlice(self.ar, try self.flatCores(e));
+                break :blk l.items;
+            },
+            .result => |r| blk: {
+                var l = std.ArrayListUnmanaged(Core).empty;
+                try l.append(self.ar, .i32); // discriminant
+                if (r.ok) |t| try self.joinInto(&l, t.*);
+                if (r.err) |t| try self.joinInto(&l, t.*);
+                break :blk l.items;
+            },
+            .name => |n| switch (self.types.get(n) orelse return error.UnknownType) {
+                .record => |fields| blk: {
+                    var l = std.ArrayListUnmanaged(Core).empty;
+                    for (fields) |f| try l.appendSlice(self.ar, try self.flatCores(f.type));
+                    break :blk l.items;
+                },
+                .variant => |cases| blk: {
+                    var l = std.ArrayListUnmanaged(Core).empty;
+                    try l.append(self.ar, .i32); // discriminant
+                    for (cases) |c| if (c.type) |t| try self.joinInto(&l, t);
+                    break :blk l.items;
+                },
+                .@"enum", .resource => &[_]Core{.i32},
+                .flags => |labels| blk: {
+                    var l = std.ArrayListUnmanaged(Core).empty;
+                    for (0..(labels.len + 31) / 32) |_| try l.append(self.ar, .i32);
+                    break :blk l.items;
+                },
+                .alias => unreachable, // resolved above
+            },
+            else => &[_]Core{try self.coreOf(ty)}, // scalar
+        };
+    }
+
+    /// Join `ty`'s flat cores element-wise into `l[1..]` (extending as needed).
+    fn joinInto(self: *Gen, l: *std.ArrayListUnmanaged(Core), ty: ast.Type) GenError!void {
+        const cores = try self.flatCores(ty);
+        for (cores, 0..) |c, i| {
+            const idx = 1 + i;
+            if (idx < l.items.len) l.items[idx] = joinCoreG(l.items[idx], c) else try l.append(self.ar, c);
         }
     }
 
@@ -1395,5 +1493,53 @@ test "generate: option<handle> / option<scalar> params" {
     try testing.expect(std.mem.indexOf(u8, out, "const t_0: i32 = if (t) |v| v.handle else 0;") != null);
     try testing.expect(std.mem.indexOf(u8, out, "const n_0: i32 = if (n) |v| @bitCast(v) else 0;") != null);
     try testing.expect(std.mem.indexOf(u8, out, "imp.@\"set-a\"(t_disc, t_0, n_disc, n_0)") != null);
+}
+
+test "generate: aggregate params (variant / record) lower via canon.lowerFlat" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // variant method { get, post, other(string) }   → disc + (ptr, len) = 3 slots
+    // record point { x: u32, y: u32 }                 → 2 slots
+    const str_ty: ast.Type = .string;
+    const method_cases = [_]ast.Case{
+        .{ .name = "get", .type = null },
+        .{ .name = "post", .type = null },
+        .{ .name = "other", .type = str_ty },
+    };
+    const point_fields = [_]ast.Field{
+        .{ .name = "x", .type = .u32 },
+        .{ .name = "y", .type = .u32 },
+    };
+    const method_ref = ast.Type{ .name = "method" };
+    const point_ref = ast.Type{ .name = "point" };
+    const iface_items = [_]ast.InterfaceItem{
+        .{ .type = .{ .name = "method", .kind = .{ .variant = &method_cases } } },
+        .{ .type = .{ .name = "point", .kind = .{ .record = &point_fields } } },
+        .{ .func = .{ .name = "set-method", .func = .{ .params = &.{.{ .name = "m", .type = method_ref }}, .result = .bool } } },
+        .{ .func = .{ .name = "move-to", .func = .{ .params = &.{.{ .name = "p", .type = point_ref }}, .result = .u32 } } },
+    };
+    const iface = ast.Interface{ .name = "api", .items = &iface_items };
+    const imp_world = ast.World{ .name = "guest", .items = &.{
+        .{ .import = .{ .interface_ref = .{ .ref = .{ .name = "api" } } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "demo", .name = "m" },
+        .items = &.{ .{ .interface = iface }, .{ .world = imp_world } },
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+    try g.generate(imp_world, "guest");
+    const out = g.out.items;
+    // variant flattens to disc + joined payload (here (ptr, len)) = 3 i32 slots.
+    try testing.expect(std.mem.indexOf(u8, out, "extern \"demo:m/api\" fn @\"set-method\"(m_0: i32, m_1: i32, m_2: i32) i32;") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "const m_s = canon.lowerFlat(Method, m, &abi.alloc);") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "imp.@\"set-method\"(m_s[0], m_s[1], m_s[2])") != null);
+    // record flattens to its concatenated fields = 2 i32 slots.
+    try testing.expect(std.mem.indexOf(u8, out, "extern \"demo:m/api\" fn @\"move-to\"(p_0: i32, p_1: i32) i32;") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "const p_s = canon.lowerFlat(Point, p, &abi.alloc);") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "imp.@\"move-to\"(p_s[0], p_s[1])") != null);
 }
 


### PR DESCRIPTION
## Summary

Closes the gap in `wabt component bindgen` ("v1") tracked by #284: extend the
Zig guest-binding generator from a restricted subset (primitives, `string`,
`option`, `list`, `record`, `enum`) to the full type and function surface a real
WASI 0.3 world needs.

**Acceptance milestone met:** a `wasi:http@0.3.0` handler **service** world
(`import wasi:http/types@0.3.0; export wasi:http/handler@0.3.0;`) can now be
passed directly to `wabt component bindgen`; the generated bindings compile to
`wasm32-freestanding` and `wabt component new` accepts the core module → a valid
component. The generated `handle` async shell matches the hand-written
`wasi_http.zig` reference exactly (`[task-return](d0..d7)`).

> Depends on the `canon` runtime changes in #287 (the generated code imports
> `canon.Result` / `canon.lowerFlat` / `canon.Stream` / …).

## What's supported now

- **`result<T, E>`** returns (`canon.Result`, flat + indirect).
- **`variant`** and **`flags`** types/returns (`union(enum)` / `packed struct`).
- **`tuple`**, **`future<T>`**, **`stream<T>`**, **`error-context`** in signatures
  (handles via a unified `isHandleLike`).
- **Imported resources** — handle-wrapper structs with `[constructor]` /
  `[method]` / `[static]` / `[resource-drop]` externs and a `deinit`.
- **Aggregate / multi-slot parameters** (record/variant/result/tuple/flags and
  multi-slot options) via `canon.lowerFlat`, including the variant/result join;
  `option<handle>` / `option<scalar>`; `list<T>` params; alias resolution.
- **Async exports** — async lift + `[task-return]`, delivering flat and
  multi-slot results.
- **`use pkg:iface.{…}`** type imports, resolved in the containing interface's
  package context (so a short `use types.{…}` inside `wasi:http/handler`
  resolves `types` as `wasi:http/types`).

Also fixes two pre-existing codegen bugs surfaced by single-word / colliding WIT
names (the export lifted-params local shadowing a param named `a`; the import
`extern` decl colliding with its typed wrapper) and a real dangling-slice bug in
the flat-core computation (a runtime scalar core returned via `&[_]Core{…}` read
back as garbage, mis-typing an `option<u64>` slot).

## Validation

- `zig build test`: **630/630** unit tests pass (per-feature substring/golden
  tests on the emitted source).
- End-to-end against the #287 `canon`/`abi`: generated bindings for each feature
  compile to wasm32 and `wabt component new` accepts them (incl. the full
  `wasi:http/types` and the `svc` handler world). Several run on the local
  wasmtime 46 build — e.g. async `run() -> result` → `ok`,
  `double(21)` → `42`, `classify(99)` → `err("too big")`.

## Deferred (follow-ups, noted in the issue)

- `named_func` / `named_interface` world externs — blocked by the core pipeline
  (#285); bindgen support tracked in #286.
- Complex-element `future`/`stream` (the function-reference intrinsic form, e.g.
  the handler's `future<result<…>>`); calling **imported** async functions
  (async lower); rewriting `example/http` to a single `svc` world.
