### PR TITLE
canon: lift list<variant> / non-layout-matching element lists (#306)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,9 +15,11 @@ pub fn build(b: *std.Build) void {
     cm_async.addImport("abi", abi);
 
     // Comptime canonical-ABI value marshaller (records / strings / options /
-    // lists → linear memory). Depends only on `std`; a guest passes it the
-    // `abi.alloc` realloc.
+    // lists → linear memory). Lowers via a caller-supplied realloc; for `lift`
+    // of a `list<E>` whose element can't be borrowed in place (e.g. a tagged
+    // `variant`) it copies elements via `abi`'s scratch arena.
     const canon = b.addModule("canon", .{ .root_source_file = b.path("src/canon.zig") });
+    canon.addImport("abi", abi);
 
     // `wabt component bindgen`-generated `wasi:cli@0.3.0` import client wrappers;
     // `wasi_cli` is the ergonomic layer over them.
@@ -88,6 +90,7 @@ pub fn build(b: *std.Build) void {
             .target = b.graph.host,
         }),
     });
+    canon_tests.root_module.addImport("abi", abi);
     const run_canon_tests = b.addRunArtifact(canon_tests);
 
     const test_step = b.step("test", "Run native unit tests");
@@ -169,7 +172,7 @@ pub const ModuleSpec = struct {
 
 pub const modules = [_]ModuleSpec{
     .{ .name = "abi" },
-    .{ .name = "canon" },
+    .{ .name = "canon", .deps = &.{"abi"} },
     .{ .name = "cm_async", .deps = &.{"abi"} },
     .{ .name = "wasi_cli_bindings", .deps = &.{ "canon", "abi" } },
     .{ .name = "wasi_cli", .deps = &.{ "cm_async", "canon", "abi", "wasi_cli_bindings" } },

--- a/src/canon.zig
+++ b/src/canon.zig
@@ -36,6 +36,12 @@
 
 const std = @import("std");
 
+/// The guest's `cabi_realloc` scratch arena — `lift` allocates from it when a
+/// `list<E>` element can't be borrowed in place (its native Zig layout differs
+/// from the canonical one, e.g. a tagged `variant`), copying each element into a
+/// fresh native array with the same lifetime as the host-allocated list.
+const abi = @import("abi");
+
 /// A bump allocator the canonical ABI calls to place `string` / `list` element
 /// storage during `lower` (the guest's `cabi_realloc` arena). `lift` borrows
 /// memory and needs none.
@@ -485,14 +491,21 @@ fn liftSlice(comptime E: type, base: [*]const u8) []const E {
     // Borrow in place when `E`'s canonical layout equals its native one — the
     // canonical element array is then already a valid `[]const E` (primitives,
     // plus `string` / `list` / `record` / `tuple` of such on little-endian
-    // wasm32). An element whose layouts differ (e.g. a tagged `variant` /
-    // `result`) would need element-wise copies into a fresh allocation.
-    if (!comptime layoutMatches(E))
-        @compileError("canon: lifting list<" ++ @typeName(E) ++ "> (layout mismatch) is unsupported");
+    // wasm32). Otherwise (a tagged `variant` / `result`, or an aggregate
+    // reaching one) lift element-by-element into a fresh native array allocated
+    // from the same scratch arena the host placed the canonical list in.
+    const ptr = load(usize, base);
     const len = load(usize, base + @sizeOf(usize));
     if (len == 0) return &.{};
-    const items: [*]const E = @ptrFromInt(load(usize, base));
-    return items[0..len];
+    if (comptime layoutMatches(E)) {
+        const items: [*]const E = @ptrFromInt(ptr);
+        return items[0..len];
+    }
+    const esize = comptime sizeOf(E); // canonical element stride (matches `lowerSlice`)
+    const src: [*]const u8 = @ptrFromInt(ptr);
+    const out: [*]E = @ptrCast(@alignCast(abi.alloc(len * @sizeOf(E), @alignOf(E))));
+    for (0..len) |i| out[i] = lift(E, src + i * esize);
+    return out[0..len];
 }
 
 // ── Return area for indirect (memory) results ───────────────────────
@@ -956,6 +969,31 @@ test "round-trip: toy and scalars" {
     try testing.expectEqual(@as(u32, 100), t.id);
     try testing.expectEqual(@as(u32, 1), t.pet_id);
     try testing.expectEqualStrings("Yarn Ball", t.name);
+}
+
+test "lift list<variant>: element-wise copy of a non-layout-matching element (#306)" {
+    test_top = 0;
+    abi.resetScratch();
+    // variant V { num(u32), nothing, text(string) } — a tagged union whose Zig
+    // layout differs from the canonical discriminant+payload, so the list can't
+    // be borrowed in place.
+    const V = union(enum) { num: u32, nothing: void, text: []const u8 };
+    const items = [_]V{ .{ .num = 42 }, .{ .nothing = {} }, .{ .text = "hi" } };
+    const list: []const V = &items;
+    var buf: [sizeOf([]const V)]u8 align(8) = undefined;
+    lower([]const V, list, &buf, &testAlloc);
+    const got = lift([]const V, &buf);
+    try testing.expectEqual(@as(usize, 3), got.len);
+    try testing.expect(got[0] == .num);
+    try testing.expectEqual(@as(u32, 42), got[0].num);
+    try testing.expect(got[1] == .nothing);
+    try testing.expect(got[2] == .text);
+    try testing.expectEqualStrings("hi", got[2].text);
+
+    // An empty list lifts to an empty slice (no allocation).
+    var ebuf: [sizeOf([]const V)]u8 align(8) = undefined;
+    lower([]const V, &.{}, &ebuf, &testAlloc);
+    try testing.expectEqual(@as(usize, 0), lift([]const V, &ebuf).len);
 }
 
 test "lowerFlat round-trips through liftParams" {


### PR DESCRIPTION
## Problem

`canon.liftSlice` only borrowed a canonical list in place when the element's native Zig layout equalled its canonical layout (primitives, slices, records/tuples of those). A tagged `variant`/`result` (Zig `union(enum)`, whose layout differs from the canonical discriminant+payload) hit a `@compileError`, blocking `wasi:sockets/ip-name-lookup.resolve-addresses` (→ `list<ip-address>`, where `ip-address` is a variant) and any list of a union-shaped element.

## Fix

`liftSlice` keeps the zero-copy borrow for layout-matching elements and otherwise lifts each element from its canonical slot (stride `sizeOf(E)`, matching `lowerSlice`) into a fresh native `[]E`, allocated from the same `cabi_realloc` scratch arena the host placed the list in. `canon` gains an `abi` import for that arena (no cycle — `abi` depends only on `std`); `lower` stays allocator-agnostic via its `Realloc` param.

## Validation

- Native round-trip test: `lower`/`lift` of `list<union(enum){num, nothing, text}>` (incl. an empty list). 28/30 native tests pass (2 skipped).
- `wasi:sockets@0.3.0` bindings now **fully type-check** (tcp/udp socket resources + `ip-name-lookup`) — `list<ip-address>` previously failed to compile.
- **End to end on wasmtime 46**: a command calling `ip-name-lookup.resolve-addresses("127.0.0.1")` prints:
  ```
  resolved 1 address(es):
    ipv4 127.0.0.1
  ```

Fixes #306. Unblocks the `sockets` item of #280 (generator side: #303; wrapper side: #304).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>