### PR TITLE
component bindgen: drop stray module-scope resetScratch in export shells

### DIFF
--- a/src/tools/component_bindgen.zig
+++ b/src/tools/component_bindgen.zig
@@ -544,7 +544,6 @@ const Gen = struct {
         if (func.is_async) return self.emitAsyncExportFunc(iface_id, name, func);
         const export_sym = try std.fmt.allocPrint(self.ar, "{s}#{s}", .{ iface_id, name });
         try self.emitSyncExportFuncSym(export_sym, name, func);
-        self.raw("    wit_types.resetScratch();\n");
     }
 
     /// Emit a module-scope export shell for a top-level world func
@@ -1587,6 +1586,9 @@ test "generate: export shells + import wrappers" {
         try testing.expect(std.mem.indexOf(u8, out, "export fn @\"test:t/store#ping\"(x: i32) wit_types.canon.CoreReturn(u32)") != null);
         try testing.expect(std.mem.indexOf(u8, out, "wit_types.canon.returnResult(u32, Impl.ping(__params.x), &wit_types.alloc)") != null);
         try testing.expect(std.mem.indexOf(u8, out, "export fn @\"test:t/store#get\"(id: i32) wit_types.canon.CoreReturn(?Pet)") != null);
+        // No stray module-scope statement after an export shell's closing brace
+        // (regression: a duplicate resetScratch was emitted at container scope).
+        try testing.expect(std.mem.indexOf(u8, out, "}\n\n    wit_types.resetScratch();") == null);
     }
     {
         var g = Gen{ .ar = ar, .resolver = res, .impl = "impl" };


### PR DESCRIPTION
emitSyncExportFuncSym already emits wit_types.resetScratch() inside each export shell; emitExportFunc additionally emitted one after the closing brace, landing at container scope and breaking every interface-export world (invalid Zig: 'expected , after field'). Remove it and add a regression assertion.