### PR TITLE
wasi_sockets: ergonomic TCP client + UDP helpers (#311 phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ src/
   wasi_filesystem_bindings.zig  `wabt component bindgen`-generated wasi:filesystem@0.3.0 import client wrappers
   wasi_filesystem.zig  ergonomic wasi:filesystem@0.3.0 layer (preopens, open, read/writeAll via stream<u8>, stat/get-type)
   wasi_sockets_bindings.zig  `wabt component bindgen`-generated wasi:sockets@0.3.0 import client wrappers
-  wasi_sockets.zig     ergonomic wasi:sockets@0.3.0 layer (tcp/udp socket resources + ip-name-lookup resolveAddresses)
+  wasi_sockets.zig     ergonomic wasi:sockets@0.3.0 layer (TCP connect/send/recv, UDP connect/send/recv, ip-name-lookup resolveAddresses, address builders)
   wasi_http_bindings.zig  `wabt component bindgen`-generated wasi:http/types@0.3.0 import client wrappers
   wasi_http.zig        ergonomic wasi:http@0.3.0 service handler layer (exportHandler + Request/Responder, over the generated body stream/trailers future)
   root.zig             `wasip3` re-export index

--- a/build.zig
+++ b/build.zig
@@ -93,6 +93,8 @@ pub fn build(b: *std.Build) void {
     const wasi_sockets = b.addModule("wasi_sockets", .{ .root_source_file = b.path("src/wasi_sockets.zig") });
     wasi_sockets.addImport("wasi_sockets_bindings", wasi_sockets_bindings);
     wasi_sockets.addImport("canon", canon);
+    wasi_sockets.addImport("cm_async", cm_async);
+    wasi_sockets.addImport("abi", abi);
 
     // Single-import library surface re-exporting every module.
     const wasip3 = b.addModule("wasip3", .{ .root_source_file = b.path("src/root.zig") });
@@ -221,7 +223,7 @@ pub const modules = [_]ModuleSpec{
     .{ .name = "wasi_filesystem_bindings", .deps = &.{ "canon", "abi", "cm_async" } },
     .{ .name = "wasi_filesystem", .deps = &.{ "wasi_filesystem_bindings", "canon", "cm_async", "abi" } },
     .{ .name = "wasi_sockets_bindings", .deps = &.{ "canon", "abi", "cm_async" } },
-    .{ .name = "wasi_sockets", .deps = &.{ "wasi_sockets_bindings", "canon" } },
+    .{ .name = "wasi_sockets", .deps = &.{ "wasi_sockets_bindings", "canon", "cm_async", "abi" } },
     .{ .name = "wasi_http_bindings", .deps = &.{ "canon", "abi", "cm_async" } },
     .{ .name = "wasi_http", .deps = &.{ "wasi_http_bindings", "canon", "abi", "cm_async" } },
 };

--- a/src/wasi_sockets.zig
+++ b/src/wasi_sockets.zig
@@ -23,6 +23,16 @@
 
 const b = @import("wasi_sockets_bindings");
 const canon = @import("canon");
+const cm = @import("cm_async");
+const abi = @import("abi");
+
+const ByteStream = canon.Stream(u8);
+// The send/receive completion `future<result<_, error-code>>`, recovered by
+// reflection on the generated `tcp-socket.send` signature (its return type).
+const SendFut = @typeInfo(@TypeOf(b.TcpSocket.send)).@"fn".return_type.?;
+
+/// Canonical `stream`/`future` status: blocked (operation pending).
+const BLOCKED: i32 = @bitCast(@as(u32, 0xffff_ffff));
 
 // ── re-exported generated types ─────────────────────────────────────
 pub const IpAddress = b.IpAddress;
@@ -46,4 +56,141 @@ pub const LookupErrorCode = b.IpNameLookupErrorCode;
 /// scratch arena; copy out to retain. Never succeeds with zero results.
 pub fn resolveAddresses(name: []const u8) canon.Result([]const IpAddress, LookupErrorCode) {
     return b.ip_name_lookup.resolveAddresses(name);
+}
+
+// ── address helpers ─────────────────────────────────────────────────
+
+/// Build an IPv4 socket address from octets + port.
+pub fn ipv4(a: u8, c: u8, d: u8, e: u8, port: u16) IpSocketAddress {
+    return .{ .ipv4 = .{ .port = port, .address = .{ a, c, d, e } } };
+}
+
+/// The address family of a socket address.
+pub fn familyOf(addr: IpSocketAddress) IpAddressFamily {
+    return switch (addr) {
+        .ipv4 => .ipv4,
+        .ipv6 => .ipv6,
+    };
+}
+
+// ── async helpers (drive the generated stream/future channels) ──────
+
+/// Block on `waitable` until it makes progress; returns the event payload.
+fn waitCode(waitable: i32) u32 {
+    const set = cm.WaitableSet.create();
+    set.add(waitable);
+    _ = set.waitOne();
+    const code: u32 = abi.retWords()[1];
+    set.drop();
+    return code;
+}
+
+/// Write all of `bytes` to a stream's writable end, waiting on a blocked write.
+fn writeStreamAll(s: ByteStream, bytes: []const u8) void {
+    var off: usize = 0;
+    while (off < bytes.len) {
+        const status = s.write(bytes[off..]);
+        const code: u32 = if (status == BLOCKED) waitCode(s.handle) else @bitCast(status);
+        const n: usize = code >> 4;
+        if (n == 0) break;
+        off += n;
+    }
+}
+
+/// Drive a `future<result<_, error-code>>` to completion (value ignored) and
+/// drop its readable end.
+fn awaitFuture(fut: anytype) void {
+    var buf: [16]u8 align(8) = undefined;
+    const status = fut.readInto(&buf);
+    if (status == BLOCKED) _ = waitCode(fut.handle);
+    fut.dropReadable();
+}
+
+// ── TCP client ──────────────────────────────────────────────────────
+
+/// A connected TCP stream — a thin wrapper driving the `tcp-socket` resource's
+/// `send` / `receive` byte streams (the same pattern as `wasi_filesystem` file
+/// I/O and the cli stdout stream).
+pub const TcpStream = struct {
+    socket: TcpSocket,
+
+    /// Send all of `bytes`, flushing fully before returning.
+    pub fn send(self: TcpStream, bytes: []const u8) void {
+        const ends = ByteStream.new();
+        const fut = self.socket.send(ends.readable); // host drains the readable end
+        writeStreamAll(ends.writable, bytes);
+        ends.writable.dropWritable(); // EOF
+        awaitFuture(fut);
+    }
+
+    /// Receive up to `buf.len` bytes into `buf`, waiting on blocked reads.
+    /// Returns the prefix read (shorter than `buf` at end-of-stream).
+    pub fn recv(self: TcpStream, buf: []u8) []const u8 {
+        const tup = self.socket.receive();
+        const stream: ByteStream = tup[0];
+        const fut: SendFut = tup[1];
+        var len: usize = 0;
+        while (len < buf.len) {
+            const status = stream.read(buf[len..]);
+            const code: u32 = if (status == BLOCKED) waitCode(stream.handle) else @bitCast(status);
+            len += @as(usize, code >> 4);
+            if (code & 0xf != 0) break; // closed / EOF
+            if (code >> 4 == 0) break; // no progress
+        }
+        stream.dropReadable();
+        awaitFuture(fut);
+        return buf[0..len];
+    }
+
+    /// Drop the underlying socket handle.
+    pub fn close(self: TcpStream) void {
+        self.socket.deinit();
+    }
+};
+
+/// Open a TCP connection to `remote` (creating + connecting a socket of the
+/// matching address family). `connect` is async; it blocks until established.
+pub fn connect(remote: IpSocketAddress) canon.Result(TcpStream, ErrorCode) {
+    const sock = switch (TcpSocket.create(familyOf(remote))) {
+        .ok => |s| s,
+        .err => |e| return .{ .err = e },
+    };
+    switch (sock.connect(remote)) {
+        .ok => {},
+        .err => |e| {
+            sock.deinit();
+            return .{ .err = e };
+        },
+    }
+    return .{ .ok = .{ .socket = sock } };
+}
+
+// ── UDP ─────────────────────────────────────────────────────────────
+
+/// Create + `connect` a UDP socket to `remote` (so `udpSend`/`udpRecv` use it as
+/// the default peer).
+pub fn udpConnect(remote: IpSocketAddress) canon.Result(UdpSocket, ErrorCode) {
+    const sock = switch (UdpSocket.create(familyOf(remote))) {
+        .ok => |s| s,
+        .err => |e| return .{ .err = e },
+    };
+    switch (sock.connect(remote)) {
+        .ok => {},
+        .err => |e| {
+            sock.deinit();
+            return .{ .err = e };
+        },
+    }
+    return .{ .ok = sock };
+}
+
+/// Send a UDP datagram (`remote` = null uses the connected peer). Async.
+pub fn udpSend(sock: UdpSocket, bytes: []const u8, remote: ?IpSocketAddress) canon.Result(void, ErrorCode) {
+    return sock.send(bytes, remote);
+}
+
+/// Receive a UDP datagram: the payload (borrows the scratch arena) + the sender
+/// address. Async.
+pub fn udpRecv(sock: UdpSocket) canon.Result(canon.Tuple(.{ []const u8, IpSocketAddress }), ErrorCode) {
+    return sock.receive();
 }


### PR DESCRIPTION
Phase 1 of #311 — ergonomic `wasi:sockets` **TCP client** + **UDP** helpers + address builders, over the generated `tcp-socket`/`udp-socket` clients.

- **`TcpStream`** — `connect(remote)` (create + async connect), `send(bytes)` (write-via the send stream), `recv(buf)` (read the receive stream), `close`. The byte-stream + completion-future driving mirrors `wasi_filesystem`/`wasi_cli`.
- **UDP** — `udpConnect` / `udpSend` (async) / `udpRecv` (async → `(bytes, addr)`).
- **Address builders** — `ipv4(a,b,c,d, port)` → `IpSocketAddress`, `familyOf(addr)`.
- The send/receive completion future type is recovered by **reflection** on the generated `tcp-socket.send` signature.

### Validation (wasmtime 46, `-S inherit-network -S tcp`/`-S udp`, host Python echo servers)

```
TCP: connect 127.0.0.1:9000, send "ping\n", recv -> "ping"   (echo: 5 bytes)
UDP: connect 127.0.0.1:9001, send "pong",  recv -> "pong"   (echo: 4 bytes)
```

Depends on #312 (the `cm_async` blocking-result fix — `tcp-socket.connect` was the first call to need it). **TCP listen/accept** (reading the `stream<tcp-socket>` accept stream) is the remaining piece of #311.

Refs #311.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>