### PR TITLE
petstore: drive the generated single-svc wasi:http bindings (#289)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,39 +36,51 @@ on lives on the orphan branch `wasip3` of the same repository.
 
 `interface store` is a typed data-access API: `pet` / `toy` **records**, with
 `option<record>` results and `count` + indexed `*-at` accessors (instead of
-`list<record>`). Worlds: `svc` (the frontend) `import`s `store` and wasi:http;
-`store-provider` (the backend) `export`s `store`; `store-consumer` is an
-import-only world used by bindgen.
+`list<record>`). Worlds: `svc` (the frontend) `import`s `store` **and**
+`wasi:http/types` and `export`s the async `wasi:http/handler`; `store-provider`
+(the backend) `export`s `store`.
 
 Both sides' canonical-ABI glue is **generated at build time** by
 `wabt component bindgen`, which emits the flattened `extern`/`export` shells and
 the `Pet` / `Toy` Zig types and delegates all marshalling to `wasip3`'s comptime
 `canon` library. There is no hand-written `extern struct`, flat-vs-indirect
-logic, or lower/lift code on either side.
+logic, or lower/lift code on either side — and no hand-written `wasi_http`: the
+frontend drives the **generated** `wasi:http` bindings directly.
 
 - **Backend** — `build.zig` runs `bindgen` on `store-provider` to generate the
   `export fn` shells (params lifted with `canon.liftParams`, return type
   `canon.CoreReturn(R)`, result encoded with `canon.returnResult`). The shells
   call **`src/memory_store.zig`** — the in-memory pets/toys store, pure business
   logic returning the generated `Pet` / `Toy` types.
-- **Frontend** — `bindgen` on `store-consumer` generates the `store.*` import
-  wrappers (results decoded with `canon.liftResultFlat` / `canon.lift`).
-  `src/main.zig` calls them and builds `PetJson` / `ToyJson`, serializing with
-  `std.json` (`emit_null_optional_fields = false`, so an absent `tag` is
-  omitted).
+- **Frontend** — `bindgen` on the single `svc` world generates everything
+  `src/main.zig` needs: the `store.*` import wrappers (results decoded with
+  `canon.liftResultFlat` / `canon.lift`), the `wasi:http/types` resource wrappers
+  (`Request` / `Response` / `Fields` and the body `stream<u8>` / trailers
+  `future` channels), and the async `wasi:http/handler@0.3.0#handle` export — in
+  `--manual-return` form, so the handler can `task.return` the response and then
+  keep streaming its body. `src/main.zig` calls them and builds `PetJson` /
+  `ToyJson`, serializing with `std.json` (`emit_null_optional_fields = false`, so
+  an absent `tag` is omitted).
 
 ### The HTTP request (WASI 0.3 has no `wasi:io`)
 
-Per request the frontend handler:
+Per request the frontend handler (`src/main.zig`, driving the generated `svc`
+bindings):
 
-1. Reads the request **method** and **path-with-query** (`request.get-method`,
-   `request.get-path-with-query`), then the request **body** by `consume-body` +
-   a cooperative `stream.read` loop.
+1. Reads the request **method** and **path-with-query** (`Request.getMethod`,
+   `Request.getPathWithQuery`), then the request **body** by `Request.consumeBody`
+   + a cooperative `stream.read` loop on the returned body `stream<u8>`.
 2. Routes to the imported `store` calls and serializes JSON into a per-task
    buffer.
-3. Builds a `response` (status + `content-type` header + body `stream<u8>`),
-   reports it with `task.return`, then streams the body and resolves the
-   trailers — cooperatively waiting on a `waitable-set` whenever a write blocks.
+3. Builds a `Response` (status + `content-type` header + body `stream<u8>` +
+   trailers `future`), reports it with the generated `handleReturn` (`task.return`),
+   then streams the body and resolves the trailers — cooperatively waiting on a
+   `cm_async.WaitableSet` whenever a write blocks.
+
+The body `stream<u8>` and the `future<result<…>>` trailers/transmission channels
+are the **non-primitive async element** bindings (`canon.Stream` / `canon.FutureOf`
+bound to function-reference intrinsics) the generator emits for the `wasi:http`
+signatures.
 
 **Concurrency.** Hosts may invoke `handle` concurrently (interleaved at `await`
 points on one thread). The store is static global state (in the backend
@@ -79,9 +91,10 @@ corrupt each other.
 ## Prerequisites
 
 - `zig` 0.16, a **P3-capable `wabt`** (with non-primitive stream/future element
-  support, value-typed export interfaces, and the `component bindgen` subcommand
-  — see cataggar/wabt #281/#282/#283), and **`wasmtime` >= 46** on `PATH` — or
-  pointed to via the `WABT` and `WASMTIME` environment variables.
+  support, async imports/exports, spilled `task.return`, and `component bindgen`
+  with `--manual-return` — see cataggar/wabt #281–#284 and #289), and
+  **`wasmtime` >= 46** on `PATH` — or pointed to via the `WABT` and `WASMTIME`
+  environment variables.
 
 ## Build and serve
 
@@ -97,14 +110,14 @@ zig build check           # analyze the guest modules (used by ZLS); no install
 ### Editor / ZLS
 
 The guests are compiled by shelling out to `zig build-exe` (`wasip3.zigBuildWasm`),
-which the language server can't introspect, so `@import("wasi_http")` and the
-generated `store_consumer` / `store_provider` bindings would otherwise be
-unresolved. `wasip3.zigBuildWasm` therefore auto-registers a `check` step that
-mirrors each guest's module graph as a real `addExecutable` / `addImport` — no
-build.zig wiring needed here. `.vscode/settings.json` points ZLS's build-on-save
-at it (`zig.zls.buildOnSaveStep = "check"`), so imports resolve and diagnostics
-surface in the editor. `wabt` must be on `PATH` (ZLS runs the build to
-materialize the generated bindings).
+which the language server can't introspect, so the generated `svc` /
+`store_provider` bindings would otherwise be unresolved. `wasip3.zigBuildWasm`
+therefore auto-registers a `check` step that mirrors each guest's module graph as
+a real `addExecutable` / `addImport` — no build.zig wiring needed here.
+`.vscode/settings.json` points ZLS's build-on-save at it
+(`zig.zls.buildOnSaveStep = "check"`), so imports resolve and diagnostics surface
+in the editor. `wabt` must be on `PATH` (ZLS runs the build to materialize the
+generated bindings).
 
 In another terminal:
 

--- a/build.zig
+++ b/build.zig
@@ -4,14 +4,19 @@ const wasip3 = @import("wasip3");
 pub fn build(b: *std.Build) void {
     const dep = b.dependency("wasip3", .{});
 
-    const store_consumer = wasip3.wabtComponentBindgen(b, .{ .world = "store-consumer" });
+    // The `svc` world generates the whole guest surface the frontend needs:
+    // the `wasi:http/types` client wrappers, the `store` client, and the async
+    // `wasi:http/handler` export. `handle` is generated in manual-return form so
+    // the handler can `task.return` the response and then keep streaming its
+    // body.
+    const svc = wasip3.wabtComponentBindgen(b, .{ .world = "svc", .manual_returns = &.{"handle"} });
     const store_provider = wasip3.wabtComponentBindgen(b, .{ .world = "store-provider" });
 
     const web_core = wasip3.zigBuildWasm(b, .{
         .source = b.path("src/main.zig"),
         .output = "http.core.wasm",
-        .imports = wasip3.guestImports(b, dep, &.{"wasi_http"}, &.{
-            .{ .bindings = store_consumer },
+        .imports = wasip3.guestImports(b, dep, &.{ "cm_async", "canon", "abi" }, &.{
+            .{ .bindings = svc },
         }),
     });
     const web = wasip3.wabtComponentNew(b, .{ .wasm_core = web_core, .world = "svc" });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,7 +6,7 @@
     .dependencies = .{
         .wasip3 = .{
             .url = "https://github.com/cataggar/wabt/archive/refs/heads/wasip3.tar.gz",
-            .hash = "wasip3-0.3.0-Kmwy2rJIAQDQXNxDSBa7Yzi57bxqSUNZgw1my7q1UEat",
+            .hash = "wasip3-0.3.0-Kmwy2ozJAQDXhcYsVftW1kyyjcx7vtXFMpmVsE3px3Yk",
         },
     },
     .paths = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,12 +1,134 @@
-//! PetStore — a `wasi:http@0.3.0` service implementing the TypeSpec petstore
-//! sample (microsoft/typespec petstore.tsp) over an in-memory store seeded
-//! with example pets and toys.
+//! PetStore — a `wasi:http@0.3.0` service (TypeSpec petstore sample) driven
+//! entirely by the `wabt component bindgen`-generated `svc` bindings: the
+//! `wasi:http/types` client wrappers, the `store` data-access client, and the
+//! async `handle` export (manual-return streaming form). No hand-written
+//! `wasi_http`.
 
 const std = @import("std");
-const http = @import("wasi_http");
+const svc = @import("svc");
+const cm = @import("cm_async");
+const canon = @import("canon");
+const abi = @import("abi");
 
-const store = @import("store_consumer").store;
-const Pet = @import("store_consumer").Pet;
+// Force the generated export shells (`wasi:http/handler@0.3.0#handle`) to emit:
+// they live in this dependency module while `main` is the compilation root.
+comptime {
+    _ = svc;
+}
+
+const store = svc.store;
+const Pet = svc.Pet;
+
+// ── wasi:http protocol (over the generated bindings) ────────────────
+
+const TxnFut = @typeInfo(@TypeOf(svc.Request.consumeBody)).@"fn".params[1].type.?;
+const TrailersFut = @typeInfo(@TypeOf(svc.Response.new)).@"fn".params[2].type.?;
+const ByteStream = canon.Stream(u8);
+
+/// Canonical `stream`/`future` status: blocked (operation pending).
+const BLOCKED: i32 = @bitCast(@as(u32, 0xffff_ffff));
+
+// `ok(())` / `ok(none)` of the transmission / trailers futures are all-zero.
+var ok_zero: [64]u8 align(8) = [_]u8{0} ** 64;
+
+/// Block on `waitable` until it makes progress; returns the event payload
+/// (`waitable-set.wait` writes `[waitable, payload]` to the ret-area).
+fn waitCode(waitable: i32) u32 {
+    const set = cm.WaitableSet.create();
+    set.add(waitable);
+    _ = set.waitOne();
+    const code: u32 = abi.retWords()[1];
+    set.drop();
+    return code;
+}
+
+fn readBody(request: svc.Request, buf: []u8) []const u8 {
+    const res = TxnFut.new();
+    const tup = svc.Request.consumeBody(request, res.readable);
+    const stream: ByteStream = tup[0];
+    const trailers: TrailersFut = tup[1];
+
+    var len: usize = 0;
+    while (len < buf.len) {
+        const status = stream.read(buf[len..]);
+        const code: u32 = if (status == BLOCKED) waitCode(stream.handle) else @bitCast(status);
+        len += @as(usize, code >> 4);
+        if (code & 0xf != 0) break; // dropped (EOF) / cancelled
+        if (code >> 4 == 0) break; // no progress
+    }
+    stream.dropReadable();
+    trailers.dropReadable();
+    _ = res.writable.writeFrom(&ok_zero);
+    res.writable.dropWritable();
+    return buf[0..len];
+}
+
+fn writeBody(writable: ByteStream, bytes: []const u8) void {
+    var off: usize = 0;
+    while (off < bytes.len) {
+        const status = writable.write(bytes[off..]);
+        const code: u32 = if (status == BLOCKED) waitCode(writable.handle) else @bitCast(status);
+        const n: usize = code >> 4;
+        if (n == 0) break;
+        off += n;
+    }
+    writable.dropWritable();
+}
+
+fn writeTrailers(writable: TrailersFut) void {
+    const status = writable.writeFrom(&ok_zero);
+    if (status == BLOCKED) _ = waitCode(writable.handle);
+    writable.dropWritable();
+}
+
+/// What a route fills: status, content-type, and a body in a caller buffer.
+const Responder = struct {
+    status: u16 = 200,
+    content_type: []const u8 = "application/json",
+    buf: []u8,
+    len: usize = 0,
+
+    fn setStatus(self: *Responder, status: u16) void {
+        self.status = status;
+    }
+    fn print(self: *Responder, comptime fmt: []const u8, args: anytype) void {
+        const out = std.fmt.bufPrint(self.buf[self.len..], fmt, args) catch self.buf[self.len..self.len];
+        self.len += out.len;
+    }
+    fn body(self: *const Responder) []const u8 {
+        return self.buf[0..self.len];
+    }
+};
+
+fn sendResponse(res: *const Responder) void {
+    const headers = svc.Fields.init();
+    _ = headers.append("content-type", res.content_type);
+
+    const payload = res.body();
+    const has_body = payload.len != 0;
+    var body_writable: ByteStream = undefined;
+    var contents: ?ByteStream = null;
+    if (has_body) {
+        const bs = ByteStream.new();
+        contents = bs.readable;
+        body_writable = bs.writable;
+    }
+
+    const tf = TrailersFut.new();
+    const tup = svc.Response.new(headers, contents, tf.readable);
+    const response: svc.Response = tup[0];
+    const transmission: TxnFut = tup[1];
+    transmission.dropReadable();
+
+    if (res.status != 200) _ = response.setStatusCode(res.status);
+
+    svc.handleReturn(.{ .ok = response });
+
+    if (has_body) writeBody(body_writable, payload);
+    writeTrailers(tf.writable);
+}
+
+// ── PetStore routes (TypeSpec petstore sample) ──────────────────────
 
 const json_opts = std.json.Stringify.Options{ .emit_null_optional_fields = false };
 
@@ -38,17 +160,16 @@ fn petJson(p: Pet) PetJson {
     return .{ .id = @intCast(p.id), .name = p.name, .tag = p.tag, .age = @intCast(p.age) };
 }
 
-/// Serialize `value` as minified JSON into the response buffer via std.json.
-fn writeJson(res: *http.Responder, value: anytype) void {
+fn writeJson(res: *Responder, value: anytype) void {
     res.print("{f}", .{std.json.fmt(value, json_opts)});
 }
 
-fn writeError(res: *http.Responder, status: u16, code: i32, message: []const u8) void {
+fn writeError(res: *Responder, status: u16, code: i32, message: []const u8) void {
     res.setStatus(status);
     writeJson(res, ErrorJson{ .code = code, .message = message });
 }
 
-fn listPets(res: *http.Responder) void {
+fn listPets(res: *Responder) void {
     var items: [128]PetJson = undefined;
     var n: usize = 0;
     const count = store.petCount();
@@ -62,7 +183,7 @@ fn listPets(res: *http.Responder) void {
     writeJson(res, .{ .items = items[0..n] });
 }
 
-fn readPet(id: u32, res: *http.Responder) void {
+fn readPet(id: u32, res: *Responder) void {
     if (store.getPet(id)) |p| {
         writeJson(res, petJson(p));
     } else {
@@ -70,7 +191,7 @@ fn readPet(id: u32, res: *http.Responder) void {
     }
 }
 
-fn deletePet(id: u32, res: *http.Responder) void {
+fn deletePet(id: u32, res: *Responder) void {
     if (store.deletePet(id)) {
         writeJson(res, .{ .message = "deleted" });
     } else {
@@ -78,7 +199,7 @@ fn deletePet(id: u32, res: *http.Responder) void {
     }
 }
 
-fn listToys(pet_id: u32, res: *http.Responder) void {
+fn listToys(pet_id: u32, res: *Responder) void {
     var items: [128]ToyJson = undefined;
     var n: usize = 0;
     const count = store.toyCount(pet_id);
@@ -92,11 +213,11 @@ fn listToys(pet_id: u32, res: *http.Responder) void {
     writeJson(res, .{ .items = items[0..n] });
 }
 
-fn createPet(req: *const http.Request, res: *http.Responder) void {
-    if (req.body.len == 0) return writeError(res, 400, 400, "request body required");
+fn createPet(body: []const u8, res: *Responder) void {
+    if (body.len == 0) return writeError(res, 400, 400, "request body required");
     var jbuf: [4096]u8 = undefined;
     var fba = std.heap.FixedBufferAllocator.init(&jbuf);
-    const parsed = std.json.parseFromSliceLeaky(PetInput, fba.allocator(), req.body, .{
+    const parsed = std.json.parseFromSliceLeaky(PetInput, fba.allocator(), body, .{
         .ignore_unknown_fields = true,
     }) catch return writeError(res, 400, 400, "invalid pet json");
     if (parsed.age < 0 or parsed.age > 20) return writeError(res, 400, 400, "age must be 0..20");
@@ -105,14 +226,26 @@ fn createPet(req: *const http.Request, res: *http.Responder) void {
     writeJson(res, petJson(p));
 }
 
-fn handle(req: *const http.Request, res: *http.Responder) void {
-    const q = std.mem.indexOfScalar(u8, req.path, '?');
-    const path = if (q) |i| req.path[0..i] else req.path;
+const Method = enum { get, post, put, delete, other };
+
+fn methodOf(m: svc.Method) Method {
+    return switch (m) {
+        .get => .get,
+        .post => .post,
+        .put => .put,
+        .delete => .delete,
+        else => .other,
+    };
+}
+
+fn route(method: Method, full_path: []const u8, body: []const u8, res: *Responder) void {
+    const q = std.mem.indexOfScalar(u8, full_path, '?');
+    const path = if (q) |i| full_path[0..i] else full_path;
 
     if (std.mem.eql(u8, path, "/pets")) {
-        switch (req.method) {
+        switch (method) {
             .get => listPets(res),
-            .post => createPet(req, res),
+            .post => createPet(body, res),
             else => writeError(res, 405, 405, "method not allowed"),
         }
         return;
@@ -123,7 +256,7 @@ fn handle(req: *const http.Request, res: *http.Responder) void {
         if (std.mem.indexOfScalar(u8, rest, '/')) |slash| {
             const id_str = rest[0..slash];
             const tail = rest[slash + 1 ..];
-            if (std.mem.eql(u8, tail, "toys") and req.method == .get) {
+            if (std.mem.eql(u8, tail, "toys") and method == .get) {
                 const pid = std.fmt.parseInt(u32, id_str, 10) catch return writeError(res, 400, 400, "invalid pet id");
                 listToys(pid, res);
                 return;
@@ -132,7 +265,7 @@ fn handle(req: *const http.Request, res: *http.Responder) void {
             return;
         }
         const id = std.fmt.parseInt(u32, rest, 10) catch return writeError(res, 400, 400, "invalid pet id");
-        switch (req.method) {
+        switch (method) {
             .get => readPet(id, res),
             .delete => deletePet(id, res),
             else => writeError(res, 405, 405, "method not allowed"),
@@ -143,6 +276,22 @@ fn handle(req: *const http.Request, res: *http.Responder) void {
     writeError(res, 404, 404, "not found");
 }
 
-comptime {
-    http.exportHandler(handle);
+/// The `wasi:http/handler@0.3.0#handle` entry (manual-return form). Decode the
+/// request, run the route, then deliver + stream the response.
+pub fn handle(request: svc.Request) void {
+    var path_buf: [1024]u8 = undefined;
+    var body_buf: [8192]u8 = undefined;
+    var resp_buf: [8192]u8 = undefined;
+
+    const method = methodOf(request.getMethod());
+    const raw_path = request.getPathWithQuery() orelse "";
+    const pn = @min(raw_path.len, path_buf.len);
+    @memcpy(path_buf[0..pn], raw_path[0..pn]);
+    const path = path_buf[0..pn];
+    // consume-body moves the request, so read method + path first.
+    const body = readBody(request, &body_buf);
+
+    var res = Responder{ .buf = &resp_buf };
+    route(method, path, body, &res);
+    sendResponse(&res);
 }

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -39,6 +39,10 @@ interface store {
 
 // A `wasi:http/service`-shaped world that also imports the `store`
 // data-access interface; exports the async `handler` the host calls.
+// `wabt component bindgen` generates the full client surface — the
+// `wasi:http/types` wrappers, the `store` client, and the async `handle`
+// export — so the frontend drives the generated bindings directly (no
+// hand-written `wasi_http`).
 world svc {
     import wasi:http/types@0.3.0;
     import store;
@@ -48,11 +52,4 @@ world svc {
 // The storage component: exports the `store` interface.
 world store-provider {
     export store;
-}
-
-// Import-only world used by `wabt component bindgen` to generate the
-// frontend's `store` client wrappers (the `svc` world also imports
-// wasi:http, which bindgen v1 does not handle).
-world store-consumer {
-    import store;
 }


### PR DESCRIPTION
Phase 4 of #289: the petstore frontend now drives the bindings generated from the single `svc` world directly — no hand-written `wasi_http`, no `store-consumer` helper world.

`wabt component bindgen` on `svc` emits the whole frontend surface: the `wasi:http/types` resource wrappers (`Request` / `Response` / `Fields` + the body `stream<u8>` and trailers `future` channels), the `store` client, and the async `wasi:http/handler@0.3.0#handle` export in `--manual-return` form (so the handler can `task.return` the response and keep streaming the body).

- `src/main.zig` decodes the request (method / path / body stream), routes to the store, builds a `Response`, calls the generated `handleReturn` (`task.return`), then streams the body and resolves the trailers — waiting on a `cm_async.WaitableSet` when a write blocks.
- `wit/world.wit` drops the `store-consumer` world.
- `build.zig` points web bindgen at `svc` with `manual_returns = handle` and imports `cm_async` / `canon` / `abi` instead of `wasi_http`.
- `build.zig.zon` re-pinned to the wasip3 tarball that has `manual_returns` (cataggar/wabt#291).

Validated: `zig build` -> `zig-out/petstore.wasm`; `zig build serve` -> `GET /pets` / `POST /pets` / `GET /pets/{id}` / `DELETE /pets/{id}` / `GET /pets/{id}/toys` all return correct JSON on wasmtime 46.

Depends on cataggar/wabt#290 (generator) + #291 (runtime + build helper).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>