### PR TITLE
build.zig.zon: set version to 3.0.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wabt,
-    .version = "0.1.0",
+    .version = "3.0.0",
     .fingerprint = 0x9e1a5a2ee6c5ad78,
     .minimum_zig_version = "0.16.0",
     .paths = .{


### PR DESCRIPTION
Bumps the package manifest version in `build.zig.zon` from the placeholder `0.1.0` to `3.0.0`, aligning it with the `v3.0.0-dev.*` release line.

Manifest still parses (`zig build` works). No other code change.