### PR TITLE
#311 sockets Phase 2: TCP listen/accept

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ src/
   wasi_filesystem_bindings.zig  `wabt component bindgen`-generated wasi:filesystem@0.3.0 import client wrappers
   wasi_filesystem.zig  ergonomic wasi:filesystem@0.3.0 layer (preopens, open, read/writeAll via stream<u8>, stat/get-type)
   wasi_sockets_bindings.zig  `wabt component bindgen`-generated wasi:sockets@0.3.0 import client wrappers
-  wasi_sockets.zig     ergonomic wasi:sockets@0.3.0 layer (TCP connect/send/recv, UDP connect/send/recv, ip-name-lookup resolveAddresses, address builders)
+  wasi_sockets.zig     ergonomic wasi:sockets@0.3.0 layer (TCP connect/send/recv + listen/accept, UDP connect/send/recv, ip-name-lookup resolveAddresses, address builders)
   wasi_http_bindings.zig  `wabt component bindgen`-generated wasi:http/types@0.3.0 import client wrappers
   wasi_http.zig        ergonomic wasi:http@0.3.0 service handler layer (exportHandler + Request/Responder, over the generated body stream/trailers future)
   root.zig             `wasip3` re-export index

--- a/src/wasi_sockets.zig
+++ b/src/wasi_sockets.zig
@@ -30,6 +30,10 @@ const ByteStream = canon.Stream(u8);
 // The send/receive completion `future<result<_, error-code>>`, recovered by
 // reflection on the generated `tcp-socket.send` signature (its return type).
 const SendFut = @typeInfo(@TypeOf(b.TcpSocket.send)).@"fn".return_type.?;
+// The accept stream `stream<tcp-socket>` returned by `tcp-socket.listen`,
+// recovered from the `.ok` arm of its `canon.Result(stream, error-code)` return.
+const ListenRet = @typeInfo(@TypeOf(b.TcpSocket.listen)).@"fn".return_type.?;
+const AcceptStream = @typeInfo(ListenRet).@"union".fields[0].type;
 
 /// Canonical `stream`/`future` status: blocked (operation pending).
 const BLOCKED: i32 = @bitCast(@as(u32, 0xffff_ffff));
@@ -163,6 +167,56 @@ pub fn connect(remote: IpSocketAddress) canon.Result(TcpStream, ErrorCode) {
         },
     }
     return .{ .ok = .{ .socket = sock } };
+}
+
+// ── TCP server ──────────────────────────────────────────────────────
+
+/// A listening TCP socket whose `accept` yields inbound connections by reading
+/// the `stream<tcp-socket>` the host produces — each element is an accepted
+/// `tcp-socket` resource handle.
+pub const TcpListener = struct {
+    socket: TcpSocket,
+    accepts: AcceptStream,
+
+    /// Accept the next inbound connection, blocking until one arrives. Returns
+    /// null when the accept stream closes.
+    pub fn accept(self: TcpListener) ?TcpStream {
+        var one: [1]TcpSocket = undefined;
+        const status = self.accepts.read(&one);
+        const code: u32 = if (status == BLOCKED) waitCode(self.accepts.handle) else @bitCast(status);
+        if (code >> 4 == 0) return null; // closed / no socket delivered
+        return .{ .socket = one[0] };
+    }
+
+    /// Stop listening: drop the accept stream and the listener socket.
+    pub fn close(self: TcpListener) void {
+        self.accepts.dropReadable();
+        self.socket.deinit();
+    }
+};
+
+/// Bind + listen on `local`; the returned listener's `accept` yields inbound
+/// `TcpStream`s.
+pub fn listen(local: IpSocketAddress) canon.Result(TcpListener, ErrorCode) {
+    const sock = switch (TcpSocket.create(familyOf(local))) {
+        .ok => |s| s,
+        .err => |e| return .{ .err = e },
+    };
+    switch (sock.bind(local)) {
+        .ok => {},
+        .err => |e| {
+            sock.deinit();
+            return .{ .err = e };
+        },
+    }
+    const accepts = switch (sock.listen()) {
+        .ok => |s| s,
+        .err => |e| {
+            sock.deinit();
+            return .{ .err = e };
+        },
+    };
+    return .{ .ok = .{ .socket = sock, .accepts = accepts } };
 }
 
 // ── UDP ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
#311 Phase 2: ergonomic TCP `listen` / `accept` for the wasi:sockets@0.3.0 wrapper.

## What
- `listen(local)` ? create + bind + listen a tcp-socket, returns a `TcpListener` over the host-produced `stream<tcp-socket>` accept stream.
- `TcpListener.accept()` ? reads one accepted `tcp-socket` handle from the accept stream (blocking via the shared `waitCode` helper), returns a connected `TcpStream`, or null when the accept stream closes.
- `TcpListener.close()` ? drops the accept stream + listener socket.

The private `stream<tcp-socket>` channel type is recovered from `tcp-socket.listen`'s generated `Result(__chan0, Err)` return by reflection (same trick as wasi_http / Phase 1).

## Validation
End-to-end on wasmtime 46 (`-S inherit-network -S tcp`): a server component listens on 127.0.0.1:9100, accepts an inbound connection, receives a line and echoes it; a host Python client round-trips `hello from host`. `zig build test` green.

Builds on #312 (cm_async blocking-result fix) + #313 (Phase 1 TCP client + UDP).
