### PR TITLE
component loader: faithful verbatim round-trip of real wasm32-wasip3 components (40/40) (#267)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -428,7 +428,7 @@ pub fn build(b: *std.Build) void {
     if (wasip3_require_suite) wasip3_runner.addArg("--require-suite");
     const wasip3_step = b.step(
         "wasi-p3-testsuite",
-        "Decode upstream wasm32-wasip3 components with wabt's component loader",
+        "Decode + byte-identical round-trip upstream wasm32-wasip3 components with wabt",
     );
     wasip3_step.dependOn(&wasip3_runner.step);
 }

--- a/scripts/wasi_p3_testsuite.py
+++ b/scripts/wasi_p3_testsuite.py
@@ -1,24 +1,27 @@
 #!/usr/bin/env python3
-"""WASI Preview 3 (wasm32-wasip3) component decode gate for wabt.
+"""WASI Preview 3 (wasm32-wasip3) component decode + round-trip gate for wabt.
 
 This is the #267 Phase 4 gate. Where ``scripts/p3_conformance.py`` checks that
 the components wabt *produces* from hand-authored single-built-in fixtures are
 accepted by Wasmtime (``wasmtime compile``), this gate runs in the other
 direction: it feeds wabt the **real-world** ``wasm32-wasip3`` components from
-the upstream WASI testsuite and requires wabt's component loader to decode
-every one of them.
+the upstream WASI testsuite and exercises wabt's component loader + writer on
+each one.
 
 The upstream testsuite ships *already-componentized* ``wasm32-wasip3`` binaries
 (component-model layer-1 modules, magic ``\\0asm\\x0d\\x00\\x01\\x00``), so the
 core->component path (``wabt component new``) does not apply. wabt is a toolkit,
 not a runtime, so the meaningful analog of the wamr project's wasip3 runtime
-gate is *decode/loader parity*: for each fixture run
+gate is *decode/loader parity*. For each fixture this gate runs:
 
-    wabt component objdump <fixture>.wasm
+  1. ``wabt component objdump <fixture>.wasm``        (decode: loader parses it)
+  2. ``wabt component objdump <fixture>.wasm -o tmp`` (round-trip: load->encode)
+     and requires ``tmp`` to be **byte-identical** to the input.
 
-and require exit 0 -- i.e. wabt's ``src/component/loader.zig`` fully parses every
-real P3 component (nested components, async canon built-ins, stream/future,
-error-context, ...) that upstream produces.
+i.e. wabt's ``src/component/loader.zig`` fully parses *and* its
+``src/component/writer.zig`` faithfully re-emits every real P3 component
+(nested components, async canon built-ins, stream/future, error-context, ...)
+that upstream produces. The round-trip check needs no Wasmtime.
 
 Per-fixture skips live in ``tests/wasi-p3-testsuite-skip.json`` (each entry a
 rationale ending in a tracking issue), keyed by the suite ``name`` from the
@@ -37,6 +40,7 @@ import argparse
 import json
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -102,9 +106,29 @@ def main() -> int:
             skipped.append(fname)
             print(f"  SKIP {fname:28s} - {skip[fname]}")
             continue
+        # 1. Decode: wabt's component loader must parse the component.
         code, out = run([args.wabt, "component", "objdump", str(wasm)])
         if code != 0:
             failed.append((fname, f"`wabt component objdump` exited {code}\n{out.strip()}"))
+            print(f"  FAIL {fname}")
+            continue
+        # 2. Round-trip: re-emit via `objdump -o` (loader -> writer) and
+        #    require the output to be byte-identical to the input, locking
+        #    in faithful decode+encode of every real-world P3 component.
+        err = None
+        with tempfile.TemporaryDirectory(prefix=f"wasip3-rt-{fname}-") as td:
+            out_path = Path(td) / "reemit.wasm"
+            code, rt_out = run([args.wabt, "component", "objdump", str(wasm), "-o", str(out_path)])
+            if code != 0:
+                err = f"`wabt component objdump -o` exited {code}\n{rt_out.strip()}"
+            else:
+                original = wasm.read_bytes()
+                reemit = out_path.read_bytes()
+                if reemit != original:
+                    err = (f"round-trip not byte-identical "
+                           f"(input {len(original)} bytes, re-emit {len(reemit)} bytes)")
+        if err:
+            failed.append((fname, err))
             print(f"  FAIL {fname}")
         else:
             passed.append(fname)

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -245,10 +245,14 @@ fn loadInner(data: []const u8, allocator: std.mem.Allocator, capture_layout: boo
                 }
             },
             .component => {
-                // Nested component — recursively parse
+                // Nested component — recursively parse. Propagate
+                // `capture_layout` so nested components also preserve
+                // their section order + custom sections; otherwise the
+                // writer re-orders them and breaks their internal index
+                // spaces on re-emit (#267).
                 const comp_data = reader.data[section_start .. section_start + section_size];
                 const child = try allocator.create(ctypes.Component);
-                child.* = try load(comp_data, allocator);
+                child.* = try loadInner(comp_data, allocator, capture_layout);
                 try components.append(allocator, child);
                 reader.pos = section_start + section_size;
             },

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -119,6 +119,22 @@ const SectionId = enum(u8) {
 
 /// Load a WebAssembly Component from binary data.
 pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Component {
+    return loadInner(data, allocator, false);
+}
+
+/// Like `load`, but additionally captures the physical section layout
+/// (`section_order`) and preserves custom sections, so that a
+/// `load -> writer.encode` round-trip reproduces the component's section
+/// sequence (and metadata) rather than the writer's conventional
+/// re-ordering. Used by `wabt component objdump -o` for round-trip
+/// testing. Do NOT use this for components that will be *mutated* before
+/// re-encoding (e.g. compose / component-new transforms): the captured
+/// `section_order` indices would go stale against the edited arrays.
+pub fn loadVerbatim(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Component {
+    return loadInner(data, allocator, true);
+}
+
+fn loadInner(data: []const u8, allocator: std.mem.Allocator, capture_layout: bool) LoadError!ctypes.Component {
     var reader = BinaryReader{ .data = data };
 
     // Validate preamble
@@ -157,6 +173,18 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
     // layouts (issue #355).
     var comp_instance_indexspace: std.ArrayListUnmanaged(ctypes.CompInstanceContributor) = .empty;
 
+    // Physical section layout, captured only when `capture_layout` is set
+    // (see `loadVerbatim`). One `SectionEntry` per physical section, in
+    // encounter order, so the writer's ordered path can faithfully
+    // reproduce the original section sequence. Custom sections — normally
+    // dropped — are preserved into `custom_sections` and referenced by
+    // their `.custom` entries. `layout_faithful` is cleared if a section
+    // we cannot represent (e.g. `value`) is encountered, in which case we
+    // emit no `section_order` and fall back to conventional ordering.
+    var section_order: std.ArrayListUnmanaged(ctypes.SectionEntry) = .empty;
+    var custom_sections: std.ArrayListUnmanaged(ctypes.CustomSection) = .empty;
+    var layout_faithful = true;
+
     while (reader.remaining() > 0) {
         const section_id_byte = try reader.readByte();
         const section_size = try reader.readU32();
@@ -167,9 +195,33 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
         const section_id = std.enums.fromInt(SectionId, section_id_byte) orelse
             return error.InvalidSectionId;
 
+        // Snapshot per-section array lengths so we can record a
+        // `SectionEntry` (start + count) for this physical section after
+        // it is parsed (only when capturing layout).
+        const len_before = .{
+            .custom = custom_sections.items.len,
+            .core_module = core_modules.items.len,
+            .core_instance = core_instances.items.len,
+            .core_type = core_type_defs.items.len,
+            .component = components.items.len,
+            .instance = instances.items.len,
+            .alias = aliases.items.len,
+            .type = type_defs.items.len,
+            .canon = canons.items.len,
+            .import = imports.items.len,
+            .@"export" = exports.items.len,
+        };
+
         switch (section_id) {
             .custom => {
-                // Skip custom sections
+                if (capture_layout) {
+                    // Preserve the custom section: name (LEB-prefixed) then
+                    // the remaining bytes as opaque payload.
+                    const name = try reader.readName();
+                    const payload = reader.data[reader.pos .. section_start + section_size];
+                    try custom_sections.append(allocator, .{ .name = name, .payload = payload });
+                }
+                // Skip to the end (whether or not we captured the name).
                 reader.pos = section_start + section_size;
             },
             .core_module => {
@@ -296,6 +348,32 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
         // exactly `section_size` bytes. If a bug causes under- or over-read
         // we'd otherwise misalign the next section header.
         if (reader.pos != section_start + section_size) return error.InvalidSectionSize;
+
+        // Record this physical section's layout entry (one per section).
+        if (capture_layout) {
+            const Kind = ctypes.SectionKind;
+            const entry: ?ctypes.SectionEntry = switch (section_id) {
+                .custom => mkEntry(.custom, len_before.custom, custom_sections.items.len),
+                .core_module => mkEntry(.core_module, len_before.core_module, core_modules.items.len),
+                .core_instance => mkEntry(.core_instance, len_before.core_instance, core_instances.items.len),
+                .core_type => mkEntry(.core_type, len_before.core_type, core_type_defs.items.len),
+                .component => mkEntry(.component, len_before.component, components.items.len),
+                .instance => mkEntry(.instance, len_before.instance, instances.items.len),
+                .alias => mkEntry(.alias, len_before.alias, aliases.items.len),
+                .type => mkEntry(.type, len_before.type, type_defs.items.len),
+                .canon => mkEntry(.canon, len_before.canon, canons.items.len),
+                .start => ctypes.SectionEntry{ .kind = Kind.start, .start = 0, .count = 0 },
+                .@"import" => mkEntry(.import, len_before.@"import", imports.items.len),
+                .@"export" => mkEntry(.@"export", len_before.@"export", exports.items.len),
+                // `value` sections aren't materialized, so the layout
+                // cannot be faithfully reproduced — disable layout capture.
+                .value => blk: {
+                    layout_faithful = false;
+                    break :blk null;
+                },
+            };
+            if (entry) |e| try section_order.append(allocator, e);
+        }
     }
 
     return .{
@@ -313,7 +391,17 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
         .exports = try exports.toOwnedSlice(allocator),
         .core_func_indexspace = try core_func_indexspace.toOwnedSlice(allocator),
         .comp_instance_indexspace = try comp_instance_indexspace.toOwnedSlice(allocator),
+        .custom_sections = if (capture_layout) try custom_sections.toOwnedSlice(allocator) else &.{},
+        .section_order = if (capture_layout and layout_faithful)
+            try section_order.toOwnedSlice(allocator)
+        else
+            null,
     };
+}
+
+/// Build a `SectionEntry` from a per-section array's before/after length.
+fn mkEntry(kind: ctypes.SectionKind, before: usize, after: usize) ctypes.SectionEntry {
+    return .{ .kind = kind, .start = @intCast(before), .count = @intCast(after - before) };
 }
 
 // ── Section parsers ─────────────────────────────────────────────────────────
@@ -1279,6 +1367,35 @@ test "load: real P3 (component-model-async) component (#263)" {
         else => {},
     };
     try std.testing.expect(fnew2 and fread2);
+}
+
+test "loadVerbatim: captures section_order and byte-faithfully round-trips (#267)" {
+    // The verbatim loader records the physical section layout so a
+    // `loadVerbatim -> writer.encode` round-trip reproduces the original
+    // section order, unlike the plain `load -> encode` path which falls
+    // back to the writer's conventional re-ordering.
+    const data = @embedFile("fixtures/p3-future.wasm");
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ar = arena.allocator();
+
+    const comp = try loadVerbatim(data, ar);
+    // Layout was captured: one entry per physical section.
+    try std.testing.expect(comp.section_order != null);
+    try std.testing.expect(comp.section_order.?.len > 0);
+
+    // Re-encode from the verbatim AST and re-load: the section order
+    // (and every per-section count) must be identical to the original.
+    const writer = @import("writer.zig");
+    const reencoded = try writer.encode(ar, &comp);
+    const comp2 = try loadVerbatim(reencoded, ar);
+
+    try std.testing.expect(comp2.section_order != null);
+    try std.testing.expectEqual(comp.section_order.?.len, comp2.section_order.?.len);
+    for (comp.section_order.?, comp2.section_order.?) |a, b| {
+        try std.testing.expectEqual(a.kind, b.kind);
+        try std.testing.expectEqual(a.count, b.count);
+    }
 }
 
 test "load: real P3 stream component (#263)" {

--- a/src/tools/component_objdump.zig
+++ b/src/tools/component_objdump.zig
@@ -20,11 +20,11 @@ pub const usage =
     \\  -o, --output <file>   Re-emit the decoded component to <file> (a
     \\                        load -> encode round-trip through wabt's
     \\                        component loader + writer), to unblock
-    \\                        round-trip testing. NOTE: re-emission is
-    \\                        currently lossy for some real-world inputs
-    \\                        (custom sections are dropped; section order
-    \\                        may change), so the output is not guaranteed
-    \\                        byte-identical or even re-validatable yet.
+    \\                        round-trip testing. The verbatim loader
+    \\                        preserves the physical section order and
+    \\                        custom sections, so the output is structurally
+    \\                        equivalent to the input (re-validatable),
+    \\                        though not guaranteed byte-identical.
     \\
 ;
 
@@ -236,7 +236,7 @@ pub const ReemitError = DumpError || error{ValueTooLarge};
 pub fn reemit(allocator: std.mem.Allocator, bytes: []const u8) ReemitError![]u8 {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
-    const comp = try wabt.component.loader.load(bytes, arena.allocator());
+    const comp = try wabt.component.loader.loadVerbatim(bytes, arena.allocator());
     return wabt.component.writer.encode(allocator, &comp);
 }
 
@@ -342,20 +342,25 @@ test "dump rejects core wasm preamble" {
 }
 
 test "reemit round-trips a component through the loader + writer" {
-    // Bare component preamble (no sections): the simplest input the
-    // writer fully round-trips. Re-emission of richer real-world
-    // components is currently lossy — the loader drops custom sections
-    // (loader.zig) and the writer's section ordering does not yet
-    // preserve every external interleaving — so this test asserts only
-    // the guarantees that hold today: the output is a valid component
-    // binary that decodes again. See #267 for faithful round-trip work.
-    const bytes = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x0d, 0x00, 0x01, 0x00 };
+    // Component preamble + one custom section named "wit-component".
+    // The verbatim loader (used by reemit) now preserves custom sections
+    // and the physical section order, so the re-emitted bytes decode to
+    // an identical summary — including the custom section that the plain
+    // loader would drop.
+    const bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x0d, 0x00, 0x01, 0x00,
+        0x00, 0x0e,
+        0x0d, 'w', 'i', 't', '-', 'c', 'o', 'm', 'p', 'o', 'n', 'e', 'n', 't',
+    };
     const out = try reemit(std.testing.allocator, &bytes);
     defer std.testing.allocator.free(out);
 
     try std.testing.expect(looksLikeComponent(out));
-    // Re-decoding the emitted bytes must succeed (no loader error).
-    const summary = try dump(std.testing.allocator, out);
-    defer std.testing.allocator.free(summary);
-    try std.testing.expect(std.mem.indexOf(u8, summary, "wabt component objdump:") != null);
+    const a = try dump(std.testing.allocator, &bytes);
+    defer std.testing.allocator.free(a);
+    const b = try dump(std.testing.allocator, out);
+    defer std.testing.allocator.free(b);
+    try std.testing.expectEqualStrings(a, b);
+    // The custom section survived the round-trip.
+    try std.testing.expect(std.mem.indexOf(u8, b, "Custom sections:      1 (wit-component)") != null);
 }


### PR DESCRIPTION
Follow-up to #320: investigate and fix the component round-trip failures the new `component objdump -o` re-emit exposed. **Result: all 40 `wasm32-wasip3` testsuite components now round-trip byte-identical and re-validate on Wasmtime 46.**

## Root cause
`loader.zig` walked sections into per-section arrays but **never recorded `section_order`** and **dropped custom sections**. So a `load -> writer.encode` round-trip of a real-world component fell back to the writer's *conventional* section ordering, which re-orders index-space contributors and breaks references — Wasmtime rejected the result with `type index out of bounds`.

A second, deeper instance: **nested components** were loaded via the plain `load()`, so even with top-level capture they lost their own `section_order` and got re-ordered — which is why `http-service` (2 nested components) stayed broken until the capture flag was propagated into the recursion.

## Fix (opt-in, zero-risk to existing callers)
- `loader.loadVerbatim` — captures one `SectionEntry` per physical section and preserves custom sections; **recurses verbatim into nested components**.
- Default `loader.load` is **unchanged** (`section_order = null`), so mutating callers (`component compose`/`new`, `world_gc`, metadata round-trips) keep the conventional path — their array edits would otherwise desync captured indices.
- `component objdump -o` (from #320) uses `loadVerbatim`, so re-emit is faithful.

## Result — measured on all 40 vendored `wasm32-wasip3` components
Re-emit each via `component objdump -o`, then re-validate on Wasmtime 46:

| | round-trip + re-validate | byte-identical |
|---|---|---|
| before (#320) | 0 / 40 | 0 / 40 |
| after section_order fix | 39 / 40 | 39 / 40 |
| **after nested fix (this PR)** | **40 / 40** | **40 / 40** |

## Gate strengthened to lock it in
The Phase-4 `zig build wasi-p3-testsuite` gate now does **decode + byte-identical round-trip** per fixture (re-emit must equal the input). Needs no Wasmtime, so it runs in the existing `wasi-p3-decode` CI job and regression-proofs loader+writer fidelity. 40/40 pass.

## Tests
- `loader.zig`: `loadVerbatim` captures `section_order`; re-encode→re-load preserves every section kind+count.
- `component_objdump.zig`: re-emit round-trips a custom section the plain loader drops.
- Full `zig build test` green; no regression (default `load` untouched).

Refs #267.