### PR TITLE
component new: realloc opt for stream/future read/write of complex elements (#308)

### DIFF
--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -4040,19 +4040,26 @@ fn buildComponentShimFixup(
     {
         const memop_start: u32 = @intCast(canons.items.len);
         const mem_realloc = [_]ctypes.CanonOpt{ .{ .memory = memory_core_idx }, .{ .realloc = realloc_core_idx } };
+        const mem_only = [_]ctypes.CanonOpt{.{ .memory = memory_core_idx }};
         for (async_groups) |grp| {
+            // A complex (non-primitive) element may reach a `string`/`list` whose
+            // lift needs `cabi_realloc` (e.g. `future<result<_, error-code>>`
+            // where `error-code` has an `other(option<string>)` case); a
+            // primitive element (`stream<u8>`) never does, so it stays
+            // memory-only to keep the simple cases bit-identical.
+            const elem_opts: []const ctypes.CanonOpt = if (grp.elem_raw != null) &mem_realloc else &mem_only;
             for (grp.fields) |field| {
                 if (!field.is_mem_op) continue;
                 const canon: ctypes.Canon = switch (grp.family) {
                     .stream => blk: {
-                        const opts = try ar.dupe(ctypes.CanonOpt, &.{.{ .memory = memory_core_idx }});
+                        const opts = try ar.dupe(ctypes.CanonOpt, elem_opts);
                         break :blk if (std.mem.eql(u8, field.name, "write"))
                             .{ .stream_write = .{ .type_idx = grp.stream_type_idx, .opts = opts } }
                         else
                             .{ .stream_read = .{ .type_idx = grp.stream_type_idx, .opts = opts } };
                     },
                     .future => blk: {
-                        const opts = try ar.dupe(ctypes.CanonOpt, &.{.{ .memory = memory_core_idx }});
+                        const opts = try ar.dupe(ctypes.CanonOpt, elem_opts);
                         break :blk if (std.mem.eql(u8, field.name, "write"))
                             .{ .future_write = .{ .type_idx = grp.stream_type_idx, .opts = opts } }
                         else


### PR DESCRIPTION
## Problem

The memory-opt async canons (`stream.read`/`.write`, `future.read`/`.write`) were always emitted with only the `(memory)` opt. That's correct for a primitive element (`stream<u8>`), but a **complex** element can reach a `string`/`list` whose lift needs `cabi_realloc` — e.g. `wasi:filesystem` `read-via-stream` / `write-via-stream` return `future<result<_, error-code>>`, and that `error-code` has an `other(option<string>)` case. wasmtime then rejects the component at load:

```
canonical option `realloc` is required
```

This surfaced only after #304 fixed the cross-interface future-type resolution (the filesystem future now binds to the correct, string-reaching `error-code`).

## Fix

Emit `(memory)+(realloc)` for `stream`/`future` `read`/`write` when the element is **complex** (`grp.elem_raw != null`); keep memory-only for a **primitive** element so the simple cases (`stream<u8>`, `future<u8>`) stay bit-identical.

## Validation

- **`wasi:filesystem` `write-via-stream` + `read-via-stream` now run** end to end on wasmtime 46 (a guest writes then reads back a file → `read back: hello ... wrapper`, `stat size=35`).
- Regression: the **wasi:http petstore** composes + serves (GET/POST create id 4); cli/clocks/random run; the primitive-stream/future tests are unchanged.
- **640/640** generator tests pass.

Refs #280.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>