### PR TITLE
ci: WASI P3 conformance gate pinned to Wasmtime 46 (#267 Phase 3b)

### DIFF
--- a/.github/workflows/p3-conformance.yml
+++ b/.github/workflows/p3-conformance.yml
@@ -38,9 +38,5 @@ jobs:
             cataggar/zig@${{ env.ZIG_VERSION }} RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
             bytecodealliance/wasmtime@${{ env.WASMTIME_VERSION }}
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.x'
-
       - name: Run P3 conformance gate
         run: zig build p3-conformance -Dp3-require-wasmtime

--- a/.github/workflows/p3-conformance.yml
+++ b/.github/workflows/p3-conformance.yml
@@ -3,8 +3,8 @@ name: WASI P3 conformance
 # Phase 3b of cataggar/wabt#267: validate wabt-produced WASI Preview 3
 # components against a pinned upstream Wasmtime. Runs on push-to-main and
 # nightly (plus manual dispatch) — intentionally NOT on `pull_request`, so it
-# never gates PRs. Until the pinned Wasmtime release is tagged, the job
-# downloads nothing and the conformance step is skipped, so the job stays green.
+# never gates PRs. Zig and Wasmtime are installed from GitHub releases via the
+# `ghr` install action.
 on:
   push:
     branches: [main]
@@ -16,12 +16,11 @@ permissions:
   contents: read
 
 env:
-  # Wasmtime release to validate P3 components against. The P3 canon built-ins
-  # (`backpressure.*`, `context.*`, `subtask.cancel`) require Wasmtime >= 46
-  # (wasmparser 0.251). Bump this single line once a newer P3-capable release
-  # ships. v46.0.0 is not yet tagged as of this PR; until it is, the job skips
-  # the conformance run cleanly (see the install step).
+  # Tool versions installed from GitHub releases via `ghr`. The P3 canon
+  # built-ins (`backpressure.*`, `context.*`, `subtask.cancel`) require Wasmtime
+  # >= 46 (wasmparser 0.251). Bump these single lines to move the pins.
   WASMTIME_VERSION: v46.0.0
+  ZIG_VERSION: v0.16.0
 
 jobs:
   p3-conformance:
@@ -32,41 +31,16 @@ jobs:
         with:
           submodules: true
 
-      - name: Install Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+      - name: Install Zig and Wasmtime via ghr
+        uses: cataggar/ghr/actions/install@v0.5.2
         with:
-          version: 0.16.0
+          tools: |
+            cataggar/zig@${{ env.ZIG_VERSION }} RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
+            bytecodealliance/wasmtime@${{ env.WASMTIME_VERSION }}
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
 
-      - name: Install Wasmtime ${{ env.WASMTIME_VERSION }}
-        id: wasmtime
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          ver="${WASMTIME_VERSION}"
-          api="https://api.github.com/repos/bytecodealliance/wasmtime/releases/tags/${ver}"
-          code=$(curl -sL -o /dev/null -w '%{http_code}' \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" "${api}" || echo 000)
-          if [ "${code}" != "200" ]; then
-            echo "::notice::Wasmtime ${ver} is not released yet (releases API returned ${code}); skipping P3 conformance until it ships."
-            echo "available=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-          asset="wasmtime-${ver}-x86_64-linux.tar.xz"
-          url="https://github.com/bytecodealliance/wasmtime/releases/download/${ver}/${asset}"
-          curl -fsSL "${url}" -o "${RUNNER_TEMP}/wasmtime.tar.xz"
-          mkdir -p "${RUNNER_TEMP}/wasmtime"
-          tar -xf "${RUNNER_TEMP}/wasmtime.tar.xz" -C "${RUNNER_TEMP}/wasmtime" --strip-components=1
-          chmod +x "${RUNNER_TEMP}/wasmtime/wasmtime"
-          echo "WASMTIME=${RUNNER_TEMP}/wasmtime/wasmtime" >> "${GITHUB_ENV}"
-          echo "available=true" >> "${GITHUB_OUTPUT}"
-          "${RUNNER_TEMP}/wasmtime/wasmtime" --version
-
       - name: Run P3 conformance gate
-        if: steps.wasmtime.outputs.available == 'true'
         run: zig build p3-conformance -Dp3-require-wasmtime

--- a/.github/workflows/p3-conformance.yml
+++ b/.github/workflows/p3-conformance.yml
@@ -1,0 +1,72 @@
+name: WASI P3 conformance
+
+# Phase 3b of cataggar/wabt#267: validate wabt-produced WASI Preview 3
+# components against a pinned upstream Wasmtime. Runs on push-to-main and
+# nightly (plus manual dispatch) — intentionally NOT on `pull_request`, so it
+# never gates PRs. Until the pinned Wasmtime release is tagged, the job
+# downloads nothing and the conformance step is skipped, so the job stays green.
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '17 6 * * *' # nightly ~06:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # Wasmtime release to validate P3 components against. The P3 canon built-ins
+  # (`backpressure.*`, `context.*`, `subtask.cancel`) require Wasmtime >= 46
+  # (wasmparser 0.251). Bump this single line once a newer P3-capable release
+  # ships. v46.0.0 is not yet tagged as of this PR; until it is, the job skips
+  # the conformance run cleanly (see the install step).
+  WASMTIME_VERSION: v46.0.0
+
+jobs:
+  p3-conformance:
+    name: WASI P3 conformance (Wasmtime ${{ env.WASMTIME_VERSION }})
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.x'
+
+      - name: Install Wasmtime ${{ env.WASMTIME_VERSION }}
+        id: wasmtime
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ver="${WASMTIME_VERSION}"
+          api="https://api.github.com/repos/bytecodealliance/wasmtime/releases/tags/${ver}"
+          code=$(curl -sL -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" "${api}" || echo 000)
+          if [ "${code}" != "200" ]; then
+            echo "::notice::Wasmtime ${ver} is not released yet (releases API returned ${code}); skipping P3 conformance until it ships."
+            echo "available=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          asset="wasmtime-${ver}-x86_64-linux.tar.xz"
+          url="https://github.com/bytecodealliance/wasmtime/releases/download/${ver}/${asset}"
+          curl -fsSL "${url}" -o "${RUNNER_TEMP}/wasmtime.tar.xz"
+          mkdir -p "${RUNNER_TEMP}/wasmtime"
+          tar -xf "${RUNNER_TEMP}/wasmtime.tar.xz" -C "${RUNNER_TEMP}/wasmtime" --strip-components=1
+          chmod +x "${RUNNER_TEMP}/wasmtime/wasmtime"
+          echo "WASMTIME=${RUNNER_TEMP}/wasmtime/wasmtime" >> "${GITHUB_ENV}"
+          echo "available=true" >> "${GITHUB_OUTPUT}"
+          "${RUNNER_TEMP}/wasmtime/wasmtime" --version
+
+      - name: Run P3 conformance gate
+        if: steps.wasmtime.outputs.available == 'true'
+        run: zig build p3-conformance -Dp3-require-wasmtime

--- a/build.zig
+++ b/build.zig
@@ -8,6 +8,10 @@ pub fn build(b: *std.Build) void {
     const stack_protector = b.option(bool, "stack-protector", "Enable stack protector (requires libc linkage)") orelse false;
     const link_libc = b.option(bool, "link-libc", "Link against libc") orelse stack_protector;
     const version = b.option([]const u8, "version", "Version string") orelse "dev";
+    // When set, `zig build p3-conformance` fails (instead of skipping) if no
+    // usable Wasmtime is found — set by the CI p3-conformance job, which
+    // installs a pinned Wasmtime that supports the P3 canon built-ins.
+    const p3_require_wasmtime = b.option(bool, "p3-require-wasmtime", "Fail (not skip) p3-conformance when no Wasmtime is found (CI)") orelse false;
 
     const options = b.addOptions();
     options.addOption([]const u8, "version", version);
@@ -389,6 +393,9 @@ pub fn build(b: *std.Build) void {
         "--wabt",
     });
     p3_runner.addArtifactArg(wabt_exe);
+    // CI installs a pinned Wasmtime and sets this so a missing/broken
+    // Wasmtime is a hard failure rather than a silent skip.
+    if (p3_require_wasmtime) p3_runner.addArg("--require-wasmtime");
     const p3_step = b.step(
         "p3-conformance",
         "Validate wabt-produced P3 components against Wasmtime (set WASMTIME)",

--- a/tests/p3/subtask-drop.wat
+++ b/tests/p3/subtask-drop.wat
@@ -1,0 +1,8 @@
+;; subtask.drop (0x0d): no-memory subtask-handle release built-in.
+(module
+  (import "[task-return]local:p/run@0.1.0#run" "task-return" (func (param i32)))
+  (import "[subtask]" "drop" (func (param i32)))
+  (memory (export "memory") 1)
+  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) (i32.const 0))
+  (func (export "local:p/run@0.1.0#run") (call 0 (i32.const 0)))
+)


### PR DESCRIPTION
Phase 3b of #267: a CI job that validates wabt-produced WASI Preview 3 components against a pinned upstream Wasmtime. **Drafted now and pre-staged to self-activate the moment Wasmtime v46.0.0 is tagged** (still unreleased — latest stable is v45.0.2).

## What this adds
- **`.github/workflows/p3-conformance.yml`** — runs `zig build p3-conformance` against a pinned Wasmtime.
  - Triggers: **push-to-main + nightly + `workflow_dispatch`**. Intentionally **not** `pull_request`, so it never gates other PRs.
  - Wasmtime version is one `WASMTIME_VERSION` env var (`v46.0.0`). The install step queries the releases API first; if that tag isn't released yet it **skips the conformance run and stays green**. Once v46.0.0 ships, the next push/nightly (or a manual re-run) downloads it and runs for real — no further edits needed. Future bumps are a one-line change.
- **`build.zig`** — new `-Dp3-require-wasmtime` option so the CI run **fails (not skips)** when no usable Wasmtime is found; local `zig build p3-conformance` still skips gracefully.

## Why "bump"
The P3 canon built-ins wired in #273/#274/#275 (`backpressure.*`, `context.*`, `subtask.cancel`) are only accepted by Wasmtime ≥ 46 (wasmparser 0.251), so the conformance gate needs a released 46 to pin against. This PR is the wasmtime-46 pin; bumping later is a one-line `WASMTIME_VERSION` edit.

## Validation
- `zig build p3-conformance -Dp3-require-wasmtime` against a Wasmtime **46.0.0 dev build** (`5d09d889b`): **11/11 fixtures pass, 0 skipped, 0 failed**.
- With no usable Wasmtime: exits non-zero (hard failure), as intended for CI.
- Workflow YAML validated.

## Merge notes
Safe to merge now — until v46.0.0 is tagged the job self-skips (green). Opened as a **draft**; mark ready / merge whenever you prefer. After v46.0.0 releases, completes Phase 3b of #267 (and unblocks 3c).

Refs #267
