### PR TITLE
wasi_cli: regenerate bindings with per-interface channel binding (#297)

### DIFF
--- a/src/wasi_cli_bindings.zig
+++ b/src/wasi_cli_bindings.zig
@@ -34,6 +34,8 @@ pub const TerminalOutput = struct {
 };
 
 const __chan0 = canon.FutureOf(canon.Result(void, ErrorCode), "[future]wasi:cli/stdin@0.3.0#read-via-stream#1");
+const __chan1 = canon.FutureOf(canon.Result(void, ErrorCode), "[future]wasi:cli/stdout@0.3.0#write-via-stream#1");
+const __chan2 = canon.FutureOf(canon.Result(void, ErrorCode), "[future]wasi:cli/stderr@0.3.0#write-via-stream#1");
 
 pub const environment = struct {
     const imp = struct {
@@ -87,8 +89,8 @@ pub const stdout = struct {
         extern "wasi:cli/stdout@0.3.0" fn @"write-via-stream"(data: i32) i32;
     };
 
-    pub fn writeViaStream(data: canon.Stream(u8)) __chan0 {
-        return canon.liftResultFlat(__chan0, imp.@"write-via-stream"(data.handle));
+    pub fn writeViaStream(data: canon.Stream(u8)) __chan1 {
+        return canon.liftResultFlat(__chan1, imp.@"write-via-stream"(data.handle));
     }
 };
 
@@ -97,8 +99,8 @@ pub const stderr = struct {
         extern "wasi:cli/stderr@0.3.0" fn @"write-via-stream"(data: i32) i32;
     };
 
-    pub fn writeViaStream(data: canon.Stream(u8)) __chan0 {
-        return canon.liftResultFlat(__chan0, imp.@"write-via-stream"(data.handle));
+    pub fn writeViaStream(data: canon.Stream(u8)) __chan2 {
+        return canon.liftResultFlat(__chan2, imp.@"write-via-stream"(data.handle));
     }
 };
 


### PR DESCRIPTION
Regenerate `src/wasi_cli_bindings.zig` with a `wabt` containing #296 (per-interface complex-channel binding). The shared `future<result<_, error-code>>` now binds per interface (`stdin#read-via-stream#1` / `stdout#write-via-stream#1` / `stderr#write-via-stream#1`) instead of one global stdin site.

Validated: a `wasi:cli` command importing only environment/stdout/stderr (no stdin) wraps via `component new` and runs on wasmtime 46 against the regenerated package bindings -- the world that failed with `UnsupportedAsyncIntrinsic` before #296.

Fixes #297. Refs #294, #295/#296.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>