### PR TITLE
component pipeline + bindgen: named_func / named_interface world externs (Fixes #285, #286)

### DIFF
--- a/src/component/wit/metadata_decode.zig
+++ b/src/component/wit/metadata_decode.zig
@@ -48,6 +48,20 @@ pub const FuncRef = struct {
     sig: ctypes.FuncType,
 };
 
+/// A top-level world func extern (`import|export name: func(...);`).
+/// Unlike `WorldExtern`, it is not backed by an instance body — it is a
+/// component-level func import/export advertised under its plain name.
+pub const FuncExtern = struct {
+    is_export: bool,
+    /// Plain extern name on the wire, e.g. `run`.
+    name: []const u8,
+    /// Component-level func signature. For the shapes supported today
+    /// (primitive / simple value types) the sig is self-contained; a
+    /// `ValType.type_idx` payload would reference the world body's type
+    /// space (`DecodedWorld.world_decls`).
+    sig: ctypes.FuncType,
+};
+
 /// Per-slot view of an interface body's type-index space.
 ///
 /// `decodeInterfaceBody` walks the body in declaration order and
@@ -119,6 +133,13 @@ pub const DecodedWorld = struct {
     qualified_name: []const u8,
     /// All world externs (imports and exports), in declaration order.
     externs: []const WorldExtern,
+    /// Top-level world func externs (`import|export name: func(...);`,
+    /// the `named_func` WIT shape). These are component-level func
+    /// imports/exports (`ExternDesc.func`), not instances, so they are
+    /// kept separate from `externs` (which models instance-typed
+    /// imports/exports). Empty for worlds that use only interface /
+    /// inline-interface externs.
+    func_externs: []const FuncExtern,
     /// Raw on-wire world body decls. The outer scope that
     /// `WorldExtern.inst_decls`'s `alias outer (type 1 K)` references
     /// resolve against. Lets consumers transplanting an interface
@@ -188,6 +209,7 @@ pub fn decode(arena: Allocator, ct_payload: []const u8) DecodeError!DecodedWorld
     // to this decoder — they bump the on-wire type-index but don't
     // introduce a new world extern.
     var externs = std.ArrayListUnmanaged(WorldExtern).empty;
+    var func_externs = std.ArrayListUnmanaged(FuncExtern).empty;
     var i: usize = 0;
     while (i < world_body.decls.len) {
         const decl = world_body.decls[i];
@@ -195,35 +217,65 @@ pub fn decode(arena: Allocator, ct_payload: []const u8) DecodeError!DecodedWorld
             i += 1;
             continue;
         }
-        if (decl != .type or decl.type != .instance) return error.UnsupportedShape;
-        const inst_type = decl.type.instance;
-        // Find the matching import|export decl, skipping any alias
-        // decls the encoder may have spliced in between.
+        // Every extern is preceded by one or more `.type` decls (the
+        // instance type for an interface extern, or the hoisted
+        // compound + func type decls for a top-level func extern).
+        if (decl != .type) return error.UnsupportedShape;
+        // Find the matching import|export decl, skipping any alias or
+        // intervening type decls (a top-level func extern may emit
+        // compound type decls before its func-type decl).
         var j: usize = i + 1;
-        while (j < world_body.decls.len and world_body.decls[j] == .alias) : (j += 1) {}
+        while (j < world_body.decls.len and
+            world_body.decls[j] != .@"export" and
+            world_body.decls[j] != .import) : (j += 1)
+        {}
         if (j >= world_body.decls.len) return error.UnsupportedShape;
         const next = world_body.decls[j];
         var is_export: bool = undefined;
-        var qualified_name: []const u8 = undefined;
+        var extern_name: []const u8 = undefined;
+        var desc: ctypes.ExternDesc = undefined;
         switch (next) {
             .@"export" => |e| {
                 is_export = true;
-                qualified_name = e.name;
+                extern_name = e.name;
+                desc = e.desc;
             },
             .import => |im| {
                 is_export = false;
-                qualified_name = im.name;
+                extern_name = im.name;
+                desc = im.desc;
             },
             else => return error.UnsupportedShape,
         }
-        const body = try decodeInterfaceBody(arena, inst_type);
-        try externs.append(arena, .{
-            .is_export = is_export,
-            .qualified_name = qualified_name,
-            .type_slots = body.type_slots,
-            .funcs = body.funcs,
-            .inst_decls = inst_type.decls,
-        });
+        switch (desc) {
+            // Interface / inline-interface extern: an instance type.
+            .instance => {
+                if (decl.type != .instance) return error.UnsupportedShape;
+                const inst_type = decl.type.instance;
+                const body = try decodeInterfaceBody(arena, inst_type);
+                try externs.append(arena, .{
+                    .is_export = is_export,
+                    .qualified_name = extern_name,
+                    .type_slots = body.type_slots,
+                    .funcs = body.funcs,
+                    .inst_decls = inst_type.decls,
+                });
+            },
+            // Top-level world func extern (`named_func`). The func-type
+            // decl is the type decl immediately preceding the extern
+            // decl (the encoder appends the func type last among the
+            // func's hoisted type decls).
+            .func => {
+                const ftype_decl = world_body.decls[j - 1];
+                if (ftype_decl != .type or ftype_decl.type != .func) return error.UnsupportedShape;
+                try func_externs.append(arena, .{
+                    .is_export = is_export,
+                    .name = extern_name,
+                    .sig = ftype_decl.type.func,
+                });
+            },
+            else => return error.UnsupportedShape,
+        }
         i = j + 1;
     }
 
@@ -236,6 +288,7 @@ pub fn decode(arena: Allocator, ct_payload: []const u8) DecodeError!DecodedWorld
         .name = bare,
         .qualified_name = world_qualified,
         .externs = try externs.toOwnedSlice(arena),
+        .func_externs = try func_externs.toOwnedSlice(arena),
         .world_decls = world_body.decls,
     };
 }
@@ -540,6 +593,75 @@ test "decode: round-trip adder world" {
     try testing.expect(w.externs[0].funcs[0].sig.params[0].type == .u32);
     try testing.expect(w.externs[0].funcs[0].sig.results == .unnamed);
     try testing.expect(w.externs[0].funcs[0].sig.results.unnamed == .u32);
+}
+
+test "decode #285: top-level named_func export surfaces in func_externs" {
+    const wit_source =
+        \\package docs:nf@0.1.0;
+        \\world w {
+        \\    export run: func();
+        \\}
+    ;
+    const ct = try metadata_encode.encodeWorldFromSource(testing.allocator, wit_source, "w");
+    defer testing.allocator.free(ct);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const w = try decode(arena.allocator(), ct);
+
+    // No instance externs; one top-level func export named `run`.
+    try testing.expectEqual(@as(usize, 0), w.externs.len);
+    try testing.expectEqual(@as(usize, 1), w.func_externs.len);
+    try testing.expect(w.func_externs[0].is_export);
+    try testing.expectEqualStrings("run", w.func_externs[0].name);
+    try testing.expectEqual(@as(usize, 0), w.func_externs[0].sig.params.len);
+    try testing.expect(w.func_externs[0].sig.results == .none);
+}
+
+test "decode #285: top-level named_func import surfaces in func_externs" {
+    const wit_source =
+        \\package docs:nfi@0.1.0;
+        \\world w {
+        \\    import compute: func(x: u32) -> u32;
+        \\}
+    ;
+    const ct = try metadata_encode.encodeWorldFromSource(testing.allocator, wit_source, "w");
+    defer testing.allocator.free(ct);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const w = try decode(arena.allocator(), ct);
+
+    try testing.expectEqual(@as(usize, 0), w.externs.len);
+    try testing.expectEqual(@as(usize, 1), w.func_externs.len);
+    try testing.expect(!w.func_externs[0].is_export);
+    try testing.expectEqualStrings("compute", w.func_externs[0].name);
+    try testing.expectEqual(@as(usize, 1), w.func_externs[0].sig.params.len);
+    try testing.expect(w.func_externs[0].sig.params[0].type == .u32);
+    try testing.expect(w.func_externs[0].sig.results == .unnamed);
+    try testing.expect(w.func_externs[0].sig.results.unnamed == .u32);
+}
+
+test "decode #285: named_interface import surfaces as a plain-named instance extern" {
+    const wit_source =
+        \\package docs:ni@0.1.0;
+        \\world w {
+        \\    import foo: interface { bar: func() -> u32; };
+        \\}
+    ;
+    const ct = try metadata_encode.encodeWorldFromSource(testing.allocator, wit_source, "w");
+    defer testing.allocator.free(ct);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const w = try decode(arena.allocator(), ct);
+
+    try testing.expectEqual(@as(usize, 0), w.func_externs.len);
+    try testing.expectEqual(@as(usize, 1), w.externs.len);
+    try testing.expect(!w.externs[0].is_export);
+    try testing.expectEqualStrings("foo", w.externs[0].qualified_name);
+    try testing.expectEqual(@as(usize, 1), w.externs[0].funcs.len);
+    try testing.expectEqualStrings("bar", w.externs[0].funcs[0].name);
 }
 
 test "decode #191: world with cross-interface `use` and resources" {

--- a/src/component/wit/metadata_encode.zig
+++ b/src/component/wit/metadata_encode.zig
@@ -40,6 +40,26 @@
 //!     them; the func params/results then carry `ValType.type_idx`
 //!     references to those slots.
 //!
+//! World-extern naming convention (#285). Besides qualified
+//! `interface_ref` externs, two world-local `WorldExtern` shapes are
+//! supported; both `wabt component bindgen` and `component new` agree
+//! on these names (the contract is purely the advertised wire name and
+//! the guest core import/export module/field strings):
+//!
+//!   * `named_interface` — `import|export name: interface { … };`. An
+//!     inline interface advertised under its **plain local name**
+//!     (e.g. `foo`), NOT a `ns:pkg/iface@ver` qualifier. Encoded as an
+//!     instance import/export exactly like an `interface_ref`, so its
+//!     funcs' guest core import module is the plain name `foo` and the
+//!     field is the func name. Inline `use` clauses are out of scope.
+//!   * `named_func` — `import|export name: func(...) -> ...;`. A
+//!     **top-level component func** extern (`ExternDesc.func`), not an
+//!     instance: `lowerWorldFunc` hoists its type into the world body
+//!     and the main loop emits a `func` import/export decl under the
+//!     plain name. The guest core **export** name is the plain func
+//!     name (no `<iface>#` prefix). Top-level func *imports* are not
+//!     yet wired by `component new`.
+//!
 //! Deferred (rejected with `error.UnsupportedWitFeature`):
 //!
 //!   * `use` clauses (cross-interface type imports).

--- a/src/component/wit/metadata_encode.zig
+++ b/src/component/wit/metadata_encode.zig
@@ -236,6 +236,31 @@ pub fn encodeWorldFromResolverWithDiag(
             .@"export", .import => |we| {
                 const is_export = item == .@"export";
                 const ext = we;
+
+                // World-level function externs
+                // (`import|export name: func(...) -> ...;`) are
+                // **top-level component funcs**, not instances: lower
+                // the func type into the world body and emit a `func`
+                // extern decl advertised under the plain local name.
+                // They advance only the type index space
+                // (`world_type_idx`), never the instance index space.
+                if (ext == .named_func) {
+                    const nf = ext.named_func;
+                    const func_type_idx = try lowerWorldFunc(ar, &world_decls, &world_type_idx, nf.func);
+                    if (is_export) {
+                        try world_decls.append(ar, .{ .@"export" = .{
+                            .name = nf.name,
+                            .desc = .{ .func = func_type_idx },
+                        } });
+                    } else {
+                        try world_decls.append(ar, .{ .import = .{
+                            .name = nf.name,
+                            .desc = .{ .func = func_type_idx },
+                        } });
+                    }
+                    continue;
+                }
+
                 const iface_name = qualifiedName(ar, ext, pkg_id) catch return error.InvalidWit;
                 // Type aliases this interface defines that another
                 // interface pulls in via `use <this>.{T};` must be
@@ -869,7 +894,12 @@ fn qualifiedName(
             }
             break :blk try formatQualifiedName(ar, pkg.namespace, pkg.name, ref.name, pkg.version);
         },
-        .named_func, .named_interface => return error.UnsupportedWitFeature,
+        // Inline interfaces and world-level funcs are advertised on the
+        // wire under their world-local plain name (no `ns:pkg/iface@ver`
+        // qualifier). See the module doc comment + README for the
+        // named_interface / named_func naming convention.
+        .named_interface => |ni| try ar.dupe(u8, ni.name),
+        .named_func => |nf| try ar.dupe(u8, nf.name),
     };
 }
 
@@ -884,6 +914,55 @@ fn formatQualifiedName(
         return try std.fmt.allocPrint(ar, "{s}:{s}/{s}@{s}", .{ ns, pkg, item, v });
     }
     return try std.fmt.allocPrint(ar, "{s}:{s}/{s}", .{ ns, pkg, item });
+}
+
+/// Lower a world-level `func` (`named_func`) into the world body's type
+/// index space and return the type index of the appended func-type
+/// decl. Any compound param/result types are hoisted into preceding
+/// `.type` decls (mirroring `BodyBuilder.emitFuncExport`), all spliced
+/// into `world_decls`; only the type index space (`world_type_idx`)
+/// advances — a top-level func extern does not occupy an instance slot.
+///
+/// Named-type params/results are out of scope for world-level funcs:
+/// there is no enclosing interface body to bind `type` aliases, so a
+/// `.name` ref bottoms out in an empty `name_map` as
+/// `error.InvalidWit`. Primitive / `list` / `option` / `result` /
+/// `tuple` / async value types are supported.
+fn lowerWorldFunc(
+    ar: Allocator,
+    world_decls: *std.ArrayListUnmanaged(ctypes.Decl),
+    world_type_idx: *u32,
+    func: ast.Func,
+) EncodeError!u32 {
+    var builder: BodyBuilder = .{
+        .ar = ar,
+        .decls = .empty,
+        .type_idx = world_type_idx.*,
+        .name_map = .empty,
+    };
+    const params = try ar.alloc(ctypes.NamedValType, func.params.len);
+    for (func.params, 0..) |p, i| {
+        params[i] = .{ .name = p.name, .type = try builder.lowerType(p.type) };
+    }
+    const results: ctypes.FuncType.ResultList = if (func.result) |t|
+        .{ .unnamed = try builder.lowerType(t) }
+    else
+        .none;
+
+    const func_type_idx = builder.type_idx;
+    try builder.decls.append(ar, .{ .type = .{ .func = .{
+        .params = params,
+        .results = results,
+        .is_async = func.is_async,
+    } } });
+    builder.type_idx += 1;
+
+    // Splice the hoisted compound type decls + the func type decl into
+    // the world body in order (the builder started counting at
+    // `world_type_idx`, so the slots line up).
+    for (builder.decls.items) |d| try world_decls.append(ar, d);
+    world_type_idx.* = builder.type_idx;
+    return func_type_idx;
 }
 
 /// Lower an interface's WIT items to instance-type decls.
@@ -902,24 +981,81 @@ fn buildInterfaceBody(
     diag: ?*EncodeDiagnostic,
     world_name: []const u8,
 ) EncodeError![]const ctypes.Decl {
-    const ref = switch (ext) {
-        .interface_ref => |ir| ir.ref,
-        else => return error.UnsupportedWitFeature,
-    };
+    switch (ext) {
+        .interface_ref => |ir| {
+            const ref = ir.ref;
+            // Resolve the interface body across packages: same-package
+            // refs (no `pkg/` qualifier) hit the main doc;
+            // `<ns>:<pkg>/<iface>[@<ver>]` refs traverse the deps
+            // (populated by `parseLayout` walking `<root>/deps/<pkg>/`).
+            // The resolver returns the same shape either way. The
+            // returned `pkg` is the consuming interface's own package —
+            // used below as fallback context when resolving short
+            // `use src.{T};` refs against the dep's sibling files.
+            const iface_lookup = resolver.findInterfaceWithPkg(ref) orelse {
+                const ctx = std.fmt.allocPrint(ar, "world '{s}'", .{world_name}) catch world_name;
+                return failUnknownInterface(gpa, diag, ref, ctx);
+            };
+            return buildInterfaceBodyFromItems(
+                ar,
+                resolver,
+                iface_lookup.iface.items,
+                iface_lookup.pkg,
+                ref.name,
+                world_alias_map,
+                requested_exports,
+                gpa,
+                diag,
+            );
+        },
+        .named_interface => |ni| {
+            // Inline interface: its `items` live directly in the world
+            // body. Resolve named-type / `use` context against the
+            // enclosing document package (the world's own package), and
+            // advertise the extern under the plain local name `ni.name`.
+            for (ni.items) |it| {
+                // Cross-interface `use` from an inline interface is out
+                // of scope (#285 R2): the world-body alias prepass
+                // (`collectUseRequests`) only surfaces source types for
+                // `interface_ref` externs, so an inline `use` would
+                // dangle. Reject cleanly rather than emit a bad section.
+                if (it == .use) return error.UnsupportedWitFeature;
+            }
+            const pkg_ctx = resolver.main.package orelse return error.InvalidWit;
+            return buildInterfaceBodyFromItems(
+                ar,
+                resolver,
+                ni.items,
+                pkg_ctx,
+                ni.name,
+                world_alias_map,
+                requested_exports,
+                gpa,
+                diag,
+            );
+        },
+        // `named_func` is a top-level world func, not an interface body;
+        // it is emitted directly by the main loop, never via this path.
+        .named_func => return error.UnsupportedWitFeature,
+    }
+}
 
-    // Resolve the interface body across packages: same-package refs
-    // (no `pkg/` qualifier) hit the main doc; `<ns>:<pkg>/<iface>[@<ver>]`
-    // refs traverse the deps (populated by `parseLayout` walking
-    // `<root>/deps/<pkg>/`). The resolver returns the same shape
-    // either way. The returned `pkg` is the consuming interface's
-    // own package — used below as fallback context when resolving
-    // short `use src.{T};` refs against the dep's sibling files.
-    const iface_lookup = resolver.findInterfaceWithPkg(ref) orelse {
-        const ctx = std.fmt.allocPrint(ar, "world '{s}'", .{world_name}) catch world_name;
-        return failUnknownInterface(gpa, diag, ref, ctx);
-    };
-    const iface_body = iface_lookup.iface;
-
+/// Lower an explicit interface `items` list (sourced either from an
+/// `interface_ref` lookup or an inline `named_interface`) to
+/// instance-type decls. `pkg_ctx` is the package used to resolve short
+/// `use src.{T};` refs; `iface_name` is the consuming interface's local
+/// name (for diagnostics).
+fn buildInterfaceBodyFromItems(
+    ar: Allocator,
+    resolver: wit_resolver.Resolver,
+    items: []const ast.InterfaceItem,
+    pkg_ctx: ast.PackageId,
+    iface_name: []const u8,
+    world_alias_map: std.StringHashMapUnmanaged(u32),
+    requested_exports: ?[]const []const u8,
+    gpa: Allocator,
+    diag: ?*EncodeDiagnostic,
+) EncodeError![]const ctypes.Decl {
     // `BodyBuilder` tracks the type-index space inside this
     // instance-type body. Every appended `.type` decl bumps
     // `type_idx`; compound valtypes lower to a fresh `.type` decl
@@ -941,7 +1077,7 @@ fn buildInterfaceBody(
     // are then emitted in topological order (each type's name-deps
     // are emitted before it); funcs come last (they may reference
     // any name).
-    const sorted_items = try sortIfaceItemsForEncoding(ar, iface_body.items);
+    const sorted_items = try sortIfaceItemsForEncoding(ar, items);
 
     for (sorted_items) |it| {
         switch (it) {
@@ -1063,8 +1199,8 @@ fn buildInterfaceBody(
                 // canonical wit-component output: consumers of this
                 // iface can pull the type via the export chain
                 // without re-traversing the alias path).
-                const src_lookup = resolver.findInterfaceWithPkgCtx(u.from, iface_lookup.pkg) orelse {
-                    const consumer = formatQualifiedName(ar, iface_lookup.pkg.namespace, iface_lookup.pkg.name, ref.name, iface_lookup.pkg.version) catch ref.name;
+                const src_lookup = resolver.findInterfaceWithPkgCtx(u.from, pkg_ctx) orelse {
+                    const consumer = formatQualifiedName(ar, pkg_ctx.namespace, pkg_ctx.name, iface_name, pkg_ctx.version) catch iface_name;
                     return failUnknownInterface(gpa, diag, u.from, consumer);
                 };
                 const src_qname = try formatQualifiedName(
@@ -1590,6 +1726,122 @@ test "metadata_encode: bare `result` return is hoisted into a TypeDef + idx ref"
     try testing.expectEqualStrings("run", iface.decls[2].@"export".name);
     try testing.expect(iface.decls[2].@"export".desc == .func);
     try testing.expectEqual(@as(u32, 1), iface.decls[2].@"export".desc.func);
+}
+
+test "metadata_encode #285: named_interface inline import round-trips as a plain-named instance" {
+    // `import foo: interface { bar: func() -> u32; }` — an inline
+    // interface advertised under the world-local plain name `foo`
+    // (no `ns:pkg/iface@ver` qualifier), with `bar` as an instance
+    // export. Mirrors the `interface_ref` import path but sources its
+    // items inline.
+    const source =
+        \\package docs:ni@0.1.0;
+        \\world w {
+        \\    import foo: interface { bar: func() -> u32; };
+        \\}
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "w");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const outer = comp.types[0].component;
+    const world = outer.decls[0].type.component;
+    // One instance type + one import decl named `foo` (plain, unqualified).
+    try testing.expectEqual(@as(usize, 2), world.decls.len);
+    try testing.expect(world.decls[0] == .type);
+    try testing.expect(world.decls[0].type == .instance);
+    try testing.expect(world.decls[1] == .import);
+    try testing.expectEqualStrings("foo", world.decls[1].import.name);
+    try testing.expect(world.decls[1].import.desc == .instance);
+
+    // The inline interface body has one func + one export `bar`.
+    const iface = world.decls[0].type.instance;
+    try testing.expectEqual(@as(usize, 2), iface.decls.len);
+    try testing.expect(iface.decls[0] == .type);
+    try testing.expect(iface.decls[0].type == .func);
+    try testing.expect(iface.decls[1] == .@"export");
+    try testing.expectEqualStrings("bar", iface.decls[1].@"export".name);
+}
+
+test "metadata_encode #285: named_func export round-trips as a top-level func export" {
+    // `export run: func();` — a world-level function, advertised as a
+    // top-level component func export named `run` (NOT wrapped in an
+    // instance). The world body holds a `func` type decl + a `func`
+    // extern export decl.
+    const source =
+        \\package docs:nf@0.1.0;
+        \\world w {
+        \\    export run: func();
+        \\}
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "w");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const outer = comp.types[0].component;
+    const world = outer.decls[0].type.component;
+    // [func type decl, func export decl].
+    try testing.expectEqual(@as(usize, 2), world.decls.len);
+    try testing.expect(world.decls[0] == .type);
+    try testing.expect(world.decls[0].type == .func);
+    try testing.expectEqual(@as(usize, 0), world.decls[0].type.func.params.len);
+    try testing.expect(world.decls[0].type.func.results == .none);
+    try testing.expect(world.decls[1] == .@"export");
+    try testing.expectEqualStrings("run", world.decls[1].@"export".name);
+    try testing.expect(world.decls[1].@"export".desc == .func);
+    try testing.expectEqual(@as(u32, 0), world.decls[1].@"export".desc.func);
+}
+
+test "metadata_encode #285: named_func import with a primitive result round-trips" {
+    // `import compute: func(x: u32) -> u32;` — a world-level function
+    // import, advertised as a top-level component func import.
+    const source =
+        \\package docs:nfi@0.1.0;
+        \\world w {
+        \\    import compute: func(x: u32) -> u32;
+        \\}
+    ;
+    const bytes = try encodeWorldFromSource(testing.allocator, source, "w");
+    defer testing.allocator.free(bytes);
+
+    const loader = @import("../loader.zig");
+    var arena_loaded = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_loaded.deinit();
+    const comp = try loader.load(bytes, arena_loaded.allocator());
+
+    const outer = comp.types[0].component;
+    const world = outer.decls[0].type.component;
+    try testing.expectEqual(@as(usize, 2), world.decls.len);
+    try testing.expect(world.decls[0] == .type);
+    try testing.expect(world.decls[0].type == .func);
+    const f = world.decls[0].type.func;
+    try testing.expectEqual(@as(usize, 1), f.params.len);
+    try testing.expect(f.params[0].type == .u32);
+    try testing.expect(f.results == .unnamed);
+    try testing.expect(f.results.unnamed == .u32);
+    try testing.expect(world.decls[1] == .import);
+    try testing.expectEqualStrings("compute", world.decls[1].import.name);
+    try testing.expect(world.decls[1].import.desc == .func);
+}
+
+test "metadata_encode #285: inline interface with a `use` clause is rejected (R2 scope guard)" {
+    const source =
+        \\package docs:niu@0.1.0;
+        \\interface types { type t = u32; }
+        \\world w {
+        \\    import foo: interface { use types.{t}; bar: func() -> t; };
+        \\}
+    ;
+    const r = encodeWorldFromSource(testing.allocator, source, "w");
+    try testing.expectError(error.UnsupportedWitFeature, r);
 }
 
 test "metadata_encode #263: lower P3 stream/future/error-context/async func" {

--- a/src/tools/component_bindgen.zig
+++ b/src/tools/component_bindgen.zig
@@ -212,6 +212,10 @@ const Gen = struct {
         const doc_pkg = self.resolver.main.package;
 
         var uses = std.ArrayListUnmanaged(Use).empty;
+        // Top-level world funcs (`named_func`): emitted at module scope
+        // (no enclosing interface struct), separate from `uses`.
+        const TopFunc = struct { name: []const u8, func: ast.Func, is_export: bool };
+        var top_funcs = std.ArrayListUnmanaged(TopFunc).empty;
         for (world.items) |item| {
             const extern_item: ?struct { ext: ast.WorldExtern, is_export: bool } = switch (item) {
                 .import => |e| .{ .ext = e, .is_export = false },
@@ -219,17 +223,33 @@ const Gen = struct {
                 else => null,
             };
             const ei = extern_item orelse continue;
-            const ref = switch (ei.ext) {
-                .interface_ref => |ir| ir.ref,
-                else => return error.UnsupportedWitType, // named_func/named_interface: v2
-            };
-            const hit = self.resolver.findInterfaceWithPkg(ref) orelse return error.UnknownInterface;
-            try uses.append(self.ar, .{
-                .id = try ifaceId(self.ar, ref, doc_pkg),
-                .iface = hit.iface,
-                .is_export = ei.is_export,
-                .pkg = hit.pkg,
-            });
+            switch (ei.ext) {
+                .interface_ref => |ir| {
+                    const ref = ir.ref;
+                    const hit = self.resolver.findInterfaceWithPkg(ref) orelse return error.UnknownInterface;
+                    try uses.append(self.ar, .{
+                        .id = try ifaceId(self.ar, ref, doc_pkg),
+                        .iface = hit.iface,
+                        .is_export = ei.is_export,
+                        .pkg = hit.pkg,
+                    });
+                },
+                .named_interface => |ni| {
+                    // Inline interface: advertised under the world-local plain
+                    // name (matching metadata_encode / component new), so the
+                    // extern module string is `ni.name`. Reuse the interface
+                    // machinery by synthesizing a `Use` over its inline items.
+                    try uses.append(self.ar, .{
+                        .id = ni.name,
+                        .iface = .{ .name = ni.name, .items = ni.items },
+                        .is_export = ei.is_export,
+                        .pkg = doc_pkg,
+                    });
+                },
+                .named_func => |nf| {
+                    try top_funcs.append(self.ar, .{ .name = nf.name, .func = nf.func, .is_export = ei.is_export });
+                },
+            }
         }
 
         // Index every named type so `.name` refs resolve, plus any types pulled
@@ -339,6 +359,9 @@ const Gen = struct {
         for (uses.items) |u| {
             if (u.is_export) have_exports = true;
         }
+        for (top_funcs.items) |tf| {
+            if (tf.is_export) have_exports = true;
+        }
         if (have_exports) {
             self.print("const Impl = @import(\"{s}\");\n\n", .{self.impl});
         }
@@ -352,6 +375,16 @@ const Gen = struct {
         for (uses.items) |u| {
             if (!u.is_export) continue;
             try self.emitExportIface(u);
+        }
+        // ── top-level world funcs (`named_func`) ──
+        for (top_funcs.items) |tf| {
+            if (tf.is_export) {
+                try self.emitTopLevelExportFunc(tf.name, tf.func);
+            } else {
+                // Top-level func *imports* are not yet wired by
+                // `component new` (they'd dangle); a later phase.
+                return error.UnsupportedWitType;
+            }
         }
     }
 
@@ -510,9 +543,28 @@ const Gen = struct {
 
     fn emitExportFunc(self: *Gen, iface_id: []const u8, name: []const u8, func: ast.Func) GenError!void {
         if (func.is_async) return self.emitAsyncExportFunc(iface_id, name, func);
+        const export_sym = try std.fmt.allocPrint(self.ar, "{s}#{s}", .{ iface_id, name });
+        try self.emitSyncExportFuncSym(export_sym, name, func);
+    }
+
+    /// Emit a module-scope export shell for a top-level world func
+    /// (`named_func`). The core export name is the plain func name (no
+    /// `<iface>#` prefix), matching what `component new` lifts.
+    fn emitTopLevelExportFunc(self: *Gen, name: []const u8, func: ast.Func) GenError!void {
+        // Async top-level func exports need a top-level `[task-return]`
+        // intrinsic name; deferred to a later phase.
+        if (func.is_async) return error.UnsupportedWitType;
+        try self.emitSyncExportFuncSym(name, name, func);
+    }
+
+    /// Shared body for a synchronous export shell. `export_sym` is the
+    /// exact wasm core export name (`<iface>#<func>` for an interface
+    /// func, or the plain func name for a top-level world func); `name`
+    /// drives the `Impl.<fn>` call.
+    fn emitSyncExportFuncSym(self: *Gen, export_sym: []const u8, name: []const u8, func: ast.Func) GenError!void {
         const result_zig = try self.resultZig(func);
 
-        self.print("export fn @\"{s}#{s}\"(", .{ iface_id, name });
+        self.print("export fn @\"{s}\"(", .{export_sym});
         try self.emitFlatParamDecls(func.params);
         self.print(") canon.CoreReturn({s}) {{\n", .{result_zig});
         self.raw("    abi.resetScratch();\n");
@@ -1877,6 +1929,107 @@ test "generate: imported resource handle struct + methods/static/ctor/drop" {
         var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
         try testing.expectError(error.UnsupportedWitType, g.generate(exp_world, "host"));
     }
+}
+
+test "generate #286: named_interface import emits a plain-named import struct" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // world guest { import foo: interface { bar: func() -> u32; }; }
+    const foo_items = [_]ast.InterfaceItem{
+        .{ .func = .{ .name = "bar", .func = .{ .params = &.{}, .result = .u32 } } },
+    };
+    const world = ast.World{ .name = "guest", .items = &.{
+        .{ .import = .{ .named_interface = .{ .name = "foo", .items = &foo_items } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "local", .name = "ni" },
+        .items = &.{.{ .world = world }},
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+    try g.generate(world, "guest");
+    const out = g.out.items;
+
+    // Import struct named after the plain local name; the extern's wasm
+    // module is the plain name `foo`, field `bar` — matching the pipeline.
+    try testing.expect(std.mem.indexOf(u8, out, "pub const foo = struct {") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "extern \"foo\" fn @\"bar\"() i32;") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "pub fn bar() u32 {") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "return canon.liftResultFlat(u32, imp.@\"bar\"());") != null);
+}
+
+test "generate #286: named_func export emits a module-scope export shell" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // world cmd { export run: func(); }
+    const world = ast.World{ .name = "cmd", .items = &.{
+        .{ .@"export" = .{ .named_func = .{ .name = "run", .func = .{ .params = &.{}, .result = null } } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "local", .name = "nf" },
+        .items = &.{.{ .world = world }},
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+    try g.generate(world, "cmd");
+    const out = g.out.items;
+
+    // An export pulls in the user impl.
+    try testing.expect(std.mem.indexOf(u8, out, "const Impl = @import(\"impl\");") != null);
+    // Module-scope export under the plain func name (no `<iface>#` prefix).
+    try testing.expect(std.mem.indexOf(u8, out, "export fn @\"run\"() canon.CoreReturn(void) {") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Impl.run();") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "#run") == null);
+}
+
+test "generate #286: named_func export with a primitive result" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    // world cmd { export compute: func(x: u32) -> u32; }
+    const world = ast.World{ .name = "cmd", .items = &.{
+        .{ .@"export" = .{ .named_func = .{
+            .name = "compute",
+            .func = .{ .params = &.{.{ .name = "x", .type = .u32 }}, .result = .u32 },
+        } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "local", .name = "nf" },
+        .items = &.{.{ .world = world }},
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+    try g.generate(world, "cmd");
+    const out = g.out.items;
+
+    try testing.expect(std.mem.indexOf(u8, out, "export fn @\"compute\"(") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "canon.returnResult(u32, Impl.compute(") != null);
+}
+
+test "generate #286: top-level func import is rejected (later phase)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    const world = ast.World{ .name = "cmd", .items = &.{
+        .{ .import = .{ .named_func = .{ .name = "compute", .func = .{ .params = &.{}, .result = .u32 } } } },
+    } };
+    const doc = ast.Document{
+        .package = .{ .namespace = "local", .name = "nfi" },
+        .items = &.{.{ .world = world }},
+    };
+    const res = wit.resolver.Resolver.init(doc, &.{});
+
+    var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };
+    try testing.expectError(error.UnsupportedWitType, g.generate(world, "cmd"));
 }
 
 test "generate: imported resource with async methods (#300)" {

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -475,6 +475,35 @@ fn valTypesEql(a: []const wabt.types.ValType, b: []const wabt.types.ValType) boo
     return true;
 }
 
+/// A component `ValType` that is a no-memory inline scalar primitive —
+/// one flat core slot, no hoisted typedef, no `(memory)`/`(realloc)`
+/// lift opts. Excludes `string` / `error_context` (need memory or are
+/// P3 async), every compound (`list`/`tuple`/`record`/… or a hoisted
+/// `type_idx`), and resource handles (`own`/`borrow`).
+fn isInlineScalarValType(vt: ctypes.ValType) bool {
+    return switch (vt) {
+        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .f32, .f64, .char => true,
+        else => false,
+    };
+}
+
+/// Whether a top-level world func (`named_func`) signature is liftable
+/// by `buildComponent`'s fast path: every param and result is an inline
+/// scalar primitive and the param count stays within the canonical flat
+/// limit (so nothing spills to memory). Non-simple sigs are rejected
+/// (rather than emitted verbatim, which would dangle a `type_idx` into
+/// the wrong type space — an invalid component).
+fn topLevelFuncSigIsSimple(sig: ctypes.FuncType) bool {
+    if (sig.params.len > wabt.component.adapter.abi.MAX_FLAT_PARAMS) return false;
+    for (sig.params) |p| if (!isInlineScalarValType(p.type)) return false;
+    switch (sig.results) {
+        .none => {},
+        .unnamed => |vt| if (!isInlineScalarValType(vt)) return false,
+        .named => return false, // multi/named results: needs memory, out of scope
+    }
+    return true;
+}
+
 fn debugPrintCoreSig(params: []const wabt.types.ValType, results: []const wabt.types.ValType) void {
     std.debug.print("(func", .{});
     for (params) |p| std.debug.print(" (param {s})", .{@tagName(p)});
@@ -2484,16 +2513,18 @@ pub fn buildComponent(alloc: std.mem.Allocator, core_bytes: []const u8) ![]u8 {
     var captured_top_funcs = std.ArrayListUnmanaged(CapturedTopFunc).empty;
     for (decoded.func_externs) |fext| {
         if (!fext.is_export) continue; // imports rejected before path selection
-        // A top-level func whose lift needs `(memory)` / `(realloc)` /
-        // string-encoding can't ride the fast path (the shim/fixup path
-        // doesn't handle top-level funcs yet) — reject cleanly.
-        const lift_resolver = wabt.component.adapter.abi.TypeResolver{
-            .inst_decls = &.{},
-            .world_decls = decoded.world_decls,
-        };
-        if (wabt.component.adapter.abi.liftNeedsOpts(
-            wabt.component.adapter.abi.classifyFuncLift(.{ .func = fext.sig, .resolver = lift_resolver }),
-        )) return error.UnsupportedShape;
+        // Only top-level funcs whose signature is composed entirely of
+        // no-memory inline scalar primitives (and stays within the
+        // canonical flat-param/result limits) ride the fast path. Any
+        // `string` / compound (`list`/`tuple`/…) / handle / async value
+        // type would need its type hoisted+rebased into the wrapping
+        // component's type space and/or `(memory)`/`(realloc)` lift opts
+        // — neither of which this path emits for top-level funcs. The
+        // signature is appended verbatim below, so emitting a non-simple
+        // sig would dangle a `type_idx` into the wrong type space (an
+        // invalid component). Reject cleanly instead (a later phase may
+        // transcribe these). Func *imports* were already rejected.
+        if (!topLevelFuncSigIsSimple(fext.sig)) return error.UnsupportedShape;
 
         try types.append(ar, .{ .func = fext.sig });
         try Section.appendType(&order, ar, types.items.len);
@@ -6411,6 +6442,28 @@ test "buildComponent #285: top-level func import is rejected (not yet supported)
         \\(module
         \\  (import "compute" "" (func (result i32)))
         \\  (func (export "run"))
+        \\)
+    ;
+    const core = try buildCoreFromWat(testing.allocator, wat, wit, "cmd");
+    defer testing.allocator.free(core);
+    try testing.expectError(error.UnsupportedShape, buildComponent(testing.allocator, core));
+}
+
+test "buildComponent #285: named_func export with a compound (non-simple) sig is rejected" {
+    // A top-level func whose result is a compound type (`tuple<u32, u32>`)
+    // can't ride the fast path: its sig carries a `type_idx` into the
+    // embed's world-body type space, which would dangle if emitted
+    // verbatim. The fast path rejects it cleanly rather than producing an
+    // invalid component.
+    const wit =
+        \\package local:nfc@0.1.0;
+        \\world cmd {
+        \\    export f: func() -> tuple<u32, u32>;
+        \\}
+    ;
+    const wat =
+        \\(module
+        \\  (func (export "f") (param i32))
         \\)
     ;
     const core = try buildCoreFromWat(testing.allocator, wat, wit, "cmd");

--- a/src/tools/component_new.zig
+++ b/src/tools/component_new.zig
@@ -1516,6 +1516,14 @@ pub fn buildComponent(alloc: std.mem.Allocator, core_bytes: []const u8) ![]u8 {
 
     const decoded = try metadata_decode.decode(ar, found.payload);
 
+    // Top-level world func *imports* (`import name: func(...);`) are not
+    // yet wired by `component new` — rejecting here (before path
+    // selection) avoids silently dropping the guest's matching core
+    // import. Func *exports* are handled on the fast path below.
+    for (decoded.func_externs) |fext| {
+        if (!fext.is_export) return error.UnsupportedShape;
+    }
+
     // Strip the `component-type:*` custom sections from the core
     // module — they're metadata for `component new`, not part of the
     // module that goes inside the wrapping component.
@@ -2462,6 +2470,53 @@ pub fn buildComponent(alloc: std.mem.Allocator, core_bytes: []const u8) ![]u8 {
         try ext_export_start.append(ar, .{ .ext = ext, .start = start });
     }
 
+    // ── Top-level world func exports (`named_func`). Capture each like
+    //    an interface export func — append its component func type and
+    //    alias the guest's core export — but emit a top-level func
+    //    export (not an instance) further below. The core export name
+    //    convention is the plain func name (documented in the README).
+    const CapturedTopFunc = struct {
+        name: []const u8,
+        func_type_idx: u32,
+        core_func_alias_idx: u32,
+        is_async: bool,
+    };
+    var captured_top_funcs = std.ArrayListUnmanaged(CapturedTopFunc).empty;
+    for (decoded.func_externs) |fext| {
+        if (!fext.is_export) continue; // imports rejected before path selection
+        // A top-level func whose lift needs `(memory)` / `(realloc)` /
+        // string-encoding can't ride the fast path (the shim/fixup path
+        // doesn't handle top-level funcs yet) — reject cleanly.
+        const lift_resolver = wabt.component.adapter.abi.TypeResolver{
+            .inst_decls = &.{},
+            .world_decls = decoded.world_decls,
+        };
+        if (wabt.component.adapter.abi.liftNeedsOpts(
+            wabt.component.adapter.abi.classifyFuncLift(.{ .func = fext.sig, .resolver = lift_resolver }),
+        )) return error.UnsupportedShape;
+
+        try types.append(ar, .{ .func = fext.sig });
+        try Section.appendType(&order, ar, types.items.len);
+        const func_type_idx = comp_type_idx;
+        comp_type_idx += 1;
+
+        try aliases.append(ar, .{ .instance_export = .{
+            .sort = .{ .core = .func },
+            .instance_idx = main_core_inst_idx,
+            .name = fext.name,
+        } });
+        try Section.appendAlias(&order, ar, aliases.items.len);
+        const cf_idx = core_func_idx;
+        core_func_idx += 1;
+
+        try captured_top_funcs.append(ar, .{
+            .name = fext.name,
+            .func_type_idx = func_type_idx,
+            .core_func_alias_idx = cf_idx,
+            .is_async = fext.sig.is_async,
+        });
+    }
+
     // ── Canon lifts and instance exprs: appended to flat lists,
     //    section_order entries appended after.
     const lifts_start: u32 = @intCast(canons.items.len);
@@ -2469,6 +2524,20 @@ pub fn buildComponent(alloc: std.mem.Allocator, core_bytes: []const u8) ![]u8 {
         // An `async func` export lifts with the `async` canon option;
         // its async-ness reached us via the `[async]` declarator name
         // (see metadata_decode), surfaced as `fn_ref.sig.is_async`.
+        const opts: []const ctypes.CanonOpt = if (cf.is_async)
+            try ar.dupe(ctypes.CanonOpt, &.{.async_})
+        else
+            &.{};
+        try canons.append(ar, .{ .lift = .{
+            .core_func_idx = cf.core_func_alias_idx,
+            .type_idx = cf.func_type_idx,
+            .opts = opts,
+        } });
+    }
+    // Lift the captured top-level func exports into the same canon
+    // batch (after the interface export lifts, so their component func
+    // indices follow contiguously — see the export emit loop below).
+    for (captured_top_funcs.items) |cf| {
         const opts: []const ctypes.CanonOpt = if (cf.is_async)
             try ar.dupe(ctypes.CanonOpt, &.{.async_})
         else
@@ -2544,6 +2613,24 @@ pub fn buildComponent(alloc: std.mem.Allocator, core_bytes: []const u8) ![]u8 {
             .name = es.ext.qualified_name,
             .desc = .{ .instance = 0 },
             .sort_idx = .{ .sort = .instance, .idx = inst_idx },
+        });
+    }
+
+    // ── Top-level func exports: one component-level `export "<name>"
+    //    (func …)` per captured top-level func. Their lifted component
+    //    func indices follow the interface export funcs contiguously
+    //    (`comp_func_idx` was left at the first free slot by the loop
+    //    above, and the top-level lifts were appended to the canon
+    //    batch after the interface lifts).
+    for (captured_top_funcs.items) |cf| {
+        const cfi = comp_func_idx;
+        comp_func_idx += 1;
+        try exports.append(ar, .{
+            .name = cf.name,
+            // `idx = 0` placeholder → the writer emits the un-ascribed
+            // export form, deriving the func type from `sort_idx`.
+            .desc = .{ .func = 0 },
+            .sort_idx = .{ .sort = .func, .idx = cfi },
         });
     }
 
@@ -2635,6 +2722,13 @@ fn buildComponentShimFixup(
     const core_exports = try probeCoreExports(stripped_core);
     const memory_export_name = core_exports.memory_name orelse return error.MissingCoreExportMemory;
     const realloc_export_name = core_exports.realloc_name orelse return error.MissingCabiRealloc;
+
+    // The shim/fixup path does not yet emit top-level world func
+    // externs (`named_func`). Func imports are already rejected before
+    // path selection; any func extern reaching here is an export this
+    // path can't lift — reject cleanly rather than silently drop it.
+    // (Top-level func exports with only simple sigs take the fast path.)
+    if (decoded.func_externs.len > 0) return error.UnsupportedShape;
 
     // ── Phase 1: re-collect import shapes (same as the fast path).
     var resource_owner = std.StringHashMapUnmanaged([]const u8).empty;
@@ -6207,6 +6301,121 @@ test "buildComponent #263: async run export wires task.return + async lift" {
     try testing.expect(anyAsyncLift(loaded));
     try testing.expect(mainWithArgFor(loaded, "[task-return]local:p/run@0.1.0#run"));
     try testing.expect(bundleExportsFunc(loaded, "task-return"));
+}
+
+test "buildComponent #285: named_func export becomes a top-level component func export" {
+    // A world exporting a bare `run: func();` produces a component with
+    // a top-level func export named `run` (NOT wrapped in an instance).
+    // The guest core module exports the func under its plain name.
+    const wit =
+        \\package local:nf@0.1.0;
+        \\world cmd {
+        \\    export run: func();
+        \\}
+    ;
+    const wat =
+        \\(module
+        \\  (func (export "run"))
+        \\)
+    ;
+    const core = try buildCoreFromWat(testing.allocator, wat, wit, "cmd");
+    defer testing.allocator.free(core);
+
+    const comp_bytes = try buildComponent(testing.allocator, core);
+    defer testing.allocator.free(comp_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const loaded = try loader.load(comp_bytes, arena.allocator());
+
+    // Exactly one top-level export: `run`, a func (no instance).
+    var saw_run_func = false;
+    for (loaded.exports) |e| {
+        if (std.mem.eql(u8, e.name, "run")) {
+            try testing.expect(e.sort_idx != null);
+            try testing.expectEqual(ctypes.Sort.func, e.sort_idx.?.sort);
+            saw_run_func = true;
+        }
+        // No instance export should be emitted for this world.
+        if (e.sort_idx) |si| try testing.expect(si.sort != .instance);
+    }
+    try testing.expect(saw_run_func);
+    // The func was lifted from the guest's `run` core export.
+    var saw_lift = false;
+    for (loaded.canons) |c| switch (c) {
+        .lift => saw_lift = true,
+        else => {},
+    };
+    try testing.expect(saw_lift);
+}
+
+test "buildComponent #285: named_interface import becomes a plain-named instance import" {
+    // A world importing an inline interface `host: interface { add: ... }`
+    // produces a component with an instance import named `host`; the
+    // guest's `(import "host" "add" …)` core import is wired to it.
+    const wit =
+        \\package local:ni@0.1.0;
+        \\world cmd {
+        \\    import host: interface { add: func(x: u32, y: u32) -> u32; };
+        \\    export run: func();
+        \\}
+    ;
+    const wat =
+        \\(module
+        \\  (import "host" "add" (func (param i32 i32) (result i32)))
+        \\  (func (export "run"))
+        \\)
+    ;
+    const core = try buildCoreFromWat(testing.allocator, wat, wit, "cmd");
+    defer testing.allocator.free(core);
+
+    const comp_bytes = try buildComponent(testing.allocator, core);
+    defer testing.allocator.free(comp_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const loaded = try loader.load(comp_bytes, arena.allocator());
+
+    // Instance import named `host`.
+    var saw_host_import = false;
+    for (loaded.imports) |im| {
+        if (std.mem.eql(u8, im.name, "host")) {
+            try testing.expect(im.desc == .instance);
+            saw_host_import = true;
+        }
+    }
+    try testing.expect(saw_host_import);
+
+    // The imported `add` func is lowered, and the guest is fed a
+    // `(with "host" …)` bundle exporting `add`.
+    try testing.expect(bundleExportsFunc(loaded, "add"));
+    try testing.expect(mainWithArgFor(loaded, "host"));
+
+    // And `run` is still exported as a top-level func.
+    var saw_run = false;
+    for (loaded.exports) |e| {
+        if (std.mem.eql(u8, e.name, "run") and e.sort_idx != null and e.sort_idx.?.sort == .func) saw_run = true;
+    }
+    try testing.expect(saw_run);
+}
+
+test "buildComponent #285: top-level func import is rejected (not yet supported)" {
+    const wit =
+        \\package local:nfi@0.1.0;
+        \\world cmd {
+        \\    import compute: func() -> u32;
+        \\    export run: func();
+        \\}
+    ;
+    const wat =
+        \\(module
+        \\  (import "compute" "" (func (result i32)))
+        \\  (func (export "run"))
+        \\)
+    ;
+    const core = try buildCoreFromWat(testing.allocator, wat, wit, "cmd");
+    defer testing.allocator.free(core);
+    try testing.expectError(error.UnsupportedShape, buildComponent(testing.allocator, core));
 }
 
 fn countStreamCanons(loaded: anytype) usize {


### PR DESCRIPTION
Implements `named_interface` (`import|export name: interface { … };`) and `named_func` (`import|export name: func(…) -> …;`) world externs across the WIT→component pipeline (#285) and the guest bindings generator (#286). These two `WorldExtern` shapes were already parsed but rejected by the encoder, decoder, `component new`, and bindgen.

## Naming convention
- **`named_interface`** — advertised on the wire under its world-local **plain name** (e.g. `foo`), lowered as an instance import/export exactly like an `interface_ref`. Guest core import module = the plain name, field = the func name.
- **`named_func`** — a **top-level component func** extern (`ExternDesc.func`), not an instance. Guest core **export** name is the plain func name (no `<iface>#` prefix).

Both layers agree on these names; the convention is documented in the `metadata_encode` module doc comment.

## Changes
- **`metadata_encode.zig`** — `qualifiedName` returns the plain name; `buildInterfaceBody` refactored into a dispatcher + shared `buildInterfaceBodyFromItems` (used by both `interface_ref` and inline `named_interface`); new `lowerWorldFunc` hoists a top-level func type into the world-body type index space. Inline `use` clauses are out of scope (rejected).
- **`metadata_decode.zig`** — new `FuncExtern` + `DecodedWorld.func_externs`; the decode loop handles a world-body extern decl whose `ExternDesc` is `.func` (top-level func) in addition to `.instance`.
- **`component_new.zig`** — the fast path lifts each top-level func **export** into a top-level component func export (canon lift, alias the guest core export under the plain name). Top-level func **imports** are rejected before path selection; the shim/fixup path rejects any func extern; a self-contained gate rejects non-simple top-level func sigs (compound/string/handle/spill) rather than emit an invalid component.
- **`component_bindgen.zig`** — synthesizes a `Use` for `named_interface` (plain-named import struct / export shells) and emits a module-scope export shell for `named_func` export (plain core export name). Top-level func imports rejected.

## Validation
- `zig build test`: **655/655 pass**.
- End-to-end (bindgen → `zig build-exe` wasm32-freestanding against `canon`/`abi` → `wabt component embed` → `wabt component new`): the produced components **pass `wasm-tools validate --features all` and `wasmtime 46 compile`**, and `wasm-tools component wit` round-trips to the exact source world for: `export run: func();`, `import foo: interface { bar: func() -> u32; }`, and a combined world importing an inline interface + exporting a top-level func.

Fixes #285
Fixes #286
