### PR TITLE
cm_async: don't clobber blocking async-call results with the wait event

### DIFF
--- a/src/cm_async.zig
+++ b/src/cm_async.zig
@@ -216,15 +216,21 @@ pub fn awaitCall(status: i32) void {
     if (s & 0xf == @intFromEnum(CallState.returned)) return;
     const sub: i32 = @bitCast(s >> 4);
 
+    // The callee writes its result to the caller's result pointer — typically
+    // the shared ret-area — when the subtask completes. So the wait event must
+    // land in a *local* buffer (not `WaitableSet.waitOne`, which targets the
+    // ret-area) or it would clobber that result before `canon.lift` reads it.
+    // (A synchronously-returning call hits the early `return` above and never
+    // waits; only a genuinely-blocking call with a result is affected.)
+    var ev: [4]u32 align(8) = undefined;
     const set = WaitableSet.create();
     set.add(sub);
     while (true) {
-        const event = set.waitOne();
-        const w = abi.retWords();
+        const event = waitset.wait(set.handle, @intCast(@intFromPtr(&ev)));
         // `waitable-set.wait` writes [waitable, payload]; the payload of a
         // subtask event is its new CallState. Only this subtask is joined.
-        if (event == EVENT_SUBTASK and w[0] == s >> 4 and
-            w[1] == @intFromEnum(CallState.returned)) break;
+        if (event == EVENT_SUBTASK and ev[0] == s >> 4 and
+            ev[1] == @intFromEnum(CallState.returned)) break;
     }
     // Drop the subtask first: `subtask.drop` unjoins it from the set
     // (`waitable.join(_, none)` → `remove_child`), so the set is childless


### PR DESCRIPTION
## Problem

`awaitCall` blocked on the returned subtask via `WaitableSet.waitOne`, which writes the wait event to the **shared ret-area**. But the callee writes its result to the caller's result pointer — which the generated async wrappers set to that *same* ret-area (`abi.retPtr()`). So when an async call **genuinely blocks**, the `waitable-set.wait` event overwrote the result before `canon.lift` read it back.

This only bit calls that **both** have a result **and** actually block:
- a synchronously-returning async call hits `awaitCall`'s early `state == returned` return and never waits (so filesystem `stat`/`get-type` worked);
- a no-result blocking call (e.g. clocks `wait-for`) has nothing in the ret-area to clobber.

`wasi:sockets` `tcp-socket.connect` is the first call that both blocks and returns a result — it reported a bogus `err(invalid-argument)` even though the TCP connection actually succeeded.

## Fix

Read the wait event into a **local** buffer instead of the ret-area, so the callee's result survives until `canon.lift`.

## Validation

End to end on wasmtime 46 (`-S inherit-network -S tcp`): a guest connecting to a host TCP echo server now connects, sends, and receives correctly (`connected` / `received: ping`) — previously `err(invalid-argument)` despite the host accepting the connection.

Prerequisite for the `wasi:sockets` TCP/UDP helpers (#311).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>